### PR TITLE
Fix buffer overflow

### DIFF
--- a/external/mh1903_lib/SCPU_USB_Lib/SCPU_USB_HOST_Library/Core/src/usbh_stdreq.c
+++ b/external/mh1903_lib/SCPU_USB_Lib/SCPU_USB_HOST_Library/Core/src/usbh_stdreq.c
@@ -464,7 +464,7 @@ static void  USBH_ParseInterfaceDesc(USBH_InterfaceDesc_TypeDef *if_descriptor,
     if_descriptor->bDescriptorType    = *(uint8_t  *)(buf + 1);
     if_descriptor->bInterfaceNumber   = *(uint8_t  *)(buf + 2);
     if_descriptor->bAlternateSetting  = *(uint8_t  *)(buf + 3);
-    if_descriptor->bNumEndpoints      = *(uint8_t  *)(buf + 4);
+    if_descriptor->bNumEndpoints      = MIN(*(uint8_t *)(buf + 4), USBH_MAX_NUM_ENDPOINTS);
     if_descriptor->bInterfaceClass    = *(uint8_t  *)(buf + 5);
     if_descriptor->bInterfaceSubClass = *(uint8_t  *)(buf + 6);
     if_descriptor->bInterfaceProtocol = *(uint8_t  *)(buf + 7);


### PR DESCRIPTION
This PR fixes a potential security vulnerability in USBH_ParseInterfaceDesc() that was cloned from https://github.com/STMicroelectronics/stm32-mw-usb-host but did not receive the security patch.

### Details:
Affected Function: USBH_ParseInterfaceDesc() in external/mh1903_lib/SCPU_USB_Lib/SCPU_USB_HOST_Library/Core/src/usbh_stdreq.c
Original Fix: https://github.com/STMicroelectronics/stm32-mw-usb-host/commit/15c4631397bb61bcbf0dae7f46ddcad1bd26c86f

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/STMicroelectronics/stm32-mw-usb-host/commit/15c4631397bb61bcbf0dae7f46ddcad1bd26c86f
- https://nvd.nist.gov/vuln/detail/CVE-2021-34260

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
