### PR TITLE
Stub testnet support for Zcash in cypherpunk fw

### DIFF
--- a/rust/rust_c/src/zcash/structs.rs
+++ b/rust/rust_c/src/zcash/structs.rs
@@ -12,6 +12,22 @@ use app_zcash::pczt::structs::{
     ParsedFrom, ParsedOrchard, ParsedPczt, ParsedTo, ParsedTransparent,
 };
 use cstr_core;
+use zcash_vendor::zcash_protocol::consensus::Network;
+
+#[repr(C)]
+pub enum NetworkType {
+    MainNet,
+    TestNet,
+}
+
+impl From<NetworkType> for Network {
+    fn from(val: NetworkType) -> Self {
+        match val {
+            NetworkType::MainNet => Network::MainNetwork,
+            NetworkType::TestNet => Network::TestNetwork,
+        }
+    }
+}
 
 #[repr(C)]
 pub struct DisplayPczt {

--- a/src/crypto/account_public_info.c
+++ b/src/crypto/account_public_info.c
@@ -930,7 +930,7 @@ int32_t AccountPublicSavePublicInfo(uint8_t accountIndex, const char *password, 
                 if (g_chainTable[i].cryptoKey == ZCASH_UFVK_ENCRYPTED) {
                     char* zcashUfvk = NULL;
                     SimpleResponse_c_char *zcash_ufvk_response = NULL;
-                    zcash_ufvk_response = derive_zcash_ufvk(seed, len, g_chainTable[i].path);
+                    zcash_ufvk_response = derive_zcash_ufvk(seed, len, g_chainTable[i].path, GetNetworkType(HOME_WALLET_CARD_ZEC));
                     CHECK_AND_FREE_XPUB(zcash_ufvk_response)
                     zcashUfvk = zcash_ufvk_response->data;
                     SimpleResponse_u8 *iv_response = rust_derive_iv_from_seed(seed, len);
@@ -1104,7 +1104,7 @@ int32_t TempAccountPublicInfo(uint8_t accountIndex, const char *password, bool s
             if (g_chainTable[i].cryptoKey == ZCASH_UFVK_ENCRYPTED) {
                 char* zcashUfvk = NULL;
                 SimpleResponse_c_char *zcash_ufvk_response = NULL;
-                zcash_ufvk_response = derive_zcash_ufvk(seed, len, g_chainTable[i].path);
+                zcash_ufvk_response = derive_zcash_ufvk(seed, len, g_chainTable[i].path, GetNetworkType(HOME_WALLET_CARD_ZEC));
                 CHECK_AND_FREE_XPUB(zcash_ufvk_response)
                 zcashUfvk = zcash_ufvk_response->data;
                 SimpleResponse_u8 *iv_response = rust_derive_iv_from_seed(seed, len);

--- a/src/ui/gui_chain/multi/cypherpunk/gui_zcash.c
+++ b/src/ui/gui_chain/multi/cypherpunk/gui_zcash.c
@@ -3,6 +3,7 @@
 #include "user_memory.h"
 #include "account_manager.h"
 #include "gui_chain.h"
+#include "gui_home_widgets.h"
 #include "keystore.h"
 #include "screen_manager.h"
 
@@ -21,6 +22,11 @@ static DisplayPczt *g_zcashData;
         result = NULL;                                                                              \
     }
 
+NetworkType GetZcashNetworkType(void)
+{
+    return GetNetworkType(HOME_WALLET_CARD_ZEC);
+}
+
 void GuiSetZcashUrData(URParseResult *urResult, URParseMultiResult *urMultiResult, bool multi)
 {
     g_urResult = urResult;
@@ -38,7 +44,7 @@ void *GuiGetZcashGUIData(void)
 
     PtrT_TransactionParseResult_DisplayPczt parseResult = NULL;
     do {
-        parseResult = parse_zcash_tx(data, ufvk, sfp);
+        parseResult = parse_zcash_tx(data, ufvk, sfp, GetZcashNetworkType());
         CHECK_CHAIN_BREAK(parseResult);
         g_zcashData = parseResult->data;
         g_parseResult = (void *)parseResult;
@@ -303,7 +309,7 @@ PtrT_TransactionCheckResult GuiGetZcashCheckResult(void)
     GetZcashUFVK(GetCurrentAccountIndex(), ufvk, sfp);
     uint32_t zcash_account_index = 0;
     MnemonicType mnemonicType = GetMnemonicType();
-    return check_zcash_tx(data, ufvk, sfp, zcash_account_index, mnemonicType == MNEMONIC_TYPE_SLIP39);
+    return check_zcash_tx(data, ufvk, sfp, zcash_account_index, mnemonicType == MNEMONIC_TYPE_SLIP39, GetZcashNetworkType());
 }
 
 UREncodeResult *GuiGetZcashSignQrCodeData(void)

--- a/src/ui/gui_chain/multi/cypherpunk/gui_zcash.h
+++ b/src/ui/gui_chain/multi/cypherpunk/gui_zcash.h
@@ -3,6 +3,7 @@
 #include "rust.h"
 #include "gui.h"
 
+NetworkType GetZcashNetworkType(void);
 void GuiSetZcashUrData(URParseResult *urResult, URParseMultiResult *urMultiResult, bool multi);
 void *GuiGetZcashGUIData(void);
 PtrT_TransactionCheckResult GuiGetZcashCheckResult(void);

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_cypherpunk_home_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_cypherpunk_home_widgets.c
@@ -46,7 +46,7 @@ static uint8_t g_currentPage = 0;
 static bool g_isScrolling = false;
 
 static WalletState_t g_walletState[HOME_WALLET_CARD_BUTT] = {
-    {HOME_WALLET_CARD_BTC, false, "BTC", true},
+    {HOME_WALLET_CARD_BTC, false, "BTC", true, MainNet},
     HOME_WALLET_STATE_SURPLUS,
 };
 static WalletState_t g_walletBakState[HOME_WALLET_CARD_BUTT] = {0};
@@ -481,6 +481,18 @@ void GuiHomeRefresh(void)
         CreateBetaNotice();
         isFirstBeta = false;
     }
+}
+
+NetworkType GetNetworkType(HOME_WALLET_CARD_ENUM index)
+{
+    return g_walletState[index].network;
+}
+
+
+void SetNetworkType(HOME_WALLET_CARD_ENUM index, NetworkType network)
+{
+    g_walletState[index].network = network;
+    AccountPublicHomeCoinSet(g_walletState, NUMBER_OF_ARRAYS(g_walletState));
 }
 
 const ChainCoinCard_t *GetCoinCardByIndex(HOME_WALLET_CARD_ENUM index)

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_cypherpunk_home_widgets.h
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_cypherpunk_home_widgets.h
@@ -5,8 +5,8 @@
 #define HOME_WIDGETS_SURPLUS_CARD_ENUM     HOME_WALLET_CARD_ZEC, \
     HOME_WALLET_CARD_MONERO
 
-#define HOME_WALLET_STATE_SURPLUS          {HOME_WALLET_CARD_ZEC, true, "ZEC", true}, \
-    {HOME_WALLET_CARD_MONERO, true, "XMR", true}
+#define HOME_WALLET_STATE_SURPLUS          {HOME_WALLET_CARD_ZEC, true, "ZEC", true, MainNet}, \
+    {HOME_WALLET_CARD_MONERO, true, "XMR", true, MainNet}
 
 #define HOME_WALLET_CARD_SURPLUS           { \
         .index = HOME_WALLET_CARD_ZEC, \

--- a/src/ui/gui_widgets/multi/gui_home_widgets.h
+++ b/src/ui/gui_widgets/multi/gui_home_widgets.h
@@ -22,6 +22,7 @@ typedef struct {
     bool state;
     const char *name;
     bool enable;
+    NetworkType network;
     lv_obj_t *checkBox;
 } WalletState_t;
 
@@ -38,6 +39,8 @@ void GuiHomeDisActive(void);
 void GuiHomeSetWalletDesc(WalletDesc_t *wallet);
 void GuiHomeRestart(void);
 bool GuiHomePageIsTop(void);
+NetworkType GetNetworkType(HOME_WALLET_CARD_ENUM index);
+void SetNetworkType(HOME_WALLET_CARD_ENUM index, NetworkType network);
 void GuiHomePasswordErrorCount(void *param);
 void GuiRemoveKeyboardWidget(void);
 void RecalculateManageWalletState(void);
@@ -49,4 +52,3 @@ void ClearHomePageCurrentIndex(void);
 void ReturnManageWalletHandler(lv_event_t *e);
 
 #endif /* _GUI_HOME_WIDGETS_H */
-

--- a/src/ui/gui_widgets/multi/gui_standard_receive_widgets.c
+++ b/src/ui/gui_widgets/multi/gui_standard_receive_widgets.c
@@ -920,7 +920,7 @@ static void ModelGetAddress(uint32_t index, AddressDataItem_t *item)
         char ufvk[ZCASH_UFVK_MAX_LEN] = {'\0'};
         uint8_t sfp[32];
         GetZcashUFVK(GetCurrentAccountIndex(), ufvk, sfp);
-        result = generate_zcash_default_address(ufvk);
+        result = generate_zcash_default_address(ufvk, GetZcashNetworkType());
     }
 #endif
 


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
This is preliminary work for Zcash multisig support. It keeps the duplicated code more similar between the btc_only and cypherpunk firmwares. Supporting testnet is also a useful feature on its own.

There is no GUI to control this, but changing `MainNet` to `TestNet` in the `HOME_WALLET_CARD_ZEC` entry of `g_walletState` will switch to testnet for Zcash.

Changing the entries for `HOME_WALLET_CARD_BTC` or `HOME_WALLET_CARD_MONERO` will have no effect.
<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->
Replace `MainNet` with `TestNet` as described above, and use the cypherpunk simulator will perform Zcash operations on testnet.

**NB**: This was developed on top of #1945, but pushed without those commits, since there is no code dependency between them. However, since I needed that PR in order to build the simulator, this might not work without those changes.
<!-- END -->

