### PR TITLE
fix: simulator build and taproot path order in btc-only testnet mode

### DIFF
--- a/build.py
+++ b/build.py
@@ -50,7 +50,7 @@ def build_firmware(environment, options, bin_type):
             cmd += ' -DCMAKE_BUILD_TYPE=Simulator'
         # add more option here.
 
-    cmd += "-DRU_SUPPORT=true"
+    cmd += " -DRU_SUPPORT=true"
     cmd += read_feature_toggle_build_cmd()
 
     cmd_result = os.system(cmd)

--- a/src/ui/gui_widgets/gui_export_pubkey_widgets.c
+++ b/src/ui/gui_widgets/gui_export_pubkey_widgets.c
@@ -70,8 +70,8 @@ static const PathTypeItem_t g_btcPathTypeList[] = {
 
 #ifdef BTC_ONLY
 static const char *g_btcTestNetPath[] = {
-    "m/86'/1'/0'",
     "m/84'/1'/0'",
+    "m/86'/1'/0'",
     "m/49'/1'/0'",
     "m/44'/1'/0'",
 };

--- a/src/ui/gui_widgets/setting/gui_setting_widgets.c
+++ b/src/ui/gui_widgets/setting/gui_setting_widgets.c
@@ -25,6 +25,7 @@
 #include "keystore.h"
 #else
 #include "simulator_model.h"
+#include "simulator_mock_define.h"
 #endif
 
 typedef void (*setting_update_cb)(void *obj, void *param);


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->

<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
<!-- Explan how the reviewer and QA can test this PR -->
<!-- START -->

<!-- END -->

