### PR TITLE
fix: fix cardano withdraw qr decode crash

### DIFF
--- a/src/tasks/background_task.c
+++ b/src/tasks/background_task.c
@@ -28,7 +28,7 @@ void CreateBackgroundTask(void)
 {
     const osThreadAttr_t backgroundTask_attributes = {
         .name = "BackgroundTask",
-        .stack_size = 1024 * 28,
+        .stack_size = 1024 * 35,
         .priority = (osPriority_t)osPriorityBelowNormal,
     };
     g_backgroundTaskHandle = osThreadNew(BackgroundTask, NULL, &backgroundTask_attributes);


### PR DESCRIPTION
## Explanation
fix: fix cardano withdraw qr decode crash

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.



