### PR TITLE
feat: Use TRNG as a custom `getrandom` backend

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "blake2b_simd",
  "hex",
  "keystore",
+ "rand_core 0.6.4",
  "rust_tools",
  "thiserror-core",
  "zcash_vendor",
@@ -2241,6 +2242,7 @@ dependencies = [
  "hex",
  "num-bigint-dig",
  "rand_chacha",
+ "rand_core 0.6.4",
  "rsa",
  "rust_tools",
  "sha2 0.10.8",
@@ -3133,6 +3135,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rand_os"
@@ -3346,6 +3351,7 @@ dependencies = [
  "cstr_core",
  "cty",
  "ethereum_rust_c",
+ "getrandom",
  "keystore",
  "near_rust_c",
  "simulator_rust_c",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -130,4 +130,5 @@ num-bigint = { version = "0.4.5", default-features = false }
 num-integer = { version = "0.1.46", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
 blake2b_simd = { version = "1.0.2", default-features = false }
+getrandom = "0.2"
 # third party dependencies end

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -113,6 +113,7 @@ serde_derive = { version = "1.0.159" }
 serde_bytes = { version = "0.11.5", default-features = false, features = [
     "alloc",
 ] }
+rand_core = { version = "0.6" }
 rand_chacha = { version = "0.3.1", default-features = false }
 sha2 = { version = "0.10.6", default-features = false, features = ["oid"] }
 aes = { version = "0.8.4", default-features = false }

--- a/rust/apps/zcash/Cargo.toml
+++ b/rust/apps/zcash/Cargo.toml
@@ -15,6 +15,7 @@ zcash_vendor = { workspace = true }
 hex = { workspace = true }
 bitvec = {version = "1.0.1", default-features = false, features = ["alloc"]}
 blake2b_simd = { workspace = true }
+rand_core = { workspace = true, features = ["getrandom"] }
 
 [dev-dependencies]
 keystore = { path = "../../keystore" }

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -45,10 +45,10 @@ pub fn parse_pczt(pczt: &[u8], ufvk_text: &str, seed_fingerprint: &[u8; 32]) -> 
     pczt::parse::parse_pczt(seed_fingerprint, &ufvk, &pczt)
 }
 
-pub fn sign_pczt(pczt: &[u8], seed: &[u8], randomness: [u8; 32]) -> Result<Vec<u8>> {
+pub fn sign_pczt(pczt: &[u8], seed: &[u8]) -> Result<Vec<u8>> {
     let pczt =
         Pczt::parse(pczt).map_err(|_e| ZcashError::InvalidPczt(format!("invalid pczt data")))?;
-    pczt::sign::sign_pczt(&pczt, seed, randomness)
+    pczt::sign::sign_pczt(&pczt, seed)
 }
 
 

--- a/rust/keystore/Cargo.toml
+++ b/rust/keystore/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 cty = { workspace = true }
 cstr_core = { workspace = true }
 rust_tools = { workspace = true }
+rand_core = { workspace = true, features = ["getrandom"] }
 rand_chacha = { workspace = true }
 arrayref = { workspace = true }
 sha2 = { workspace = true }

--- a/rust/rust_c/Cargo.toml
+++ b/rust/rust_c/Cargo.toml
@@ -28,6 +28,7 @@ zcash_rust_c = { path = "./src/zcash", optional = true }
 
 cty = { workspace = true }
 cstr_core = { workspace = true }
+getrandom = { workspace = true, features = ["custom"] }
 
 [lib]
 crate-type = ["staticlib"]

--- a/rust/rust_c/src/bindings.rs
+++ b/rust/rust_c/src/bindings.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "use-allocator")]
 extern "C" {
     pub fn LogRustMalloc(p: *mut cty::c_void, size: u32);
     pub fn LogRustFree(p: *mut cty::c_void);
     pub fn LogRustPanic(p: *mut cty::c_char);
+}
+
+extern "C" {
+    pub fn GenerateTRNGRandomness(randomness: *mut u8, len: u8) -> i32;
 }

--- a/rust/rust_c/src/lib.rs
+++ b/rust/rust_c/src/lib.rs
@@ -3,10 +3,11 @@
 #[cfg(feature = "use-allocator")]
 extern crate alloc;
 
+mod bindings;
+mod trng;
+
 #[cfg(feature = "use-allocator")]
 mod allocator;
-#[cfg(feature = "use-allocator")]
-mod bindings;
 #[cfg(feature = "use-allocator")]
 mod my_alloc;
 

--- a/rust/rust_c/src/trng.rs
+++ b/rust/rust_c/src/trng.rs
@@ -1,0 +1,28 @@
+use core::num::NonZeroU32;
+
+use getrandom::{register_custom_getrandom, Error};
+
+use crate::bindings::GenerateTRNGRandomness;
+
+/// Same as in `keystore.h`.
+const ENTROPY_MAX_LEN: usize = 32;
+
+fn keystone_getrandom(dest: &mut [u8]) -> Result<(), Error> {
+    for chunk in dest.chunks_mut(ENTROPY_MAX_LEN) {
+        // SAFETY: `chunk.len()` is at most `ENTROPY_MAX_LEN` which fits in `u8`.
+        let len = chunk.len() as u8;
+
+        let ret = unsafe { GenerateTRNGRandomness(chunk.as_mut_ptr(), len) };
+
+        // TODO: Determine how to correctly map error codes from the underlying hardware
+        // into the `getrandom` custom error code space `Error::CUSTOM_START..=u32::MAX`.
+        if ret != 0 {
+            let error = NonZeroU32::new(Error::CUSTOM_START.saturating_add_signed(ret)).unwrap();
+            return Err(Error::from(error));
+        }
+    }
+
+    Ok(())
+}
+
+register_custom_getrandom!(keystone_getrandom);

--- a/rust/rust_c/src/zcash/src/lib.rs
+++ b/rust/rust_c/src/zcash/src/lib.rs
@@ -90,24 +90,10 @@ pub extern "C" fn parse_zcash_tx(
 }
 
 #[no_mangle]
-pub extern "C" fn sign_zcash_tx(
-    tx: PtrUR,
-    seed: PtrBytes,
-    seed_len: u32,
-    randomness: PtrBytes,
-    randomness_len: u32,
-) -> *mut UREncodeResult {
+pub extern "C" fn sign_zcash_tx(tx: PtrUR, seed: PtrBytes, seed_len: u32) -> *mut UREncodeResult {
     let pczt = extract_ptr_with_type!(tx, ZcashPczt);
     let seed = unsafe { slice::from_raw_parts(seed, seed_len as usize) };
-    let randomness = unsafe { slice::from_raw_parts(randomness, randomness_len as usize) };
-    let randomness = match randomness.try_into() {
-        Ok(x) => x,
-        Err(_e) => {
-            return UREncodeResult::from(ZcashError::SigningError(format!("invalid randomness")))
-                .c_ptr()
-        }
-    };
-    match app_zcash::sign_pczt(&pczt.get_data(), seed, randomness) {
+    match app_zcash::sign_pczt(&pczt.get_data(), seed) {
         Ok(pczt) => match ZcashPczt::new(pczt).try_into() {
             Err(e) => UREncodeResult::from(e).c_ptr(),
             Ok(v) => UREncodeResult::encode(

--- a/src/ui/gui_chain/others/gui_zcash.c
+++ b/src/ui/gui_chain/others/gui_zcash.c
@@ -312,9 +312,7 @@ UREncodeResult *GuiGetZcashSignQrCodeData(void)
         uint8_t seed[64];
         GetAccountSeed(GetCurrentAccountIndex(), seed, SecretCacheGetPassword());
         int len = GetMnemonicType() == MNEMONIC_TYPE_BIP39 ? sizeof(seed) : GetCurrentAccountEntropyLen();
-        uint8_t randomness[TRNG_RANDOMNESS_LEN];
-        GenerateTRNGRandomness(randomness, sizeof(randomness));
-        encodeResult = sign_zcash_tx(data, seed, len, randomness, sizeof(randomness));
+        encodeResult = sign_zcash_tx(data, seed, len);
         ClearSecretCache();
         CHECK_CHAIN_BREAK(encodeResult);
     } while (0);


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
This enables Rust crates that depend on the `getrandom` crate (either directly or via `rand::rngs::OsRng`) to get secure randomness directly instead of needing it to be passed through a per-callsite C FFI.
<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->

<!-- END -->

