### PR TITLE
Migrate to latest revision of Zcash crates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -20,7 +20,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -577,15 +577,16 @@ dependencies = [
 
 [[package]]
 name = "bip32"
-version = "0.5.2"
-source = "git+https://github.com/KeystoneHQ/crates.git?rev=9873e8fd56007d792fa60d6e844fdb75d527c858#9873e8fd56007d792fa60d6e844fdb75d527c858"
+version = "0.6.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143f5327f23168716be068f8e1014ba2ea16a6c91e8777bc8927da7b51e1df1f"
 dependencies = [
  "bs58 0.5.1",
  "hmac",
  "rand_core 0.6.4",
- "ripemd",
+ "ripemd 0.2.0-pre.4",
  "secp256k1",
- "sha2 0.10.8",
+ "sha2 0.11.0-pre.4",
  "subtle",
  "zeroize",
 ]
@@ -734,6 +735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.11.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd016a0ddc7cb13661bf5576073ce07330a693f8608a1320b4e20561cc12cdc"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1010,7 +1020,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -1273,6 +1283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b8ce8218c97789f16356e7896b3714f26c2ee1079b79c0b7ae7064bb9089fa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cryptoxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,7 +1508,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2e3d6615d99707295a9673e889bf363a04b2a466bd320c65a72536f7577379"
+dependencies = [
+ "block-buffer 0.11.0-rc.3",
+ "crypto-common 0.2.0-rc.1",
  "subtle",
 ]
 
@@ -1674,7 +1704,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9407f09208d5574a3ba7bf3e6963741114ba77c2#9407f09208d5574a3ba7bf3e6963741114ba77c2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2103,11 +2134,11 @@ checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "e4b1fb14e4df79f9406b434b60acef9f45c26c50062cccf1346c6103b8c47d58"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -2117,6 +2148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -2183,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216c71634ac6f6ed13c2102d64354c0a04dcbdc30e31692c5972d3974d8b6d97"
+checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
  "either",
 ]
@@ -2715,8 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.10.0"
-source = "git+https://github.com/nuttycom/nonempty.git?rev=38d37189faecb2a0e3d6adc05aa24e1b93c2483b#38d37189faecb2a0e3d6adc05aa24e1b93c2483b"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
 name = "noop_proc_macro"
@@ -2870,8 +2911,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "orchard"
-version = "0.10.1"
-source = "git+https://github.com/zcash/orchard.git?rev=e0cc7ac53ad8c97661b312a8b1c064f4cd3c6629#e0cc7ac53ad8c97661b312a8b1c064f4cd3c6629"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ef66fcf99348242a20d582d7434da381a867df8dc155b3a980eca767c56137"
 dependencies = [
  "aes",
  "bitvec",
@@ -2965,8 +3007,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9407f09208d5574a3ba7bf3e6963741114ba77c2#9407f09208d5574a3ba7bf3e6963741114ba77c2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a44b9f258645cbbac406c876e0355f4a71e3f68baa3bb30fd517b28164e0222"
 dependencies = [
  "ff",
  "getset",
@@ -3527,6 +3570,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.2.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48cf93482ea998ad1302c42739bc73ab3adc574890c373ec89710e219357579"
+dependencies = [
+ "digest 0.11.0-pre.9",
+]
+
+[[package]]
 name = "rippled_binary_codec"
 version = "0.0.6"
 source = "git+https://github.com/KeystoneHQ/rippled_binary_codec.git?tag=v0.0.8#6d54449b9f57ab5a881725d591c9283914ce8bf6"
@@ -3993,6 +4045,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -4486,7 +4549,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -5012,8 +5075,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.6.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9407f09208d5574a3ba7bf3e6963741114ba77c2#9407f09208d5574a3ba7bf3e6963741114ba77c2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a21f218c86b350d706c22489af999b098e19bf92ed6dd71770660ea29ee707d"
 dependencies = [
  "bech32 0.11.0",
  "bs58 0.5.1",
@@ -5025,16 +5089,19 @@ dependencies = [
 
 [[package]]
 name = "zcash_encoding"
-version = "0.2.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9407f09208d5574a3ba7bf3e6963741114ba77c2#9407f09208d5574a3ba7bf3e6963741114ba77c2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
 dependencies = [
  "core2",
+ "nonempty",
 ]
 
 [[package]]
 name = "zcash_keys"
-version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9407f09208d5574a3ba7bf3e6963741114ba77c2#9407f09208d5574a3ba7bf3e6963741114ba77c2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af2839a7bb0489ccf0db9fb12c67234dd83e4a3b81ef50a10beecf1e852a18e"
 dependencies = [
  "bech32 0.11.0",
  "bip32",
@@ -5072,8 +5139,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.4.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9407f09208d5574a3ba7bf3e6963741114ba77c2#9407f09208d5574a3ba7bf3e6963741114ba77c2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72df627873d103e973b536d34d16cc802d06a3d1494dc010781449789a156dc5"
 dependencies = [
  "core2",
  "hex",
@@ -5081,17 +5149,18 @@ dependencies = [
 
 [[package]]
 name = "zcash_spec"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cede95491c2191d3e278cab76e097a44b17fde8d6ca0d4e3a22cf4807b2d857"
+checksum = "ded3f58b93486aa79b85acba1001f5298f27a46489859934954d262533ee2915"
 dependencies = [
  "blake2b_simd",
 ]
 
 [[package]]
 name = "zcash_transparent"
-version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=9407f09208d5574a3ba7bf3e6963741114ba77c2#9407f09208d5574a3ba7bf3e6963741114ba77c2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b0c4ea6d9b94b5159106b65b57c4a9ea46859e7f7f8fb1be3e18e2d25bc372"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -5099,7 +5168,7 @@ dependencies = [
  "core2",
  "getset",
  "hex",
- "ripemd",
+ "ripemd 0.1.3",
  "secp256k1",
  "sha2 0.10.8",
  "subtle",
@@ -5134,7 +5203,7 @@ dependencies = [
  "postcard",
  "rand_chacha",
  "reddsa",
- "ripemd",
+ "ripemd 0.1.3",
  "secp256k1",
  "serde",
  "serde_with 3.12.0",
@@ -5192,9 +5261,9 @@ dependencies = [
 
 [[package]]
 name = "zip32"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9943793abf9060b68e1889012dafbd5523ab5b125c0fcc24802d69182f2ac9"
+checksum = "13ff9ea444cdbce820211f91e6aa3d3a56bde7202d3c0961b7c38f793abf5637"
 dependencies = [
  "blake2b_simd",
  "memuse",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -113,15 +113,3 @@ num-traits = { version = "0.2.19", default-features = false }
 blake2b_simd = { version = "1.0.2", default-features = false }
 getrandom = "0.2"
 # third party dependencies end
-
-[patch.crates-io]
-bip32 = { git = "https://github.com/KeystoneHQ/crates.git", rev = "9873e8fd56007d792fa60d6e844fdb75d527c858" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "9407f09208d5574a3ba7bf3e6963741114ba77c2" }
-nonempty = { git = "https://github.com/nuttycom/nonempty.git", rev = "38d37189faecb2a0e3d6adc05aa24e1b93c2483b" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "e0cc7ac53ad8c97661b312a8b1c064f4cd3c6629" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "9407f09208d5574a3ba7bf3e6963741114ba77c2" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "9407f09208d5574a3ba7bf3e6963741114ba77c2" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "9407f09208d5574a3ba7bf3e6963741114ba77c2" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9407f09208d5574a3ba7bf3e6963741114ba77c2" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "9407f09208d5574a3ba7bf3e6963741114ba77c2" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "9407f09208d5574a3ba7bf3e6963741114ba77c2" }

--- a/rust/zcash_vendor/Cargo.toml
+++ b/rust/zcash_vendor/Cargo.toml
@@ -28,7 +28,7 @@ f4jumble = { version = "0.1.1", default-features = false, features = ["alloc"] }
 byteorder = { version = "1", default-features = false }
 ripemd = { version = "0.1", default-features = false, features = ["oid"] }
 bs58 = { version = "0.5", default-features = false, features = ["alloc"] }
-bip32 = { version = "0.5", default-features = false, features = [
+bip32 = { version = "=0.6.0-pre.1", default-features = false, features = [
     "alloc",
     "secp256k1-ffi",
 ] }
@@ -41,14 +41,17 @@ chacha20poly1305 = { version = "0.10.1", default-features = false, features = [
 ] }
 postcard = { version = "1.0.3", features = ["alloc"] }
 getset = { version = "0.1.3" }
-orchard = { version = "0.10", default_features = false }
-pczt = { version = "0.1", features = ["orchard", "transparent"] }
+orchard = { version = "0.11", default_features = false }
+pczt = { version = "0.2", features = ["orchard", "transparent"] }
 serde = { workspace = true }
 serde_with = { version = "3.11.0", features = ["alloc", "macros"], default_features = false }
-transparent = { package = "zcash_transparent", version = "0.1", default_features = false, features = ["transparent-inputs"] }
-zcash_address = { version = "0.6.2", default_features = false }
-zcash_encoding = { version = "0.2.2", default-features = false }
-zcash_keys = { version = "0.6", default-features = false, features = ["orchard", "transparent-inputs"] }
-zcash_protocol = { version = "0.4.2", default-features = false }
-zip32 = { version = "0.1.3", default-features = false }
+transparent = { package = "zcash_transparent", version = "0.2", default_features = false, features = ["transparent-inputs"] }
+zcash_address = { version = "0.7", default_features = false }
+zcash_encoding = { version = "0.3", default-features = false }
+zcash_keys = { version = "0.7", default-features = false, features = ["orchard", "transparent-inputs"] }
+zcash_protocol = { version = "0.5", default-features = false }
+zip32 = { version = "0.2", default-features = false }
 #zcash end
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_unstable, values("zfuture"))'] }

--- a/rust/zcash_vendor/src/lib.rs
+++ b/rust/zcash_vendor/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(error_in_core)]
+
 extern crate alloc;
 
 pub mod pczt_ext;

--- a/rust/zcash_vendor/src/pczt_ext.rs
+++ b/rust/zcash_vendor/src/pczt_ext.rs
@@ -110,7 +110,7 @@ fn has_transparent(pczt: &Pczt) -> bool {
 fn is_transparent_coinbase(pczt: &Pczt) -> bool {
     pczt.transparent().inputs().len() == 1
         && pczt.transparent().inputs()[0].prevout_index() == &u32::MAX
-        && pczt.transparent().inputs()[0].prevout_txid().as_ref() == &[0u8; 32]
+        && pczt.transparent().inputs()[0].prevout_txid() == &[0u8; 32]
 }
 
 fn has_sapling(pczt: &Pczt) -> bool {
@@ -391,7 +391,7 @@ where
     llsigner
         .sign_transparent_with::<T::Error, _>(|pczt, signable, tx_modifiable| {
             let lock_time = determine_lock_time(pczt.global(), pczt.transparent().inputs())
-                .map_err(|()| transparent::pczt::ParseError::InvalidRequiredHeightLocktime)?;
+                .ok_or(transparent::pczt::ParseError::InvalidRequiredHeightLocktime)?;
             signable
                 .inputs_mut()
                 .iter_mut()


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
When the Zcash app was added, some modifications to the upstream Zcash Rust crates were needed to enable no-std support. At the time, these changes were blocked on third-party dependency updates, and so the Keystone firmware depended on patched branches. Now, we have crate releases that include the necessary no-std support, so the Keystone firmware can depend on them directly.
<!-- END -->

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->
Build whichever firmware versions contain the Zcash app.
<!-- END -->

