### PR TITLE
Do not include drv_aw32001.h

### DIFF
--- a/src/ui/gui_widgets/gui_usb_connection_widgets.c
+++ b/src/ui/gui_widgets/gui_usb_connection_widgets.c
@@ -6,7 +6,9 @@
 #include "gui_views.h"
 #include "gui_api.h"
 #include "device_setting.h"
+#ifndef COMPILE_SIMULATOR
 #include "drv_aw32001.h"
+#endif
 
 
 static void GuiUsbConnectionInit(void);


### PR DESCRIPTION
## Explanation
Do not include drv_aw32001.h

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test


