### PR TITLE
zcash: Reduce size of the signed PCZT before returning it

### DIFF
--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -7,7 +7,6 @@ pub mod pczt;
 use errors::{Result, ZcashError};
 
 use alloc::{
-    format,
     string::{String, ToString},
     vec::Vec,
 };

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -143,7 +143,7 @@ pub fn parse_pczt<P: consensus::Parameters>(
     //total_input_value = total_output_value + fee_value
     //total_output_value = total_transfer_value + total_change_value
 
-    parsed_orchard.clone().map(|orchard| {
+    if let Some(orchard) = &parsed_orchard {
         total_change_value += orchard
             .get_to()
             .iter()
@@ -157,9 +157,9 @@ pub fn parse_pczt<P: consensus::Parameters>(
             .get_to()
             .iter()
             .fold(0, |acc, to| acc + to.get_amount());
-    });
+    }
 
-    parsed_transparent.clone().map(|transparent| {
+    if let Some(transparent) = &parsed_transparent {
         total_change_value += transparent
             .get_to()
             .iter()
@@ -173,7 +173,7 @@ pub fn parse_pczt<P: consensus::Parameters>(
             .get_to()
             .iter()
             .fold(0, |acc, to| acc + to.get_amount());
-    });
+    }
 
     //treat all sapling output as output value since we don't support sapling decoding yet
     //sapling value_sum can be trusted
@@ -447,10 +447,7 @@ fn parse_orchard_output<P: consensus::Parameters>(
 
                 let is_dummy = match vk {
                     Some(_) => false,
-                    None => match (action.output().user_address(), value) {
-                        (None, 0) => true,
-                        _ => false,
-                    },
+                    None => matches!((action.output().user_address(), value), (None, 0)),
                 };
 
                 Ok(Some(ParsedTo::new(

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -4,7 +4,10 @@ use blake2b_simd::Hash;
 use keystore::algorithms::secp256k1::get_private_key_by_seed;
 use rand_core::OsRng;
 use zcash_vendor::{
-    pczt::{roles::low_level_signer, Pczt},
+    pczt::{
+        roles::{low_level_signer, redactor::Redactor},
+        Pczt,
+    },
     pczt_ext::{self, PcztSigner},
     transparent::{self, sighash::SignableInput},
 };
@@ -104,5 +107,75 @@ pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
     let signer = pczt_ext::sign(signer, &SeedSigner { seed })
         .map_err(|e| ZcashError::SigningError(e.to_string()))?;
 
-    Ok(signer.finish().serialize())
+    // Now that we've created the signature, remove the other optional fields from the
+    // PCZT, to reduce its size for the return trip and make the QR code scanning more
+    // reliable. The wallet that provided the unsigned PCZT can retain it for combining if
+    // these fields are needed.
+    let signed_pczt = Redactor::new(signer.finish())
+        .redact_orchard_with(|mut r| {
+            r.redact_actions(|mut ar| {
+                ar.clear_spend_recipient();
+                ar.clear_spend_value();
+                ar.clear_spend_rho();
+                ar.clear_spend_rseed();
+                ar.clear_spend_fvk();
+                ar.clear_spend_witness();
+                ar.clear_spend_alpha();
+                ar.clear_spend_zip32_derivation();
+                ar.clear_spend_dummy_sk();
+                ar.clear_output_recipient();
+                ar.clear_output_value();
+                ar.clear_output_rseed();
+                ar.clear_output_ock();
+                ar.clear_output_zip32_derivation();
+                ar.clear_output_user_address();
+                ar.clear_rcv();
+            });
+            r.clear_zkproof();
+            r.clear_bsk();
+        })
+        .redact_sapling_with(|mut r| {
+            r.redact_spends(|mut sr| {
+                sr.clear_zkproof();
+                sr.clear_recipient();
+                sr.clear_value();
+                sr.clear_rcm();
+                sr.clear_rseed();
+                sr.clear_rcv();
+                sr.clear_proof_generation_key();
+                sr.clear_witness();
+                sr.clear_alpha();
+                sr.clear_zip32_derivation();
+                sr.clear_dummy_ask();
+            });
+            r.redact_outputs(|mut or| {
+                or.clear_zkproof();
+                or.clear_recipient();
+                or.clear_value();
+                or.clear_rseed();
+                or.clear_rcv();
+                or.clear_ock();
+                or.clear_zip32_derivation();
+                or.clear_user_address();
+            });
+            r.clear_bsk();
+        })
+        .redact_transparent_with(|mut r| {
+            r.redact_inputs(|mut ir| {
+                ir.clear_redeem_script();
+                ir.clear_bip32_derivation();
+                ir.clear_ripemd160_preimages();
+                ir.clear_sha256_preimages();
+                ir.clear_hash160_preimages();
+                ir.clear_hash256_preimages();
+            });
+            r.redact_outputs(|mut or| {
+                or.clear_redeem_script();
+                or.clear_bip32_derivation();
+                or.clear_user_address();
+            });
+        })
+        .finish();
+
+    Ok(signed_pczt.serialize())
 }

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -16,7 +16,7 @@ struct SeedSigner<'a> {
     seed: &'a [u8],
 }
 
-impl<'a> PcztSigner for SeedSigner<'a> {
+impl PcztSigner for SeedSigner<'_> {
     type Error = ZcashError;
     fn sign_transparent<F>(
         &self,

--- a/rust/zcash_vendor/src/pczt_ext.rs
+++ b/rust/zcash_vendor/src/pczt_ext.rs
@@ -209,14 +209,11 @@ fn digest_orchard(pczt: &Pczt) -> Hash {
     h.update(mh.finalize().as_bytes());
     h.update(nh.finalize().as_bytes());
     h.update(&[*pczt.orchard().flags()]);
-    let value_balance = match pczt.orchard().value_sum() {
-        (magnitude, sign) => {
-            if *sign {
-                -(*magnitude as i64)
-            } else {
-                *magnitude as i64
-            }
-        }
+    let (magnitude, sign) = pczt.orchard().value_sum();
+    let value_balance = if *sign {
+        -(*magnitude as i64)
+    } else {
+        *magnitude as i64
     };
     h.update(&value_balance.to_le_bytes());
 


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
The unsigned PCZT provided by the wallet contains various optional fields that we use to both check the PCZT effects and create the signatures. However, we can assume that the wallet can recover these fields if it needs them, and clear them from the PCZT we return. This should make the animated QR code displayed by the Keystone device smaller and easier to scan.
<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->
- Create a Keystone transaction in Zashi.
- Scan the Zashi animated QR code with Keystone.
- Approve the transaction in Keystone.
- Scan the Keystone animated QR code with Zashi.
- Check that the signed transaction completes and is successfully broadcast to the Zcash network.
<!-- END -->

