### PR TITLE
The device reboot causes the fingerprint to empty

### DIFF
--- a/src/managers/fingerprint_process.c
+++ b/src/managers/fingerprint_process.c
@@ -287,20 +287,15 @@ static void FpRecognizeSend(uint16_t cmd, uint8_t passwd)
     // SendPackFingerMsg(FINGERPRINT_CMD_RECOGNIZE, &passwd, 0, 1, AES_KEY_ENCRYPTION);
 }
 
-void FpSaveFingerKey(void)
-{
-    FingerSetInfoToSE(g_fpTempAesKey, 0, GetCurrentAccountIndex(), SecretCacheGetPassword());
-    memset(g_fpTempAesKey, 0,  sizeof(g_fpTempAesKey));
-    ClearSecretCache();
-}
-
 void FpSaveKeyInfo(bool add)
 {
-    SetFingerManagerInfoToSE();
     if (add) {
         AddFingerManager(g_fpIndex);
     }
-    FpSaveFingerKey();
+    SetFingerManagerInfoToSE();
+    FingerSetInfoToSE(g_fpTempAesKey, 0, GetCurrentAccountIndex(), SecretCacheGetPassword());
+    memset(g_fpTempAesKey, 0,  sizeof(g_fpTempAesKey));
+    ClearSecretCache();
 }
 
 // A7FF RECV


### PR DESCRIPTION
## Explanation
jira:PRAD-3913
The device reboot causes the fingerprint to empty

## Changes
Modify the saving order of fingerprint information

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
no need to test

