### PR TITLE
fix:delete password keyboard when update fails.

### DIFF
--- a/src/ui/gui_widgets/gui_firmware_update_widgets.c
+++ b/src/ui/gui_widgets/gui_firmware_update_widgets.c
@@ -200,6 +200,7 @@ void GuiFirmwareSdCardCopyResult(bool en)
         printf("copy success\n");
     } else {
         printf("copy failed\n");
+        GuiDeleteKeyboardWidget(g_keyboardWidget);
         g_noticeHintBox = GuiCreateErrorCodeHintbox(ERR_UPDATE_FIRMWARE_NOT_DETECTED, &g_noticeHintBox);
     }
 }


### PR DESCRIPTION
## Explanation
fix:delete password keyboard when update fails.

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test


