### PR TITLE
Fix simulator build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ else()
     add_dependencies(${PROJECT_NAME} rust_c)
     target_link_libraries(${PROJECT_NAME} PRIVATE SDL2 ${CMAKE_SOURCE_DIR}/ui_simulator/lib/rust-builds/librust_c.a)
     if(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
-      target_link_libraries(${PROJECT_NAME} PRIVATE m dl pthread )
+      target_link_libraries(${PROJECT_NAME} PRIVATE m dl pthread xcb )
     endif()
 
     if(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")

--- a/src/ram/user_memory.h
+++ b/src/ram/user_memory.h
@@ -24,6 +24,10 @@ void PrintHeapInfo(void);
 
 #ifdef COMPILE_SIMULATOR
 #include <stdlib.h>
+#ifndef _ERRNO_T_DEFINED
+#define _ERRNO_T_DEFINED
+typedef int errno_t;
+#endif
 #ifndef snprintf_s
 #define snprintf_s                          snprintf
 #endif


### PR DESCRIPTION
Currently, simulator builds are broken. This PR fixes those issues.

Resolves: https://github.com/KeystoneHQ/keystone3-firmware/issues/2108