### PR TITLE
feat(debugmemory): print string value when rust ptr seems to be a char*

### DIFF
--- a/rust/rust_c/src/ethereum/src/abi.rs
+++ b/rust/rust_c/src/ethereum/src/abi.rs
@@ -18,7 +18,7 @@ pub extern "C" fn eth_parse_contract_data(
         Ok(_input_data) => {
             let result = app_ethereum::abi::parse_contract_data(_input_data, contract_json);
             match result {
-                Ok(v) => Response::success(DisplayContractData::from(v)).c_ptr(),
+                Ok(v) => Response::success_ptr(DisplayContractData::from(v).c_ptr()).c_ptr(),
                 Err(e) => Response::from(e).c_ptr(),
             }
         }

--- a/src/ui/gui_chain/gui_eth.c
+++ b/src/ui/gui_chain/gui_eth.c
@@ -953,6 +953,7 @@ static bool GetEthErc20ContractData(void *parseResult)
     }
     else
     {
+        free_Response_DisplayContractData(contractData);
         return false;
     }
     char *to = result->data->detail->to;
@@ -981,6 +982,7 @@ bool GetEthContractFromInternal(char *address, char *inputData)
                 g_contractDataExist = true;
                 g_contractData = contractData;
             } else {
+                free_Response_DisplayContractData(contractData);
                 return false;
             }
             return true;
@@ -1009,6 +1011,7 @@ bool GetEthContractFromExternal(char *address, char *selectorId, uint64_t chainI
             g_contractData = contractData;
         } else {
             SRAM_FREE(contractMethodJson);
+            free_Response_DisplayContractData(contractData);
             return false;
         }
         SRAM_FREE(contractMethodJson);

--- a/src/utils/log/log_print.c
+++ b/src/utils/log/log_print.c
@@ -5,7 +5,9 @@
 #ifdef RUST_MEMORY_DEBUG
 #include "user_memory.h"
 #include "assert.h"
-struct __RustMemoryNode {
+#include "string.h"
+struct __RustMemoryNode
+{
     void *p;
     uint32_t size;
     struct __RustMemoryNode *next;
@@ -73,8 +75,17 @@ void RustMemoryNode_print()
     while (current != NULL) {
         snprintf(memBuf, sizeof(memBuf), "Rust Memory Usage: address: 0x%x, size: %d\n", current -> p, current -> size);
         WriteDebugToSdcard(memBuf, strlen(memBuf));
-        printf("Rust Memory Usage: address: 0x%x, size: %d\r\n", current -> p, current -> size);
-        current = current -> next;
+        printf("Rust Memory Usage: address: 0x%x, size: %d\r\n", current->p, current->size);
+        if (sizeof(current->p[0]) == 1)
+        {
+            if (((char *)current->p)[current->size - 1] == '\0')
+            {
+                snprintf(memBuf, sizeof(memBuf), "Rust Memory Possible value: %s\r\n", current->p);
+                WriteDebugToSdcard(memBuf, strlen(memBuf));
+                printf("Rust Memory Possible value: %s\r\n", current->p);
+            }
+        }
+        current = current->next;
     }
 }
 #endif


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required -->
<!-- START -->
1. print char* when rust ptr seems to be a char *
2. fixed a place of memory leak
<!-- END -->

## Changes
<!-- What change is included in this PR -->
<!-- START -->
1. print char* when rust ptr seems to be a char *
2. fixed a place of memory leak
<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
<!-- Explan how the reviewer and QA can test this PR -->
<!-- START -->

<!-- END -->

