### PR TITLE
Set BATTERY_DIFF_THRESHOLD to 40

### DIFF
--- a/src/driver/drv_battery.c
+++ b/src/driver/drv_battery.c
@@ -22,7 +22,7 @@
 #define BATTERY_PRINTF(fmt, args...)
 #endif
 
-#define BATTERY_DIFF_THRESHOLD                          20
+#define BATTERY_DIFF_THRESHOLD                          40
 #define BATTERY_CHARGING_BY_TIME                        75
 #define BATTERY_LOG_PERCENT_INTERVAL                    10
 #define BATTERY_LOG_ONLY_LOW_BATTERY                    1


### PR DESCRIPTION
## Explanation
Set BATTERY_DIFF_THRESHOLD to 40

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test


