### PR TITLE
fix: revert hash paired

### DIFF
--- a/rust/apps/cardano/src/structs.rs
+++ b/rust/apps/cardano/src/structs.rs
@@ -1138,6 +1138,12 @@ impl ParsedCardanoTx {
                         }
                     }
 
+                    if !pubkey_hash_paired {
+                        return Err(CardanoError::InvalidTransaction(
+                            "invalid address".to_string(),
+                        ));
+                    }
+
                     parsed_inputs.push(ParsedCardanoInput {
                         transaction_hash: utxo.transaction_hash.clone(),
                         index: utxo.index,


### PR DESCRIPTION
## Explanation
1 revert hash paired

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.


