### PR TITLE
fix switch account bug

### DIFF
--- a/src/ui/gui_components/gui_status_bar.c
+++ b/src/ui/gui_components/gui_status_bar.c
@@ -51,6 +51,7 @@ const static CoinWalletInfo_t g_coinWalletBtn[] = {
     {CHAIN_DASH, "Confirm Transaction", &coinDash},
     {CHAIN_LTC, "Confirm Transaction", &coinLtc},
     {CHAIN_TRX, "Confirm Transaction", &coinTrx},
+    {CHAIN_COSMOS, "Confirm Transaction", &coinCosmos},
     {CHAIN_ATOM, "Confirm Transaction", &coinAtom},
     {CHAIN_OSMO, "Confirm Transaction", &coinOsmo},
     {CHAIN_SCRT, "Confirm Transaction", &coinScrt},

--- a/src/ui/gui_views/gui_multi_account_receive_view copy.c
+++ b/src/ui/gui_views/gui_multi_account_receive_view copy.c
@@ -31,7 +31,7 @@ int32_t GuiMultiAccountsReceiveViewEventProcess(void *self, uint16_t usEvent, vo
     case GUI_EVENT_DISACTIVE:
         break;
     case GUI_EVENT_REFRESH:
-        GuiMultiAccountsReceiveRefresh();
+        // GuiMultiAccountsReceiveRefresh();
         break;
     case SIG_SETUP_VIEW_TILE_PREV:
         GuiMultiAccountsReceivePrevTile();

--- a/src/ui/gui_views/gui_multi_path_coin_receive_view.c
+++ b/src/ui/gui_views/gui_multi_path_coin_receive_view.c
@@ -32,7 +32,7 @@ int32_t GuiMultiPathCoinReceiveViewEventProcess(void *self, uint16_t usEvent, vo
     case GUI_EVENT_DISACTIVE:
         break;
     case GUI_EVENT_REFRESH:
-        GuiMultiPathCoinReceiveRefresh();
+        // GuiMultiPathCoinReceiveRefresh();
         break;
     case SIG_SETUP_VIEW_TILE_PREV:
         GuiMultiPathCoinReceivePrevTile();

--- a/src/ui/gui_views/gui_standard_receive_view.c
+++ b/src/ui/gui_views/gui_standard_receive_view.c
@@ -31,7 +31,7 @@ int32_t GuiStandardReceiveViewEventProcess(void *self, uint16_t usEvent, void *p
     case GUI_EVENT_DISACTIVE:
         break;
     case GUI_EVENT_REFRESH:
-        GuiStandardReceiveRefresh();
+        // GuiStandardReceiveRefresh();
         break;
     case SIG_SETUP_VIEW_TILE_PREV:
         GuiStandardReceivePrevTile();

--- a/src/ui/gui_views/gui_utxo_receive_view.c
+++ b/src/ui/gui_views/gui_utxo_receive_view.c
@@ -32,7 +32,7 @@ int32_t GuiReceiveViewEventProcess(void *self, uint16_t usEvent, void *param, ui
         //GuiBitcoinReceiveDisActive();
         break;
     case GUI_EVENT_REFRESH:
-        GuiReceiveRefresh();
+        // GuiReceiveRefresh();
         break;
     case SIG_SETUP_VIEW_TILE_PREV:
         GuiReceivePrevTile();

--- a/src/ui/gui_widgets/gui_multi_accounts_receive_widgets.c
+++ b/src/ui/gui_widgets/gui_multi_accounts_receive_widgets.c
@@ -146,6 +146,8 @@ void GuiMultiAccountsReceiveInit(uint8_t chain)
         GuiCreateSwitchAddressButtons(g_multiAccountsReceiveWidgets.tileSwitchAddress);
     }
     lv_obj_clear_flag(g_multiAccountsReceiveWidgets.tileView, LV_OBJ_FLAG_SCROLLABLE);
+
+    GuiMultiAccountsReceiveRefresh();
 }
 
 void GuiMultiAccountsReceiveDeInit(void)

--- a/src/ui/gui_widgets/gui_multi_path_coin_receive_widgets.c
+++ b/src/ui/gui_widgets/gui_multi_path_coin_receive_widgets.c
@@ -197,6 +197,8 @@ void GuiMultiPathCoinReceiveInit(uint8_t chain)
     g_multiPathCoinReceiveWidgets.tileChangePath = lv_tileview_add_tile(g_multiPathCoinReceiveWidgets.tileView, RECEIVE_TILE_CHANGE_PATH, 0, LV_DIR_HOR);
     GuiCreateChangePathWidget(g_multiPathCoinReceiveWidgets.tileChangePath);
     lv_obj_clear_flag(g_multiPathCoinReceiveWidgets.tileView, LV_OBJ_FLAG_SCROLLABLE);
+
+    GuiMultiPathCoinReceiveRefresh();
 }
 
 void GuiMultiPathCoinReceiveDeInit(void)

--- a/src/ui/gui_widgets/gui_standard_receive_widgets.c
+++ b/src/ui/gui_widgets/gui_standard_receive_widgets.c
@@ -129,6 +129,8 @@ void GuiStandardReceiveInit(uint8_t chain)
         GuiCreateSwitchAddressButtons(g_standardReceiveWidgets.tileSwitchAccount);
     }
     lv_obj_clear_flag(g_standardReceiveWidgets.tileView, LV_OBJ_FLAG_SCROLLABLE);
+
+    GuiStandardReceiveRefresh();
 }
 
 void GuiStandardReceiveDeInit(void)

--- a/src/ui/gui_widgets/gui_utxo_receive_widgets.c
+++ b/src/ui/gui_widgets/gui_utxo_receive_widgets.c
@@ -193,6 +193,8 @@ void GuiReceiveInit(uint8_t chain)
     g_utxoReceiveWidgets.tileAddressSettings = lv_tileview_add_tile(g_utxoReceiveWidgets.tileView, UTXO_RECEIVE_TILE_ADDRESS_SETTINGS, 0, LV_DIR_HOR);
     GuiCreateAddressSettingsWidget(g_utxoReceiveWidgets.tileAddressSettings);
     lv_obj_clear_flag(g_utxoReceiveWidgets.tileView, LV_OBJ_FLAG_SCROLLABLE);
+
+    GuiReceiveRefresh();
 }
 
 void GuiReceiveDeInit(void)


### PR DESCRIPTION
## Explanation
jira:PRAD-3986

## Changes
After the lock screen of the switch account page is locked, the Back to Previous page button of the page address page can not be clicked

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
check account index after lock screen

