### PR TITLE
fix: increase background task stack size to fix cardano transaction bug

### DIFF
--- a/src/tasks/background_task.c
+++ b/src/tasks/background_task.c
@@ -28,7 +28,7 @@ void CreateBackgroundTask(void)
 {
     const osThreadAttr_t backgroundTask_attributes = {
         .name = "BackgroundTask",
-        .stack_size = 1024 * 16,
+        .stack_size = 1024 * 28,
         .priority = (osPriority_t)osPriorityBelowNormal,
     };
     g_backgroundTaskHandle = osThreadNew(BackgroundTask, NULL, &backgroundTask_attributes);


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
THIS PR increased background task stack size from 16K to 28K to fix app crash on cardano transactions.
<!-- END -->

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
<!-- Explan how the reviewer and QA can test this PR -->
<!-- START -->

<!-- END -->

