### PR TITLE
fix:exclude "test_cmd.h" when build production

### DIFF
--- a/src/tasks/cmd_task.c
+++ b/src/tasks/cmd_task.c
@@ -2,7 +2,9 @@
 #include "cmsis_os.h"
 #include "general_msg.h"
 #include "user_msg.h"
+#ifndef BUILD_PRODUCTION
 #include "test_cmd.h"
+#endif
 #include "mhscpu.h"
 
 


### PR DESCRIPTION
## Explanation
fix:exclude "test_cmd.h" when build production

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
build production

