### PR TITLE
fix: handle invalid primes in aes256_decrypt_primes function

### DIFF
--- a/rust/rust_c/src/arweave/src/lib.rs
+++ b/rust/rust_c/src/arweave/src/lib.rs
@@ -114,6 +114,10 @@ pub extern "C" fn aes256_decrypt_primes(
     let (key, iv) = generate_aes_key_iv(seed);
     match aes256_decrypt(&key, &iv, data) {
         Ok(decrypted_data) => {
+            if decrypted_data.len() != 512 {
+                return SimpleResponse::from(RustCError::InvalidData("invalid primes".to_string()))
+                    .simple_c_ptr();
+            }
             let mut result_bytes: [u8; 512] = [0; 512];
             result_bytes.copy_from_slice(&decrypted_data);
             SimpleResponse::success(Box::into_raw(Box::new(result_bytes)) as *mut u8).simple_c_ptr()


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->

<!-- END -->

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->

<!-- END -->

