### PR TITLE
feat(zcash): pass firmware version in ZcashAccounts pairing QR

### DIFF
--- a/rust/apps/wallets/src/zcash.rs
+++ b/rust/apps/wallets/src/zcash.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
 
 use alloc::vec::Vec;
 
@@ -19,6 +19,7 @@ impl_public_struct!(UFVKInfo {
 pub fn generate_sync_ur(
     key_infos: Vec<UFVKInfo>,
     seed_fingerprint: [u8; 32],
+    device_version: Option<&str>,
 ) -> URResult<ZcashAccounts> {
     let keys = key_infos
         .iter()
@@ -30,7 +31,10 @@ pub fn generate_sync_ur(
             ))
         })
         .collect::<URResult<Vec<ZcashUnifiedFullViewingKey>>>()?;
-    let accounts = ZcashAccounts::new(seed_fingerprint.to_vec(), keys);
+    let mut accounts = ZcashAccounts::new(seed_fingerprint.to_vec(), keys);
+    if let Some(version) = device_version {
+        accounts.set_device_version(version.to_string());
+    }
     Ok(accounts)
 }
 
@@ -56,7 +60,7 @@ mod tests {
             },
         ];
 
-        let result = generate_sync_ur(key_infos, seed_fingerprint);
+        let result = generate_sync_ur(key_infos, seed_fingerprint, Some("1.2.3"));
         assert!(result.is_ok());
 
         let accounts = result.unwrap();

--- a/rust/rust_c/src/wallet/cypherpunk_wallet/zcash.rs
+++ b/rust/rust_c/src/wallet/cypherpunk_wallet/zcash.rs
@@ -18,6 +18,7 @@ pub unsafe extern "C" fn get_connect_zcash_wallet_ur(
     seed_fingerprint: PtrBytes,
     seed_fingerprint_len: u32,
     zcash_keys: Ptr<CSliceFFI<ZcashKey>>,
+    device_version: PtrString,
 ) -> *mut UREncodeResult {
     if seed_fingerprint_len != 32 {
         return UREncodeResult::from(URError::UrEncodeError(format!(
@@ -41,7 +42,12 @@ pub unsafe extern "C" fn get_connect_zcash_wallet_ur(
             )
         })
         .collect();
-    let result = generate_sync_ur(ufvks, seed_fingerprint);
+    let version = if device_version.is_null() {
+        None
+    } else {
+        Some(recover_c_char(device_version))
+    };
+    let result = generate_sync_ur(ufvks, seed_fingerprint, version.as_deref());
     match result.map(|v| v.try_into()) {
         Ok(v) => match v {
             Ok(data) => UREncodeResult::encode(

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_connect_wallet_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_connect_wallet_widgets.c
@@ -367,7 +367,8 @@ UREncodeResult *GuiGetZecData(void)
     data[0].key_name = GetWalletName();
     data[0].index = 0;
     char firmwareVersion[32];
-    GetSoftWareVersionNumber(firmwareVersion);
+    snprintf(firmwareVersion, sizeof(firmwareVersion), "%d.%d.%d",
+             SOFTWARE_VERSION_MAJOR, SOFTWARE_VERSION_MINOR, SOFTWARE_VERSION_BUILD);
     return get_connect_zcash_wallet_ur(sfp, 32, keys, firmwareVersion);
 }
 

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_connect_wallet_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_connect_wallet_widgets.c
@@ -1,5 +1,6 @@
 #include "gui_connect_wallet_widgets.h"
 #include "account_public_info.h"
+#include "version.h"
 #include "gui.h"
 #include "gui_button.h"
 #include "gui_hintbox.h"
@@ -365,7 +366,9 @@ UREncodeResult *GuiGetZecData(void)
     data[0].key_text = ufvk;
     data[0].key_name = GetWalletName();
     data[0].index = 0;
-    return get_connect_zcash_wallet_ur(sfp, 32, keys);
+    char firmwareVersion[32];
+    GetSoftWareVersionNumber(firmwareVersion);
+    return get_connect_zcash_wallet_ur(sfp, 32, keys, firmwareVersion);
 }
 
 void GuiPrepareArConnectWalletView(void)


### PR DESCRIPTION
Closes #2147

## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->

When connecting a Keystone to a Zcash wallet (e.g. Zodl) via QR scan, the `ZcashAccounts` UR now includes the device firmware version. This mirrors what other chains (MetaMask, OKX, Bitget) already do via `MultiAccounts.deviceVersion`, letting wallets detect device capabilities at pairing time rather than waiting for a signed transaction.

Backwards compatible: the field is optional. Old wallets ignore the unknown CBOR key. Old firmware omits it and wallets see `nil`.

**Changes:**

- `rust/apps/wallets/src/zcash.rs` — `generate_sync_ur()` accepts an optional `device_version` parameter and stamps it into the `ZcashAccounts` CBOR.
- `rust/rust_c/src/wallet/cypherpunk_wallet/zcash.rs` — passes the version string through the C→Rust FFI boundary, with a null check for backwards compat.
- `src/ui/gui_widgets/multi/cypherpunk/gui_connect_wallet_widgets.c` — calls `GetSoftWareVersionNumber()` and passes it to `get_connect_zcash_wallet_ur()`.

https://github.com/KeystoneHQ/keystone-sdk-rust/pull/127 must be merged and tagged first (adds `device_version` to the `ZcashAccounts` CBOR type). The `ur-registry` tag in `Cargo.toml` must be updated to the new release before this compiles.

<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->

Using all three device version PRs I have opened

https://github.com/KeystoneHQ/keystone-sdk-rust/pull/127
https://github.com/KeystoneHQ/keystone-sdk-ios/pull/39
https://github.com/KeystoneHQ/keystone3-firmware/pull/2138

I tested against a zodl app that prints a debug line when connecting the keystone. We see that the keystone version is correctly communicated when connecting the hardware wallet:

https://github.com/user-attachments/assets/314b06d9-80b1-40d1-945f-92fad6503d0a

## Docs

I wrote up a short doc on how we will use QR pairing and data added when responding with the signed PCZT in order to achieve version negotiation for the upcoming quantum recoverability feature in zcash

https://hackmd.io/@valargroup/H1pGeaFh-l 

<!-- END -->
