### PR TITLE
Fix linking simulator executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,7 +377,7 @@ else()
     add_dependencies(${PROJECT_NAME} rust_c)
     target_link_libraries(${PROJECT_NAME} PRIVATE SDL2 ${CMAKE_SOURCE_DIR}/ui_simulator/lib/rust-builds/librust_c.a)
     if(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
-      target_link_libraries(${PROJECT_NAME} PRIVATE m dl pthread )
+      target_link_libraries(${PROJECT_NAME} PRIVATE m dl pthread xcb )
     endif()
 
     if(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")


### PR DESCRIPTION
Simulator executable can not be linked on Linux without xcb in target_link_libraries