### PR TITLE
fix:close test-net checkbox after selected.

### DIFF
--- a/src/ui/gui_widgets/btc_only/gui_btc_wallet_profile_widgets.c
+++ b/src/ui/gui_widgets/btc_only/gui_btc_wallet_profile_widgets.c
@@ -177,9 +177,7 @@ static void NetworkSelHandler(lv_event_t *e)
             if (target == g_networkCheckbox[i].button) {
                 printf("target is %d\n", i);
                 SetIsTestNet(i == 1);
-#ifdef BTC_ONLY
                 GuiApiEmitSignal(SIG_STATUS_BAR_TEST_NET, NULL, 0);
-#endif
                 for (j = 0; j < 2; j++) {
                     if (i == j) {
                         //checked
@@ -193,6 +191,7 @@ static void NetworkSelHandler(lv_event_t *e)
                 }
             }
         }
+        lv_obj_del(g_networkCont);
     }
 }
 


### PR DESCRIPTION
## Explanation
Close test-net checkbox after selected.

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
Test-net selection.

