### PR TITLE
Fix/passphrase switch close fp

### DIFF
--- a/src/driver/drv_aw32001.c
+++ b/src/driver/drv_aw32001.c
@@ -225,9 +225,7 @@ void Aw32001Init(void)
     Aw32001RegValueInit();
     milliVolt = GetBatteryMilliVolt();
     printf("milliVolt=%d\n", milliVolt);
-    if (milliVolt > 1000) {
-        Aw32001ChargingEnable();
-    }
+    Aw32001ChargingEnable();
 }
 
 

--- a/src/driver/drv_battery.h
+++ b/src/driver/drv_battery.h
@@ -17,7 +17,7 @@ void BatteryOpen(void);
 /// @return Battery voltage, in millivolts.
 uint32_t GetBatteryMilliVolt(void);
 
-bool BatteryIntervalHandler(void);
+bool BatteryIntervalHandler(uint32_t *sleepInterval);
 uint8_t GetBatterPercent(void);
 uint32_t GetBatteryInterval(void);
 uint8_t GetBatteryPercentByMilliVolt(uint32_t milliVolt, bool discharge);

--- a/src/tasks/background_task.c
+++ b/src/tasks/background_task.c
@@ -183,7 +183,7 @@ static void BackgroundTask(void *argument)
         }
         break;
         case BACKGROUND_MSG_BATTERY_INTERVAL: {
-            if (rcvMsg.value != 0 || BatteryIntervalHandler()) {
+            if (rcvMsg.value != 0 || BatteryIntervalHandler(NULL)) {
                 battState = GetBatterPercent();
                 if (GetUsbPowerState() == USB_POWER_STATE_CONNECT) {
                     battState |= 0x8000;

--- a/src/ui/gui_widgets/gui_lock_widgets.c
+++ b/src/ui/gui_widgets/gui_lock_widgets.c
@@ -477,6 +477,7 @@ void GuiShowGenerateXPubLoading(void)
     }
     
     SetPageLockScreen(false);
+    FpCancelCurOperate();
     g_canDismissLoading = false;
 
     g_LoadingView = GuiCreateContainer(lv_obj_get_width(lv_scr_act()), lv_obj_get_height(lv_scr_act()));

--- a/src/ui/gui_widgets/gui_transaction_detail_widgets.c
+++ b/src/ui/gui_widgets/gui_transaction_detail_widgets.c
@@ -143,6 +143,7 @@ void GuiTransactionParseFailed()
 void GuiTransactionDetailRefresh()
 {
     // PassWordPinHintRefresh(g_keyboardWidget);
+    GUI_DEL_OBJ(g_fingerSingContainer)
 }
 
 static void ThrowError()

--- a/src/ui/gui_widgets/setting/gui_wallet_setting_widgets.c
+++ b/src/ui/gui_widgets/setting/gui_wallet_setting_widgets.c
@@ -568,6 +568,9 @@ void GuiWalletDelWalletConfirm(lv_obj_t *parent)
 
 void GuiFingerCancelRegister(void)
 {
+    for (int i = 0; i < 3; i++) {
+        UpdateFingerSignFlag(i, false);
+    }
     SetPageLockScreen(true);
     FpDeleteRegisterFinger();
 }


### PR DESCRIPTION
## Explanation
1. Turn off fingerprint unlock when switching passphrase
2. Reduce wakeup times
3. Close the finger signature popup after the lock screen
4. If the number of password errors is too high, turn off the fingerprint signature function

## Changes
1. Reduce the wake-up time when the voltage is below 30%
2. When the number of password errors reaches the number of times, turn off all the fingerprint signature switches

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
1. Switch to the passphrase wallet and place your finger on your fingerprint
2. Lock screen when signing with fingerprint

