### PR TITLE
Upsliding causes the interface to move up

### DIFF
--- a/src/ui/gui_widgets/gui_about_info_widgets.c
+++ b/src/ui/gui_widgets/gui_about_info_widgets.c
@@ -413,6 +413,7 @@ static void OpenVerifyFirmwareHandler(lv_event_t *e)
 {
     lv_event_code_t code = lv_event_get_code(e);
     if (code == LV_EVENT_CLICKED) {
+        lv_obj_scroll_to_y(g_cont, 0, LV_ANIM_OFF);
         g_firmwareVerifyCont = GuiCreateContainerWithParent(g_pageWidget->contentZone, 480, 800 - GUI_MAIN_AREA_OFFSET);
         lv_obj_clear_flag(g_pageWidget->contentZone, LV_OBJ_FLAG_SCROLLABLE);
         GuiCreateVerifyFirmwareInstructionTile(g_firmwareVerifyCont);


### PR DESCRIPTION
## Explanation
Upsliding causes the interface to move up

## Changes
Clicking the checksum action slides the screen to the top

<!-- END -->

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
about info page Swipe up and click checksum
