### PR TITLE
feat(zcash): enable USB signing and account export

### DIFF
--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -5,7 +5,7 @@ use crate::common::{
     free::Free,
     structs::{SimpleResponse, TransactionCheckResult, TransactionParseResult},
     types::{Ptr, PtrBytes, PtrString, PtrT, PtrUR},
-    ur::{UREncodeResult, FRAGMENT_MAX_LENGTH_DEFAULT},
+    ur::{UREncodeResult, FRAGMENT_MAX_LENGTH_DEFAULT, FRAGMENT_UNLIMITED_LENGTH},
     utils::{convert_c_char, recover_c_char},
 };
 use crate::{extract_array, extract_array_mut};
@@ -183,6 +183,30 @@ pub unsafe extern "C" fn sign_zcash_tx(
                 v,
                 ZcashPczt::get_registry_type().get_type(),
                 FRAGMENT_MAX_LENGTH_DEFAULT,
+            )
+            .c_ptr(),
+        },
+        Err(e) => UREncodeResult::from(e).c_ptr(),
+    };
+    seed.zeroize();
+    result
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sign_zcash_tx_unlimited(
+    tx: PtrUR,
+    seed: PtrBytes,
+    seed_len: u32,
+) -> *mut UREncodeResult {
+    let pczt = extract_ptr_with_type!(tx, ZcashPczt);
+    let mut seed = extract_array_mut!(seed, u8, seed_len as usize);
+    let result = match app_zcash::sign_pczt(&pczt.get_data(), seed) {
+        Ok(pczt) => match ZcashPczt::new(pczt).try_into() {
+            Err(e) => UREncodeResult::from(e).c_ptr(),
+            Ok(v) => UREncodeResult::encode(
+                v,
+                ZcashPczt::get_registry_type().get_type(),
+                FRAGMENT_UNLIMITED_LENGTH,
             )
             .c_ptr(),
         },

--- a/src/ui/gui_chain/gui_chain.c
+++ b/src/ui/gui_chain/gui_chain.c
@@ -38,13 +38,14 @@ bool CheckViewTypeIsAllow(uint8_t viewType)
     case REMAPVIEW_AVAX:
     case REMAPVIEW_TRX:
     case REMAPVIEW_TRX_PERSONAL_MESSAGE:
+    case REMAPVIEW_ZCASH:
         return true;
     default:
         return false;
     }
 #endif
 #ifdef CYPHERPUNK_VERSION
-    return ViewTypeReMap(viewType) == REMAPVIEW_BTC || ViewTypeReMap(viewType) == REMAPVIEW_BTC_MESSAGE;
+    return ViewTypeReMap(viewType) == REMAPVIEW_BTC || ViewTypeReMap(viewType) == REMAPVIEW_BTC_MESSAGE || ViewTypeReMap(viewType) == REMAPVIEW_ZCASH;
 #endif
     return false;
 }
@@ -104,11 +105,11 @@ static const ViewHandlerEntry g_viewHandlerMap[] = {
 
     {TonTx, GuiGetTonSignQrCodeData, NULL, GuiGetTonCheckResult, CHAIN_TON, REMAPVIEW_TON},
     {TonSignProof, GuiGetTonProofSignQrCodeData, NULL, GuiGetTonCheckResult, CHAIN_TON, REMAPVIEW_TON_SIGNPROOF},
-    {ZcashTx, GuiGetZcashSignQrCodeData, NULL, GuiGetZcashCheckResult, CHAIN_ZCASH, REMAPVIEW_ZCASH},
+    {ZcashTx, GuiGetZcashSignQrCodeData, GuiGetZcashSignUrDataUnlimited, GuiGetZcashCheckResult, CHAIN_ZCASH, REMAPVIEW_ZCASH},
 #endif
 
 #ifdef CYPHERPUNK_VERSION
-    {ZcashTx, GuiGetZcashSignQrCodeData, NULL, GuiGetZcashCheckResult, CHAIN_ZCASH, REMAPVIEW_ZCASH},
+    {ZcashTx, GuiGetZcashSignQrCodeData, GuiGetZcashSignUrDataUnlimited, GuiGetZcashCheckResult, CHAIN_ZCASH, REMAPVIEW_ZCASH},
     {XmrOutput, GuiGetMoneroKeyimagesQrCodeData, NULL, GuiGetMoneroOutputCheckResult, CHAIN_XMR, REMAPVIEW_XMR_OUTPUT},
     {XmrTxUnsigned, GuiGetMoneroSignedTransactionQrCodeData, NULL, GuiGetMoneroUnsignedTxCheckResult, CHAIN_XMR, REMAPVIEW_XMR_UNSIGNED},
 #endif

--- a/src/ui/gui_chain/multi/gui_zcash.c
+++ b/src/ui/gui_chain/multi/gui_zcash.c
@@ -328,6 +328,12 @@ UREncodeResult *GuiGetZcashSignQrCodeData(void)
     return SignInternal(sign_zcash_tx, data);
 }
 
+UREncodeResult *GuiGetZcashSignUrDataUnlimited(void)
+{
+    void *data = g_isMulti ? g_urMultiResult->data : g_urResult->data;
+    return SignInternal(sign_zcash_tx_unlimited, data);
+}
+
 void FreeZcashMemory(void)
 {
     CHECK_FREE_UR_RESULT(g_urResult, false);

--- a/src/ui/gui_chain/multi/gui_zcash.h
+++ b/src/ui/gui_chain/multi/gui_zcash.h
@@ -7,6 +7,7 @@ void GuiSetZcashUrData(URParseResult *urResult, URParseMultiResult *urMultiResul
 void *GuiGetZcashGUIData(void);
 PtrT_TransactionCheckResult GuiGetZcashCheckResult(void);
 UREncodeResult *GuiGetZcashSignQrCodeData(void);
+UREncodeResult *GuiGetZcashSignUrDataUnlimited(void);
 void FreeZcashMemory(void);
 
 void GuiZcashOverview(lv_obj_t *parent, void *totalData);

--- a/src/ui/gui_widgets/multi/gui_key_derivation_request_widgets.c
+++ b/src/ui/gui_widgets/multi/gui_key_derivation_request_widgets.c
@@ -14,6 +14,7 @@
 #include "gui_keyboard_hintbox.h"
 #include "gui_lock_widgets.h"
 #include "account_public_info.h"
+#include "account_manager.h"
 #include "gui_key_derivation_request_widgets.h"
 
 typedef struct KeyDerivationWidget {
@@ -156,6 +157,8 @@ static void RecalcCurrentWalletIndex(char *origin)
         g_walletIndex = WALLET_LIST_MEDUSA;
     } else if (strcmp("gerowallet", origin) == 0) {
         g_walletIndex = WALLET_LIST_GERO;
+    } else if (strcmp("zodl", origin) == 0) {
+        g_walletIndex = WALLET_LIST_ZODL;
     } else {
         g_walletIndex = WALLET_LIST_ETERNL;
     }
@@ -525,6 +528,22 @@ static HardwareCallResult_t CheckHardwareCallRequestIsLegal(void)
 
 static UREncodeResult *ModelGenerateSyncUR(void)
 {
+#ifdef CYPHERPUNK_VERSION
+    if (strcmp("zodl", g_callData->origin) == 0) {
+        CSliceFFI_ZcashKey *zcashKeys = SRAM_MALLOC(sizeof(CSliceFFI_ZcashKey));
+        ZcashKey zcashKeyData[1];
+        zcashKeys->data = zcashKeyData;
+        zcashKeys->size = 1;
+        char ufvk[384] = {'\0'};
+        uint8_t sfp[32];
+        GetZcashUFVK(GetCurrentAccountIndex(), ufvk);
+        GetZcashSFP(GetCurrentAccountIndex(), sfp);
+        zcashKeyData[0].key_text = ufvk;
+        zcashKeyData[0].key_name = GetWalletName();
+        zcashKeyData[0].index = 0;
+        return get_connect_zcash_wallet_ur(sfp, 32, zcashKeys);
+    }
+#endif
     bool enable = IsPreviousLockScreenEnable();
     SetLockScreen(false);
     CSliceFFI_ExtendedPublicKey keys;


### PR DESCRIPTION
## Explanation

I'm building a Zcash desktop wallet that supports Keystone. On desktop (monitor + webcam), the webcam's resolution and focus limitations make it unreliable to read Keystone's animated QR codes. USB transport is the practical solution for desktop wallets.

Zcash PCZT signing and account export work via QR but are completely blocked via USB — this appears to be an implementation gap rather than an intentional restriction (BTC works over USB in CYPHERPUNK, Monero has the same gap, no security rationale is documented, and the pattern matches how Cardano was initially QR-only before #1422 wired up USB).

This PR was developed with AI assistance (Claude Code).

### Changes

**1. `CheckViewTypeIsAllow` rejects Zcash over USB**
`REMAPVIEW_ZCASH` was missing from both the WEB3 switch and the CYPHERPUNK condition, causing "this view type is not supported" for USB-received PCZTs.

**2. `unlimitHandler` is NULL for ZcashTx**
After the user approves a transaction via USB, `GetSingleUrGenerator()` returned NULL, silently dropping the signed result. A new `sign_zcash_tx_unlimited` uses `FRAGMENT_UNLIMITED_LENGTH` (11000 bytes) to avoid truncating multi-KB signed PCZTs with Orchard proofs (the default 200-byte fragment size would only send the first fragment).

**3. No USB path for Zcash account export (CYPHERPUNK)**
When Zodl wallet sends a `QRHardwareCall` with origin `"zodl"`, the device didn't recognize it. Now `ModelGenerateSyncUR` returns a `ZcashAccounts` UR via existing `get_connect_zcash_wallet_ur()`.

## Pre-merge check list
- [ ] PR run build successfully on local machine.
- [ ] All unit tests passed locally.

## How to test

1. **USB PCZT signing**: Send a `zcash-pczt` UR via `CMD_RESOLVE_UR` → device displays transaction → approve → signed PCZT returned via USB
2. **USB account export (CYPHERPUNK)**: Send `QRHardwareCall` with `origin="zodl"` → approve → `ZcashAccounts` UR returned
3. **QR regression**: QR-based Zcash signing and Zodl connection still work
4. **Other chains**: BTC/ETH USB signing unaffected
