### PR TITLE
feat: change coinType for agoric from 564 to 118

### DIFF
--- a/rust/apps/cosmos/src/lib.rs
+++ b/rust/apps/cosmos/src/lib.rs
@@ -174,9 +174,9 @@ mod tests {
         }
         {
             //general address BLD-0
-            let root_path = "44'/564'/0'";
+            let root_path = "44'/118'/0'";
             let root_xpub = "xpub6Cy2KXVssRUr6QK68mXztCSpmxK7yd68tCLHniaMVnRBxU8XYoFBSjeZ8hfg3VJDPAh3i8z1uhfpxPMy7Ub3FxyKzWu9RJdcmEkz6PL2cLu";
-            let hd_path = "44'/564'/0'/0/0";
+            let hd_path = "44'/118'/0'/0/0";
             let address = derive_address(hd_path, root_xpub, root_path, "agoric").unwrap();
             assert_eq!("agoric1r0q3ltgz67ldu86l9c6hvmwq5qke3af5h489vm", address);
         }

--- a/src/crypto/account_public_info.c
+++ b/src/crypto/account_public_info.c
@@ -84,7 +84,7 @@ static const ChainItem_t g_chainTable[] = {
     {XPUB_TYPE_SCRT,                  SECP256K1,    "scrt",                     "M/44'/529'/0'"     },
     {XPUB_TYPE_CRO,                   SECP256K1,    "cro",                      "M/44'/394'/0'"     },
     {XPUB_TYPE_IOV,                   SECP256K1,    "iov",                      "M/44'/234'/0'"     },
-    {XPUB_TYPE_BLD,                   SECP256K1,    "bld",                      "M/44'/564'/0'"     },
+    {XPUB_TYPE_BLD,                   SECP256K1,    "bld",                      "M/44'/118'/0'"     },
     {XPUB_TYPE_KAVA,                  SECP256K1,    "kava",                     "M/44'/459'/0'"     },
     {XPUB_TYPE_TERRA,                 SECP256K1,    "terra",                    "M/44'/330'/0'"     },
     {XPUB_TYPE_XRP,                   SECP256K1,    "xrp",                      "M/44'/144'/0'"     },

--- a/src/ui/gui_chain/others/gui_cosmos.c
+++ b/src/ui/gui_chain/others/gui_cosmos.c
@@ -32,7 +32,7 @@ static const CosmosChain_t g_cosmosChains[COSMOS_CHAINS_LEN] = {
     {CHAIN_DVPN, "sent", 118, XPUB_TYPE_COSMOS, "sentinelhub-2"},
     {CHAIN_IXO, "ixo", 118, XPUB_TYPE_COSMOS, "ixo-4"},
     {CHAIN_NGM, "emoney", 118, XPUB_TYPE_COSMOS, "emoney-3"},
-    {CHAIN_BLD, "agoric", 564, XPUB_TYPE_BLD, "agoric-3"},
+    {CHAIN_BLD, "agoric", 118, XPUB_TYPE_BLD, "agoric-3"},
     {CHAIN_BOOT, "bostrom", 118, XPUB_TYPE_COSMOS, "bostrom"},
     {CHAIN_JUNO, "juno", 118, XPUB_TYPE_COSMOS, "juno-1"},
     {CHAIN_STARS, "stars", 118, XPUB_TYPE_COSMOS, "stargaze-1"},


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
First of all, thank you for supporting Agoric chain on Keystone.

When I started using my keystone device, I noticed that the address for Agoric chain on my Keystone 3 Pro is different from the address on my Ledger Nano X, even though they share the same seed phrases.

Upon some digging, it seems like in this situation the coinType should be 118 instead of 564. Here are some relevant comments I found:

> My rough understanding is that 564 is a coin type we registered, but it's necessary to use 118, the default cosmos coinType, in certain interop situations; in particular, when using a ledger.

From: https://github.com/Agoric/agoric-sdk/discussions/5830#discussioncomment-5071717

PS: let me know if there are other places where I should update the coinType
<!-- END -->

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

Remark: could you point me to some documentations on how to run tests on a Mac with Apple Silicon?

## How to test
<!-- Explan how the reviewer and QA can test this PR -->
<!-- START -->
Not sure what's the best way to test this. I'm also not sure if the keystone device would cache the address generated with cointype 564 somewhere?
<!-- END -->

