### PR TITLE
fix: bitcoin overview from addresses not correctly deduplicated

### DIFF
--- a/rust/apps/bitcoin/src/transactions/parsed_tx.rs
+++ b/rust/apps/bitcoin/src/transactions/parsed_tx.rs
@@ -115,11 +115,13 @@ pub trait TxParser {
             .filter(|v| v.address.is_some())
             .map(|v| v.address.clone().unwrap_or("Unknown Address".to_string()))
             .collect::<Vec<String>>();
+        overview_from.sort();
         overview_from.dedup();
         let mut overview_to = outputs
             .iter()
             .map(|v| v.address.clone())
             .collect::<Vec<String>>();
+        overview_to.sort();
         overview_to.dedup();
         let overview = OverviewTx {
             total_output_amount: Self::format_amount(overview_amount, network),


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
THIS PR fixes the bug that bitcoin transaction overview from addresses are not correctly deduplicated.
<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
<!-- Explan how the reviewer and QA can test this PR -->
<!-- START -->

<!-- END -->

