### PR TITLE
fix: convert memo string to hex string

### DIFF
--- a/rust/apps/ethereum/src/legacy_transaction.rs
+++ b/rust/apps/ethereum/src/legacy_transaction.rs
@@ -318,7 +318,7 @@ impl TryFrom<EthTx> for LegacyTransaction {
                 eth_tx.gas_limit.parse::<u64>().unwrap(),
                 TransactionAction::Call(H160::from_str(eth_tx.to.as_str()).unwrap()),
                 eth_tx.value.parse::<u64>().unwrap(),
-                eth_tx.memo,
+                hex::encode(eth_tx.memo.as_bytes()),
             );
             Ok(legacy_transaction)
         }


### PR DESCRIPTION
## Explanation
convert memo string to hex string

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.



