### PR TITLE
./rust/CMakeLists.txt requested an older nightly build than expected

### DIFF
--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -61,7 +61,7 @@ message(STATUS "cargo build command: " ${CARGO_FLAG})
 
 #run build
 add_custom_target(rust_c ALL
-    COMMAND rustup run nightly-2024-07-01 ${RUST_CARGO_EXECUTABLE} build ${CARGO_FLAG}
+    COMMAND rustup run nightly-2024-10-09 ${RUST_CARGO_EXECUTABLE} build ${CARGO_FLAG}
     COMMAND ${COPY_BUILD_TARGET}
     COMMAND ${COPY_BINDINGS_TARGET}
     WORKING_DIRECTORY ${RUST_DIR}


### PR DESCRIPTION
Previously compilations would fail as the toolchain wasn't properly setup. Now the firmware builds.

## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
Unable to build as it was using the wrong toolchain
<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

How to execute unit tests?

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->
I setup a new Linux install
Followed the instructions in README.md
Failed at `python build.py` before the patch, now it works
<!-- END -->

