### PR TITLE
feat(wallet): add IOTA chain type to check_hardware_call_path()

### DIFF
--- a/rust/rust_c/src/wallet/mod.rs
+++ b/rust/rust_c/src/wallet/mod.rs
@@ -104,6 +104,7 @@ pub extern "C" fn check_hardware_call_path(
         "QCK" => "m/44'/118'",
         "TGD" => "m/44'/118'",
         "THOR" => "m/44'/931'",
+        "IOTA" => "m/44'/4218'",
         _ => return Response::success(false).c_ptr(),
     };
     let mut path = recover_c_char(path).to_lowercase();


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
Add IOTA chain type to check_hardware_call_path(), because it was missing and therefore calling it would always fail.
<!-- END -->

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->
Do a hardware call like deriving a key with a specific path using an IOTA bip path
<!-- END -->

