### PR TITLE
fix(dice-rolls): check slip39 duplication

### DIFF
--- a/src/ui/gui_model/gui_model.c
+++ b/src/ui/gui_model/gui_model.c
@@ -723,13 +723,17 @@ static int32_t ModelSlip39WriteEntropy(const void *inData, uint32_t inDataLen)
     uint32_t entropyLen;
     uint8_t newAccount;
     uint8_t accountCnt;
+    uint16_t id;
+    uint8_t ie;
     int ret;
 
     ems = SecretCacheGetEms(&entropyLen);
     entropy = SecretCacheGetEntropy(&entropyLen);
+    id = SecretCacheGetIdentifier();
+    ie = SecretCacheGetIteration();
 
     MODEL_WRITE_SE_HEAD
-    ret = ModelComparePubkey(false, NULL, 0, 0, 0, NULL);
+    ret = ModelComparePubkey(false, ems, entropyLen, id, ie, NULL);
     CHECK_ERRCODE_BREAK("duplicated entropy", ret);
     ret = CreateNewSlip39Account(newAccount, ems, entropy, 32, SecretCacheGetNewPassword(), SecretCacheGetIdentifier(), SecretCacheGetIteration());
     CHECK_ERRCODE_BREAK("save slip39 entropy error", ret);


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
Fix the bug that entropy duplication check does not triggered.
<!-- END -->

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
<!-- Explan how the reviewer and QA can test this PR -->
<!-- START -->

<!-- END -->

