### PR TITLE
Add macOS simulator setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ For full details, see [docs/SIMULATOR.md](docs/SIMULATOR.md).
 # Install SDL2
 brew install sdl2
 
-# Create a Python virtual environment.
-# Python 3.12 is known to work; Python 3.14 currently has dependency issues.
+# Optional: create a Python virtual environment.
+# Python 3.12 is known to work for image regeneration dependencies.
 uv venv --python python3.12
 source .venv/bin/activate
 uv pip install -r requirements.txt
@@ -127,6 +127,8 @@ uv pip install -r requirements.txt
 # Run the existing build without rebuilding.
 ./simulator.sh --no-build
 ```
+
+`simulator.sh` skips image regeneration, so Pillow/PyYAML are not required for the normal simulator build. Install `requirements.txt` when you need to regenerate image assets.
 
 ### QR Code Scanning (macOS)
 

--- a/README.md
+++ b/README.md
@@ -19,23 +19,22 @@ Its standout features include:
 Follow these steps to set up your development environment on MacOS:
 
 ```bash
-# Install GCC
-brew install armmbed/formulae/arm-none-eabi-gcc
-# If you encounter issues with Brew when installing GCC, switch to manual installation:
-# Visit https://developer.arm.com/downloads/-/gnu-rm, and select the `9-2020-q2-update`
+# Install ARM GCC toolchain
+brew install --cask gcc-arm-embedded
 
-# Install Rust
-# For instructions, visit https://www.rust-lang.org/tools/install
+# Install Rust (https://www.rust-lang.org/tools/install)
 rustup install $(cat rust-toolchain)
 rustup target add thumbv7em-none-eabihf
 cargo install bindgen-cli
-cargo install cbindgen
+rustup run stable cargo install cbindgen
 
 # Clone the repository
 git clone https://github.com/KeystoneHQ/keystone3-firmware
 cd keystone3-firmware
 git -c submodule.keystone3-firmware-release.update=none submodule update --init --recursive
 ```
+
+The current Homebrew ARM GCC is stricter than the GCC version this project originally used. The checked-in `firmware.cmake` relaxes the warning classes that currently break firmware builds with GCC 15.
 
 #### Docker
 
@@ -49,18 +48,22 @@ docker build -t keystone3-baker:local .
 
 Here's how to build the Keystone3 Firmware:
 
-#### Building multi-coins firmware
+#### Building multi-coins firmware (default)
 
 ```bash
-# Run the build script at the root of the project.
 python3 build.py
+```
+
+#### Building cypherpunk firmware
+
+```bash
+python3 build.py -t cypherpunk
 ```
 
 #### Building btc-only firmware
 
 ```bash
-# Run the build script at the root of the project.
-python build.py -t btc_only
+python3 build.py -t btc_only
 ```
 
 #### Building img to C file
@@ -104,7 +107,37 @@ The Keystone3 firmware is built with Rust and C and uses FreeRTOS as the underly
 
 ## Simulator
 
-Please follow this [Doc](docs/SIMULATOR.md).
+For full details, see [docs/SIMULATOR.md](docs/SIMULATOR.md).
+
+### Quick Start (macOS)
+
+```bash
+# Install SDL2
+brew install sdl2
+
+# Create a Python virtual environment.
+# Python 3.12 is known to work; Python 3.14 currently has dependency issues.
+uv venv --python python3.12
+source .venv/bin/activate
+uv pip install -r requirements.txt
+
+# Build and run the cypherpunk simulator.
+./simulator.sh
+
+# Run the existing build without rebuilding.
+./simulator.sh --no-build
+```
+
+### QR Code Scanning (macOS)
+
+The simulator scans QR codes directly from the screen.
+
+One-time setup:
+
+1. Grant Terminal.app screen recording permission in System Settings > Privacy & Security > Screen Recording.
+2. Run `./simulator.sh`; it reopens itself in Terminal.app so macOS grants screen capture to the expected process.
+
+For mobile-wallet QR flows, mirror the phone display to the Mac and keep the QR code visible while clicking `Scan` in the simulator.
 
 ## Contributing
 

--- a/firmware.cmake
+++ b/firmware.cmake
@@ -9,7 +9,7 @@ set(MCU cortex-m4)
 set(LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/mh1903b.ld)
 set(ARCH_FLAGS "-mcpu=${MCU} -mthumb -mlittle-endian")
 set(MCU_FLAGS "${ARCH_FLAGS} -Os -mfloat-abi=hard -mfpu=fpv4-sp-d16")
-set(CMAKE_C_FLAGS "${MCU_FLAGS} -Wall -Wno-unknown-pragmas -Wno-format -g")
+set(CMAKE_C_FLAGS "${MCU_FLAGS} -Wall -Wno-unknown-pragmas -Wno-format -g -Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration -Wno-error=discarded-qualifiers -Wno-error=int-conversion")
 set(CMAKE_CXX_FLAGS "${MCU_FLAGS} -Wall -Wno-unknown-pragmas -Wno-format -g")
 
 if(NOT BUILD_PRODUCTION)

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -2,9 +2,18 @@ message(STATUS "compile rust")
 set(LIB_NAME librust_c.a)
 
 # set variables
-find_program(RUST_CARGO_EXECUTABLE cargo)
+find_program(RUST_CARGO_EXECUTABLE cargo HINTS "$ENV{HOME}/.cargo/bin")
+find_program(RUSTUP_EXECUTABLE rustup HINTS "$ENV{HOME}/.cargo/bin")
 find_program(BINDGEN_EXE bindgen)
 find_program(CBINDGEN_EXE cbindgen)
+
+if(NOT RUST_CARGO_EXECUTABLE)
+    message(FATAL_ERROR "cargo not found. Install Rust and ensure cargo is on PATH.")
+endif()
+
+if(NOT RUSTUP_EXECUTABLE)
+    message(FATAL_ERROR "rustup not found. Install Rustup or add $HOME/.cargo/bin to PATH.")
+endif()
 
 # BUILD_ENVIRONMENT: PRODUCTION, DEBUG, SIMULATOR
 # BUILD_VARIANT: BTC_ONLY, MULTI_COINS, CYPHERPUNK
@@ -69,7 +78,7 @@ message(STATUS "cargo build command: " ${CARGO_FLAG})
 
 #run build
 add_custom_target(rust_c ALL
-    COMMAND rustup run ${RUST_TOOLCHAIN} ${RUST_CARGO_EXECUTABLE} build ${CARGO_FLAG}
+    COMMAND ${RUSTUP_EXECUTABLE} run ${RUST_TOOLCHAIN} ${RUST_CARGO_EXECUTABLE} build ${CARGO_FLAG}
     COMMAND ${COPY_BUILD_TARGET}
     COMMAND ${COPY_BINDINGS_TARGET}
     WORKING_DIRECTORY ${RUST_DIR}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4303,6 +4303,7 @@ dependencies = [
  "anyhow",
  "cocoa",
  "image",
+ "objc",
  "quircs",
  "screenshots",
  "windows 0.58.0",

--- a/rust/sim_qr_reader/Cargo.toml
+++ b/rust/sim_qr_reader/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.75"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.1"
+objc = "0.2.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58.0", features = [

--- a/rust/sim_qr_reader/src/lib.rs
+++ b/rust/sim_qr_reader/src/lib.rs
@@ -1,41 +1,230 @@
+#![allow(unexpected_cfgs)]
+
 use anyhow::Result;
 use image::DynamicImage;
+#[cfg(target_os = "macos")]
+use image::ImageOutputFormat;
 use quircs::{Code, Quirc};
 use screenshots::Screen;
+#[cfg(target_os = "macos")]
+use std::ffi::CStr;
+#[cfg(target_os = "macos")]
+use std::io::Cursor;
 use std::thread;
 use std::time::Duration;
 
 #[cfg(target_os = "macos")]
-use cocoa::{appkit::NSScreen, base::nil, foundation::NSArray};
-
-#[cfg(target_os = "windows")]
-use windows::{
-    Win32::Foundation::HWND,
-    Win32::Graphics::Gdi::{GetDC, GetDeviceCaps, LOGPIXELSX},
-    Win32::UI::HiDpi::{SetProcessDpiAwareness, PROCESS_SYSTEM_DPI_AWARE},
+use cocoa::{
+    base::{id, nil},
+    foundation::{NSAutoreleasePool, NSData, NSRect, NSUInteger},
 };
+#[cfg(target_os = "macos")]
+use objc::{class, msg_send, sel, sel_impl};
 
-fn get_screen_scaling_factor() -> f64 {
-    #[cfg(target_os = "macos")]
-    unsafe {
-        let screens = NSScreen::screens(nil);
-        let screen = NSArray::objectAtIndex(screens, 0);
+type ScanArea = (i32, i32, u32, u32);
 
-        NSScreen::backingScaleFactor(screen)
-    }
+#[derive(Debug)]
+enum ScanError {
+    Capture(anyhow::Error),
+    Decode(anyhow::Error),
+    NoQrFound,
+}
 
-    #[cfg(target_os = "windows")]
-    unsafe {
-        let hdc = GetDC(HWND::default());
-        let dpi = GetDeviceCaps(hdc, LOGPIXELSX) as f64;
-        // 96.0 default dpi
-        dpi / 96.0 as f64
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
+fn get_scale_factor(screen: &Screen) -> f64 {
+    let scale_factor = screen.display_info.scale_factor as f64;
+    if scale_factor.is_finite() && scale_factor > 0.0 {
+        scale_factor
+    } else {
         1.0
     }
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_screen_capture_permission() -> Result<()> {
+    unsafe {
+        if CGPreflightScreenCaptureAccess() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "macOS Screen Recording permission is missing. Run ./simulator.sh so the simulator opens in Terminal.app, then enable Terminal in System Settings > Privacy & Security > Screen Recording."
+            ))
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn ensure_screen_capture_permission() -> Result<()> {
+    Ok(())
+}
+
+fn decode_qr_image(
+    decoder: &mut Quirc,
+    dynamic_image: &DynamicImage,
+    scale_factor: f64,
+) -> std::result::Result<(String, ScanArea), ScanError> {
+    let codes = decoder.identify(
+        dynamic_image.width() as usize,
+        dynamic_image.height() as usize,
+        &dynamic_image.to_luma8(),
+    );
+
+    let mut last_decode_error = None;
+
+    for code in codes {
+        let code = match code {
+            Ok(code) => code,
+            Err(err) => {
+                last_decode_error = Some(anyhow::Error::from(err));
+                continue;
+            }
+        };
+
+        let decoded = match code.decode() {
+            Ok(decoded) => decoded,
+            Err(err) => {
+                last_decode_error = Some(anyhow::Error::from(err));
+                continue;
+            }
+        };
+
+        let content =
+            String::from_utf8(decoded.payload).map_err(|err| ScanError::Decode(err.into()))?;
+        let new_area = get_qr_area(&code, dynamic_image, scale_factor);
+        return Ok((content, new_area));
+    }
+
+    #[cfg(target_os = "macos")]
+    match decode_qr_with_coreimage(dynamic_image, scale_factor) {
+        Ok(Some(result)) => return Ok(result),
+        Ok(None) => {}
+        Err(err) => return Err(ScanError::Decode(err)),
+    }
+
+    if let Some(err) = last_decode_error {
+        Err(ScanError::Decode(err))
+    } else {
+        Err(ScanError::NoQrFound)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn decode_qr_with_coreimage(
+    dynamic_image: &DynamicImage,
+    scale_factor: f64,
+) -> Result<Option<(String, ScanArea)>> {
+    unsafe {
+        let _pool = NSAutoreleasePool::new(nil);
+
+        let mut png_bytes = Vec::new();
+        dynamic_image.write_to(&mut Cursor::new(&mut png_bytes), ImageOutputFormat::Png)?;
+
+        let data: id = NSData::dataWithBytes_length_(
+            nil,
+            png_bytes.as_ptr() as *const _,
+            png_bytes.len() as NSUInteger,
+        );
+        let ci_image: id = msg_send![class!(CIImage), imageWithData: data];
+        if ci_image == nil {
+            return Ok(None);
+        }
+
+        let detector_type: id = msg_send![
+            class!(NSString),
+            stringWithUTF8String: b"CIDetectorTypeQRCode\0".as_ptr()
+                as *const std::os::raw::c_char
+        ];
+        let detector: id =
+            msg_send![class!(CIDetector), detectorOfType: detector_type context: nil options: nil];
+        if detector == nil {
+            return Ok(None);
+        }
+
+        let features: id = msg_send![detector, featuresInImage: ci_image];
+        let count: NSUInteger = msg_send![features, count];
+
+        for i in 0..count {
+            let feature: id = msg_send![features, objectAtIndex: i];
+            let message: id = msg_send![feature, messageString];
+            if message == nil {
+                continue;
+            }
+
+            let content = nsstring_to_string(message)?;
+            let bounds: NSRect = msg_send![feature, bounds];
+            let new_area = nsrect_to_scan_area(bounds, dynamic_image, scale_factor);
+            println!("QR decoded with CoreImage fallback");
+            return Ok(Some((content, new_area)));
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(target_os = "macos")]
+fn nsstring_to_string(string: id) -> Result<String> {
+    unsafe {
+        let bytes: *const std::os::raw::c_char = msg_send![string, UTF8String];
+        if bytes.is_null() {
+            return Err(anyhow::anyhow!("QR string conversion failed"));
+        }
+
+        Ok(CStr::from_ptr(bytes).to_string_lossy().into_owned())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn nsrect_to_scan_area(
+    bounds: NSRect,
+    dynamic_image: &DynamicImage,
+    scale_factor: f64,
+) -> ScanArea {
+    let margin = 10.0;
+    let min_x = (bounds.origin.x - margin).max(0.0);
+    let min_y = (bounds.origin.y - margin).max(0.0);
+    let max_x = (bounds.origin.x + bounds.size.width + margin).min(dynamic_image.width() as f64);
+    let max_y = (bounds.origin.y + bounds.size.height + margin).min(dynamic_image.height() as f64);
+
+    let x = (min_x / scale_factor).floor() as i32;
+    let y = ((dynamic_image.height() as f64 - max_y) / scale_factor)
+        .max(0.0)
+        .floor() as i32;
+    let max_x = (max_x / scale_factor).ceil() as i32;
+    let max_y = ((dynamic_image.height() as f64 - min_y) / scale_factor)
+        .max(0.0)
+        .ceil() as i32;
+    let width = (max_x - x).max(1) as u32;
+    let height = (max_y - y).max(1) as u32;
+
+    (x, y, width, height)
+}
+
+fn offset_scan_area(area: ScanArea, origin_x: i32, origin_y: i32) -> ScanArea {
+    let (x, y, width, height) = area;
+    (x + origin_x, y + origin_y, width, height)
+}
+
+fn capture_and_decode_screen(
+    screen: &Screen,
+    decoder: &mut Quirc,
+    area: Option<ScanArea>,
+) -> std::result::Result<(String, ScanArea), ScanError> {
+    let (origin_x, origin_y) = area.map(|(x, y, _, _)| (x, y)).unwrap_or((0, 0));
+    let image = match area {
+        Some((x, y, width, height)) => {
+            println!(
+                "Capture area on screen[{}]: ({x}, {y}, {width}, {height})",
+                screen.display_info.id
+            );
+            screen
+                .capture_area(x, y, width, height)
+                .map_err(ScanError::Capture)?
+        }
+        None => screen.capture().map_err(ScanError::Capture)?,
+    };
+
+    let dynamic_image = DynamicImage::ImageRgba8(image);
+    let (content, new_area) = decode_qr_image(decoder, &dynamic_image, get_scale_factor(screen))?;
+    Ok((content, offset_scan_area(new_area, origin_x, origin_y)))
 }
 
 pub fn continuously_read_qr_code_from_screen<G>(
@@ -45,68 +234,99 @@ pub fn continuously_read_qr_code_from_screen<G>(
 where
     G: Fn(&str) -> bool,
 {
+    ensure_screen_capture_permission()?;
+
     let screens = Screen::all()?;
-    let screen = screens.first().ok_or(anyhow::anyhow!("No screen found"))?;
+    println!("Screens detected: {}", screens.len());
+    for (i, screen) in screens.iter().enumerate() {
+        println!(
+            "  screen[{i}]: id={} x={} y={} w={} h={} scale={}",
+            screen.display_info.id,
+            screen.display_info.x,
+            screen.display_info.y,
+            screen.display_info.width,
+            screen.display_info.height,
+            screen.display_info.scale_factor
+        );
+    }
+    if screens.is_empty() {
+        return Err(anyhow::anyhow!("No screen found"));
+    }
+
     let mut decoder = Quirc::default();
-
-    let scaling_factor = get_screen_scaling_factor();
-    println!("Screen scaling factor: {scaling_factor}");
-
-    let mut qr_area: Option<(i32, i32, u32, u32)> = None;
-
-    let mut capture_and_decode =
-        |area: Option<(i32, i32, u32, u32)>| -> Result<(String, Option<(i32, i32, u32, u32)>)> {
-            let image = match area {
-                Some((x, y, width, height)) => {
-                    let scaled_x = (x as f64 / scaling_factor) as i32;
-                    let scaled_y = (y as f64 / scaling_factor) as i32;
-                    let scaled_width = (width as f64 / scaling_factor) as u32;
-                    let scaled_height = (height as f64 / scaling_factor) as u32;
-                    println!(
-                        "Capture area: ({scaled_x}, {scaled_y}, {scaled_width}, {scaled_height})"
-                    );
-                    screen.capture_area(scaled_x, scaled_y, scaled_width, scaled_height)?
-                }
-                None => screen.capture()?,
-            };
-            let dynamic_image = DynamicImage::ImageRgba8(image);
-            let mut codes = decoder.identify(
-                dynamic_image.width() as usize,
-                dynamic_image.height() as usize,
-                &dynamic_image.to_luma8(),
-            );
-
-            if let Some(Ok(code)) = codes.next() {
-                let decoded = code.decode()?;
-                let content = String::from_utf8(decoded.payload)?;
-                let new_area = Some(get_qr_area(&code, &dynamic_image));
-                Ok((content, new_area))
-            } else {
-                Err(anyhow::anyhow!("No QR code found on screen"))
-            }
-        };
-
+    let mut focused_screen_index: Option<usize> = None;
+    let mut qr_area: Option<ScanArea> = None;
     let interval = Duration::from_millis(100);
-
     let mut loop_count = 0;
 
     while loop_count < max_loop_count {
         println!("Loop count: {loop_count}, max: {max_loop_count}");
-        match capture_and_decode(qr_area) {
-            Ok((content, new_area)) => {
+        let attempt: Result<(usize, String, ScanArea)> = if let Some(screen_index) =
+            focused_screen_index
+        {
+            let screen = &screens[screen_index];
+            capture_and_decode_screen(screen, &mut decoder, qr_area)
+                .map(|(content, new_area)| (screen_index, content, new_area))
+                .map_err(|err| match err {
+                    ScanError::Capture(err) => {
+                        anyhow::anyhow!("Screen capture failed on screen[{screen_index}]: {err}")
+                    }
+                    ScanError::Decode(err) => {
+                        anyhow::anyhow!("QR decode failed on screen[{screen_index}]: {err}")
+                    }
+                    ScanError::NoQrFound => {
+                        anyhow::anyhow!("No QR code found on screen[{screen_index}]")
+                    }
+                })
+        } else {
+            let mut capture_errors = Vec::new();
+            let mut decode_errors = Vec::new();
+            let mut result = None;
+
+            for (screen_index, screen) in screens.iter().enumerate() {
+                match capture_and_decode_screen(screen, &mut decoder, None) {
+                    Ok((content, new_area)) => {
+                        result = Some((screen_index, content, new_area));
+                        break;
+                    }
+                    Err(ScanError::NoQrFound) => {}
+                    Err(ScanError::Capture(err)) => {
+                        capture_errors.push(format!("screen[{screen_index}]: {err}"));
+                    }
+                    Err(ScanError::Decode(err)) => {
+                        decode_errors.push(format!("screen[{screen_index}]: {err}"));
+                    }
+                }
+            }
+
+            if !capture_errors.is_empty() {
+                println!("Screen capture errors: {}", capture_errors.join(" | "));
+            }
+            if !decode_errors.is_empty() {
+                println!("QR decode errors: {}", decode_errors.join(" | "));
+            }
+
+            result.ok_or_else(|| anyhow::anyhow!("No QR code found on any display"))
+        };
+
+        match attempt {
+            Ok((screen_index, content, new_area)) => {
+                focused_screen_index = Some(screen_index);
+
                 if on_qr_code_detected(&content) {
                     break;
                 }
-                if qr_area.is_none() {
-                    qr_area = new_area;
-                }
-                if let Some(area) = qr_area {
-                    println!("QR code area determined: {area:?}");
-                }
+
+                qr_area = Some(new_area);
+                println!("QR code area determined on screen[{screen_index}]: {new_area:?}");
             }
-            Err(_) => {
-                println!("No QR code detected, resetting scan area");
-                qr_area = None; // Reset scan area
+            Err(err) => {
+                println!("Scan attempt failed: {err}");
+                if focused_screen_index.is_some() || qr_area.is_some() {
+                    println!("Resetting screen focus and scan area");
+                }
+                focused_screen_index = None;
+                qr_area = None;
             }
         }
         thread::sleep(interval);
@@ -116,21 +336,35 @@ where
     Ok(())
 }
 
-fn get_qr_area(code: &Code, image: &DynamicImage) -> (i32, i32, u32, u32) {
+fn get_qr_area(code: &Code, image: &DynamicImage, scale_factor: f64) -> ScanArea {
     let points = code.corners;
     let min_x = points.iter().map(|p| p.x).min().unwrap();
     let min_y = points.iter().map(|p| p.y).min().unwrap();
     let max_x = points.iter().map(|p| p.x).max().unwrap();
     let max_y = points.iter().map(|p| p.y).max().unwrap();
 
-    let width = (max_x - min_x) as u32;
-    let height = (max_y - min_y) as u32;
-
     let margin = 10;
-    let x = (min_x - margin).max(0);
-    let y = (min_y - margin).max(0);
-    let width = (width + 2 * margin as u32).min(image.width() - x as u32);
-    let height = (height + 2 * margin as u32).min(image.height() - y as u32);
+    let padded_min_x = (min_x - margin).max(0) as f64;
+    let padded_min_y = (min_y - margin).max(0) as f64;
+    let padded_max_x = (max_x + margin).min(image.width() as i32) as f64;
+    let padded_max_y = (max_y + margin).min(image.height() as i32) as f64;
+
+    let x = (padded_min_x / scale_factor).floor() as i32;
+    let y = (padded_min_y / scale_factor).floor() as i32;
+    let max_x = (padded_max_x / scale_factor).ceil() as i32;
+    let max_y = (padded_max_y / scale_factor).ceil() as i32;
+    let width = (max_x - x).max(1) as u32;
+    let height = (max_y - y).max(1) as u32;
 
     (x, y, width, height)
 }
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+    fn CGPreflightScreenCaptureAccess() -> bool;
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreImage", kind = "framework")]
+unsafe extern "C" {}

--- a/simulator.sh
+++ b/simulator.sh
@@ -9,12 +9,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 if [ "$TERM_PROGRAM" != "Apple_Terminal" ]; then
     echo "Reopening in Terminal.app for QR scanning support..."
-    QUOTED_SCRIPT_DIR="$(printf '%q' "$SCRIPT_DIR")"
-    QUOTED_ARGS=()
-    for ARG in "$@"; do
-        QUOTED_ARGS+=("$(printf '%q' "$ARG")")
-    done
-    osascript -e "tell application \"Terminal\" to do script \"cd $QUOTED_SCRIPT_DIR && ./simulator.sh ${QUOTED_ARGS[*]}\""
+    LAUNCHER_DIR="$(mktemp -d -t keystone-simulator.XXXXXX)"
+    LAUNCHER="$LAUNCHER_DIR/keystone-simulator.command"
+    {
+        printf '#!/bin/bash\n'
+        printf 'cd %q\n' "$SCRIPT_DIR"
+        printf './simulator.sh'
+        for ARG in "$@"; do
+            printf ' %q' "$ARG"
+        done
+        printf '\n'
+    } > "$LAUNCHER"
+    chmod +x "$LAUNCHER"
+    open -a Terminal "$LAUNCHER"
     exit 0
 fi
 
@@ -30,6 +37,12 @@ elif [ -d "$HOME/.cargo/bin" ]; then
     export PATH="$HOME/.cargo/bin:$PATH"
 fi
 
+if command -v python3.12 >/dev/null 2>&1; then
+    PYTHON_BIN=python3.12
+else
+    PYTHON_BIN=python3
+fi
+
 BUILD=true
 if [ "$1" = "--no-build" ] || [ "$1" = "-n" ]; then
     BUILD=false
@@ -38,7 +51,7 @@ fi
 
 if [ "$BUILD" = true ]; then
     echo "=== Building Cypherpunk Simulator ==="
-    python3 build.py -t cypherpunk -o simulator
+    "$PYTHON_BIN" build.py -t cypherpunk -o simulator -s
     echo ""
 fi
 

--- a/simulator.sh
+++ b/simulator.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Keystone Simulator - Build and Run
+#
+# Automatically opens in Terminal.app for QR screen scanning to work.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ "$TERM_PROGRAM" != "Apple_Terminal" ]; then
+    echo "Reopening in Terminal.app for QR scanning support..."
+    QUOTED_SCRIPT_DIR="$(printf '%q' "$SCRIPT_DIR")"
+    QUOTED_ARGS=()
+    for ARG in "$@"; do
+        QUOTED_ARGS+=("$(printf '%q' "$ARG")")
+    done
+    osascript -e "tell application \"Terminal\" to do script \"cd $QUOTED_SCRIPT_DIR && ./simulator.sh ${QUOTED_ARGS[*]}\""
+    exit 0
+fi
+
+cd "$SCRIPT_DIR"
+
+if [ -f ".venv/bin/activate" ]; then
+    source .venv/bin/activate
+fi
+
+if [ -f "$HOME/.cargo/env" ]; then
+    source "$HOME/.cargo/env"
+elif [ -d "$HOME/.cargo/bin" ]; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+BUILD=true
+if [ "$1" = "--no-build" ] || [ "$1" = "-n" ]; then
+    BUILD=false
+    shift
+fi
+
+if [ "$BUILD" = true ]; then
+    echo "=== Building Cypherpunk Simulator ==="
+    python3 build.py -t cypherpunk -o simulator
+    echo ""
+fi
+
+echo "=== Starting Simulator ==="
+exec ./build/simulator "$@"

--- a/ui_simulator/simulator_model.c
+++ b/ui_simulator/simulator_model.c
@@ -616,7 +616,8 @@ static bool on_qr_detected(const char *qrString)
 
 int32_t read_qrcode()
 {
-    read_qr_code_from_screen(on_qr_detected, 64);
+    reset_qr_state();
+    read_qr_code_from_screen(on_qr_detected, 200);
     return 0;
 }
 #else


### PR DESCRIPTION
## Summary

Adds a master-based macOS simulator setup branch that makes the cypherpunk simulator easier to build and run locally on macOS.

- Adds `simulator.sh` as the normal entry point for building/running the cypherpunk simulator.
- Makes the runner reopen itself in Terminal.app for QR screen-capture support.
- Skips image regeneration during normal simulator builds so Pillow/PyYAML are not required just to run the simulator.
- Improves Rust tool discovery when Terminal.app starts with a minimal PATH.
- Updates macOS README setup notes.
- Improves simulator QR screen scanning with permission checks, multi-display scanning, scale-aware crop tracking, scanner state reset, and a CoreImage fallback on macOS.

## macOS setup notes

For a normal simulator run:

```bash
brew install sdl2
rustup install $(cat rust-toolchain)
cargo install bindgen-cli
rustup run stable cargo install cbindgen
./simulator.sh
```

For full firmware builds on macOS, install the ARM GCC toolchain too:

```bash
brew install --cask gcc-arm-embedded
rustup target add thumbv7em-none-eabihf
```

`simulator.sh` uses `python3.12` if available, otherwise `python3`. It passes `-s` to `build.py`, so it skips image regeneration. That means `requirements.txt` is only needed when regenerating image assets, not for the normal simulator build.

## Screen Recording / QR scanning

The simulator scans QR codes from the Mac screen, not from the camera. macOS gates this behind Screen Recording permission for the terminal application that launches the simulator.

I previously saw this fail when launching from Ghostty because the screen capture permission was tied to the terminal app. The runner now detects when it is not already running inside Terminal.app and opens a temporary `.command` launcher in Terminal.app. After that, grant Terminal.app permission here:

System Settings > Privacy & Security > Screen Recording > Terminal

After granting permission, rerun `./simulator.sh`. If macOS already had Terminal.app open before the permission change, quitting/reopening Terminal.app may be required before screen capture works.

## Verification

- `bash -n simulator.sh`
- `git diff --check`
- `cargo check --manifest-path rust/Cargo.toml -p sim_qr_reader`
- `/usr/local/bin/python3.12 build.py -t cypherpunk -o simulator -s`

The full simulator build completed successfully on macOS. Existing unrelated C/Rust warnings remain.