### PR TITLE
Fix debugmemory issues

### DIFF
--- a/rust/rust_c/src/common/src/macros.rs
+++ b/rust/rust_c/src/common/src/macros.rs
@@ -46,6 +46,7 @@ macro_rules! impl_c_ptr {
 macro_rules! impl_simple_c_ptr {
     ($name:ident<$t: ident>) => {
         impl<$t> $name<$t> {
+            #[cfg(feature = "debug-memory")]
             #[track_caller]
             pub fn simple_c_ptr(self) -> *mut Self {
                 let x = alloc::boxed::Box::into_raw(alloc::boxed::Box::new(self));
@@ -56,6 +57,10 @@ macro_rules! impl_simple_c_ptr {
                     core::panic::Location::caller()
                 ));
                 x
+            }
+            #[cfg(not(feature = "debug-memory"))]
+            pub fn simple_c_ptr(self) -> *mut Self {
+                alloc::boxed::Box::into_raw(alloc::boxed::Box::new(self))
             }
         }
     };

--- a/src/ui/gui_views/gui_standard_receive_view.c
+++ b/src/ui/gui_views/gui_standard_receive_view.c
@@ -11,7 +11,6 @@ static int32_t GuiStandardReceiveViewInit(uint8_t chain)
 
 static int32_t GuiStandardReceiveViewDeInit(void)
 {
-    printf("GuiStandardReceiveViewDeInit\n");
     GuiStandardReceiveDeInit();
     return SUCCESS_CODE;
 }


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required -->
<!-- START -->
This PR fixes an issue about memory info was print without debugmemory build option, and removes an useless printf.
<!-- END -->

## Changes
<!-- What change is included in this PR -->
<!-- START -->
1. add compile config.
2. remove a printf
<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
<!-- Explan how the reviewer and QA can test this PR -->
<!-- START -->

<!-- END -->

