### PR TITLE
XPUB chain number check

### DIFF
--- a/src/crypto/account_public_info.c
+++ b/src/crypto/account_public_info.c
@@ -657,6 +657,11 @@ static bool GetPublicKeyFromJsonString(const char *string)
             ret = false;
             break;
         }
+        if (cJSON_GetArraySize(keyJson) != NUMBER_OF_ARRAYS(g_chainTable)) {
+            printf("chain number does not match:%d %d\n", cJSON_GetArraySize(keyJson), NUMBER_OF_ARRAYS(g_chainTable));
+            ret = false;
+            break;
+        }
         for (i = 0; i < NUMBER_OF_ARRAYS(g_chainTable); i++) {
             chainJson = cJSON_GetObjectItem(keyJson, g_chainTable[i].name);
             if (chainJson == NULL) {


### PR DESCRIPTION
## Explanation
XPUB chain number check. Regenerate XPUBs if the chain number does not match.

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
Upgrading firmware from each other between versions GENERAL and BTC_ONLY. The XPUB should be regenerated.
