### PR TITLE
fix(slip39): should not modify ems when get ms

### DIFF
--- a/src/crypto/slip39/slip39.c
+++ b/src/crypto/slip39/slip39.c
@@ -716,11 +716,7 @@ void GetSlip39MnemonicsWords(uint8_t *masterSecret, uint8_t *ems, uint8_t wordCn
 
 int Slip39GetSeed(uint8_t *ems, uint8_t *seed, uint8_t emsLen, const char *passphrase, uint8_t ie, uint16_t id)
 {
-    int ret = _decrypt(ems, emsLen, ems, emsLen, (uint8_t *)passphrase, strlen(passphrase), ie, id);
-    if (ret == 0) {
-        memcpy(seed, ems, emsLen);
-    }
-    return ret;
+    return _decrypt(ems, emsLen, seed, emsLen, (uint8_t *)passphrase, strlen(passphrase), ie, id);
 }
 
 int Sli39GetMasterSecret(uint8_t threshold, uint8_t wordsCount, uint8_t *ems, uint8_t *masterSecret,


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
This PR fixes a bug caused by dice rolls changes.
<!-- END -->

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
<!-- Explan how the reviewer and QA can test this PR -->
<!-- START -->

<!-- END -->

