### PR TITLE
fix:ensure USB state before open USB connection msg box.

### DIFF
--- a/src/ui/gui_views/gui_init_view.c
+++ b/src/ui/gui_views/gui_init_view.c
@@ -18,11 +18,12 @@
 #include "gui_about_info_widgets.h"
 #include "account_manager.h"
 #include "gui_setup_widgets.h"
+#include "device_setting.h"
+#include "drv_aw32001.h"
+#include "usb_task.h"
 #ifdef COMPILE_SIMULATOR
 #include "simulator_model.h"
 #else
-#include "drv_aw32001.h"
-#include "device_setting.h"
 #endif
 
 static int32_t GuiInitViewInit(void)
@@ -94,7 +95,9 @@ int32_t GUI_InitViewEventProcess(void *self, uint16_t usEvent, void *param, uint
     case SIG_INIT_USB_CONNECTION:
         rcvValue = *(uint32_t *)param;
         if (rcvValue != 0 && !GuiLockScreenIsTop() && GetUsbDetectState() && ((GetCurrentAccountIndex() != 0xFF) || GuiIsSetup())) {
-            OpenMsgBox(&g_guiMsgBoxUsbConnection);
+            if (GetUsbState() == false) {
+                OpenMsgBox(&g_guiMsgBoxUsbConnection);
+            }
         } else {
             CloseMsgBox(&g_guiMsgBoxUsbConnection);
         }


### PR DESCRIPTION
## Explanation
fix:ensure USB state before open USB connection msg box.

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
update firmware through SD card when usb connection established.
