### PR TITLE
fix:checksum sdcard version show when sdcard bin version less than or equal to the current version

### DIFF
--- a/src/firmware/firmware_update.c
+++ b/src/firmware/firmware_update.c
@@ -213,6 +213,7 @@ static bool CheckVersion(const OtaFileInfo_t *info, const char *filePath, uint32
     uint32_t nowVersionNumber = (nowMajor * epoch * epoch)  + (nowMinor * epoch) + nowBuild;
     uint32_t fileVersionNumber = (fileMajor * epoch * epoch)  + (fileMinor * epoch) + fileBuild;
 
+    sprintf(version, "%d.%d.%d", fileMajor, fileMinor, fileBuild);
     if (fileVersionNumber <= nowVersionNumber) {
         SRAM_FREE(g_dataUnit);
         SRAM_FREE(g_fileUnit);
@@ -220,7 +221,6 @@ static bool CheckVersion(const OtaFileInfo_t *info, const char *filePath, uint32
     }
     SRAM_FREE(g_dataUnit);
     SRAM_FREE(g_fileUnit);
-    sprintf(version, "%d.%d.%d", fileMajor, fileMinor, fileBuild);
     return true;
 }
 

--- a/src/ui/gui_widgets/gui_firmware_update_widgets.c
+++ b/src/ui/gui_widgets/gui_firmware_update_widgets.c
@@ -621,7 +621,7 @@ static void GuiFirmwareUpdateViewSha256(char *version, uint8_t percent)
         ConvertToLowerCase(hash);
         snprintf(tempBuf, sizeof(tempBuf), "#F5870A %.8s#%.24s\n%.24s#F5870A %.8s#", hash, &hash[8], &hash[32], &hash[56]);
         lv_obj_t *label = lv_obj_get_child(g_noticeHintBox, lv_obj_get_child_cnt(g_noticeHintBox) - 3);
-        lv_label_set_text_fmt(label, "CheckSum(v%s):\n%s", version, tempBuf);
+        lv_label_set_text_fmt(label, "Checksum(v%s):\n%s", version, tempBuf);
     }
 }
 


### PR DESCRIPTION
## Explanation
PRAD-3979
When the firmware version in the SD card <= device firmware version, the version number is not shown next to the Checksum

## Changes
When the version number in the sd card is less than the current version number, the version number is also displayed

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test


