### PR TITLE
Optimize Zcash migration signing flow

### DIFF
--- a/.github/workflows/rust-zcash-checks.yml
+++ b/.github/workflows/rust-zcash-checks.yml
@@ -2,6 +2,9 @@ on:
   pull_request:
     paths:
       - rust/apps/zcash/**
+      - rust/zcash_vendor/**
+      - rust/rust_c/src/zcash/**
+      - rust/rust_c/src/common/ur.rs
 
 name: Zcash Checks
 
@@ -28,3 +31,25 @@ jobs:
 
       - name: Run rust/apps/zcash
         run: cd rust/apps/zcash && cargo +$RUST_TOOLCHAIN llvm-cov  --fail-under-regions 69 --fail-under-functions 71 --fail-under-lines 76 --ignore-filename-regex 'keystore/*|utils/*|zcash_vendor/*'
+
+  # The rust_c Zcash FFI tests (batch validation, reviewed-batch fingerprint)
+  # only build under the simulator feature set (the device feature set has no
+  # host panic handler), and the simulator's screen-capture dependency needs
+  # macOS on CI.
+  RustCZcashTest:
+    name: rust_c Zcash FFI tests
+    runs-on: macos-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Read Rust toolchain
+        run: echo "RUST_TOOLCHAIN=$(cat rust-toolchain)" >> $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Run rust_c zcash tests
+        run: cd rust && cargo +$RUST_TOOLCHAIN test -p rust_c --no-default-features --features simulator-cypherpunk --lib -- zcash common::ur

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@
 ### What's new
 
 1. Added support for Zcash batch PCZT signing
+2. Zcash migration batches review as one split transaction plus a single migration summary instead of one page per child
+3. Zcash batch signing returns a compact signatures-only QR (far fewer frames) and only signs the exact batch that was reviewed
+4. The device no longer auto-locks while a long Zcash batch review is loading
 
 ### Bug Fixes
 
 1. Fixed stalled Zcash signing when response QR generation fails
+2. Fixed Zcash batch signing skipping wallet-controlled zero-value change spends, which made signed batches unextractable
 
 
 ## 2.4.6 (2026-6-12)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1676,7 +1676,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=dc95dcef33a081b925db551eac8bf6533fff22ed#dc95dcef33a081b925db551eac8bf6533fff22ed"
+source = "git+https://github.com/valargroup/librustzcash?rev=03d6d678d711f7a02a3bab07b3c2fe22570732ec#03d6d678d711f7a02a3bab07b3c2fe22570732ec"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1803,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/valargroup/librustzcash?rev=dc95dcef33a081b925db551eac8bf6533fff22ed#dc95dcef33a081b925db551eac8bf6533fff22ed"
+source = "git+https://github.com/valargroup/librustzcash?rev=03d6d678d711f7a02a3bab07b3c2fe22570732ec#03d6d678d711f7a02a3bab07b3c2fe22570732ec"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3039,8 +3039,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
-source = "git+https://github.com/zcash/orchard?rev=b2af0a11abe00f59c51258d349c2105fe7a16215#b2af0a11abe00f59c51258d349c2105fe7a16215"
+version = "0.15.0-pre.1"
+source = "git+https://github.com/valargroup/orchard?rev=c8e98aa8a2bcdd365df6915c4056882bea1904d1#c8e98aa8a2bcdd365df6915c4056882bea1904d1"
 dependencies = [
  "aes",
  "bitvec",
@@ -3141,7 +3141,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.7.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=dc95dcef33a081b925db551eac8bf6533fff22ed#dc95dcef33a081b925db551eac8bf6533fff22ed"
+source = "git+https://github.com/valargroup/librustzcash?rev=03d6d678d711f7a02a3bab07b3c2fe22570732ec#03d6d678d711f7a02a3bab07b3c2fe22570732ec"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3885,6 +3885,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sim_qr_reader",
+ "spin",
  "sui-transaction-types-core",
  "thiserror-core",
  "ur-parse-lib",
@@ -4105,7 +4106,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.0",
+ "bitcoin_hashes 0.12.0",
  "secp256k1-sys",
 ]
 
@@ -4811,7 +4812,7 @@ dependencies = [
 [[package]]
 name = "ur-registry"
 version = "1.0.5"
-source = "git+https://github.com/KeystoneHQ/keystone-sdk-rust.git?rev=0884de4b2e927bc3f95a98dff62045e0d492e574#0884de4b2e927bc3f95a98dff62045e0d492e574"
+source = "git+https://github.com/valargroup/keystone-sdk-rust.git?rev=97c1a5d5df5fb457a169cd66e0f91e40acb18c64#97c1a5d5df5fb457a169cd66e0f91e40acb18c64"
 dependencies = [
  "bs58",
  "hex",
@@ -5409,12 +5410,12 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.12.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=dc95dcef33a081b925db551eac8bf6533fff22ed#dc95dcef33a081b925db551eac8bf6533fff22ed"
+source = "git+https://github.com/valargroup/librustzcash?rev=03d6d678d711f7a02a3bab07b3c2fe22570732ec#03d6d678d711f7a02a3bab07b3c2fe22570732ec"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (git+https://github.com/valargroup/librustzcash?rev=dc95dcef33a081b925db551eac8bf6533fff22ed)",
+ "f4jumble 0.1.1 (git+https://github.com/valargroup/librustzcash?rev=03d6d678d711f7a02a3bab07b3c2fe22570732ec)",
  "zcash_encoding",
  "zcash_protocol",
 ]
@@ -5422,7 +5423,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=dc95dcef33a081b925db551eac8bf6533fff22ed#dc95dcef33a081b925db551eac8bf6533fff22ed"
+source = "git+https://github.com/valargroup/librustzcash?rev=03d6d678d711f7a02a3bab07b3c2fe22570732ec#03d6d678d711f7a02a3bab07b3c2fe22570732ec"
 dependencies = [
  "corez",
  "hex",
@@ -5432,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.14.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=dc95dcef33a081b925db551eac8bf6533fff22ed#dc95dcef33a081b925db551eac8bf6533fff22ed"
+source = "git+https://github.com/valargroup/librustzcash?rev=03d6d678d711f7a02a3bab07b3c2fe22570732ec#03d6d678d711f7a02a3bab07b3c2fe22570732ec"
 dependencies = [
  "bech32 0.11.0",
  "bip32",
@@ -5471,7 +5472,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.28.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=dc95dcef33a081b925db551eac8bf6533fff22ed#dc95dcef33a081b925db551eac8bf6533fff22ed"
+source = "git+https://github.com/valargroup/librustzcash?rev=03d6d678d711f7a02a3bab07b3c2fe22570732ec#03d6d678d711f7a02a3bab07b3c2fe22570732ec"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5501,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.9.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=dc95dcef33a081b925db551eac8bf6533fff22ed#dc95dcef33a081b925db551eac8bf6533fff22ed"
+source = "git+https://github.com/valargroup/librustzcash?rev=03d6d678d711f7a02a3bab07b3c2fe22570732ec#03d6d678d711f7a02a3bab07b3c2fe22570732ec"
 dependencies = [
  "corez",
  "hex",
@@ -5540,7 +5541,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.8.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=dc95dcef33a081b925db551eac8bf6533fff22ed#dc95dcef33a081b925db551eac8bf6533fff22ed"
+source = "git+https://github.com/valargroup/librustzcash?rev=03d6d678d711f7a02a3bab07b3c2fe22570732ec#03d6d678d711f7a02a3bab07b3c2fe22570732ec"
 dependencies = [
  "bip32",
  "bs58",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -109,6 +109,10 @@ cipher = { version = "0.4.4", default-features = false, features = [
 ] }
 lazy_static = "1.4.0"
 ref-cast = "1.0.16"
+spin = { version = "0.9.8", default-features = false, features = [
+    "mutex",
+    "spin_mutex",
+] }
 tendermint-proto = "0.32"
 prost = { version = "0.11", default-features = false }
 prost-types = { version = "0.11", default-features = false }
@@ -122,13 +126,13 @@ zeroize = { version = "1.8.2", default-features = false }
 # third party dependencies end
 
 [patch.crates-io]
-orchard = { git = "https://github.com/zcash/orchard", rev = "b2af0a11abe00f59c51258d349c2105fe7a16215" }
-pczt = { git = "https://github.com/valargroup/librustzcash", rev = "dc95dcef33a081b925db551eac8bf6533fff22ed" }
-zcash_address = { git = "https://github.com/valargroup/librustzcash", rev = "dc95dcef33a081b925db551eac8bf6533fff22ed" }
-zcash_encoding = { git = "https://github.com/valargroup/librustzcash", rev = "dc95dcef33a081b925db551eac8bf6533fff22ed" }
-zcash_keys = { git = "https://github.com/valargroup/librustzcash", rev = "dc95dcef33a081b925db551eac8bf6533fff22ed" }
-zcash_primitives = { git = "https://github.com/valargroup/librustzcash", rev = "dc95dcef33a081b925db551eac8bf6533fff22ed" }
-zcash_protocol = { git = "https://github.com/valargroup/librustzcash", rev = "dc95dcef33a081b925db551eac8bf6533fff22ed" }
-zcash_transparent = { git = "https://github.com/valargroup/librustzcash", rev = "dc95dcef33a081b925db551eac8bf6533fff22ed" }
-# Use the upstream SDK rev with the Zcash batch registry types until they are published as a crate.
-ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust.git", rev = "0884de4b2e927bc3f95a98dff62045e0d492e574" }
+orchard = { git = "https://github.com/valargroup/orchard", rev = "c8e98aa8a2bcdd365df6915c4056882bea1904d1" }
+pczt = { git = "https://github.com/valargroup/librustzcash", rev = "03d6d678d711f7a02a3bab07b3c2fe22570732ec" }
+zcash_address = { git = "https://github.com/valargroup/librustzcash", rev = "03d6d678d711f7a02a3bab07b3c2fe22570732ec" }
+zcash_encoding = { git = "https://github.com/valargroup/librustzcash", rev = "03d6d678d711f7a02a3bab07b3c2fe22570732ec" }
+zcash_keys = { git = "https://github.com/valargroup/librustzcash", rev = "03d6d678d711f7a02a3bab07b3c2fe22570732ec" }
+zcash_primitives = { git = "https://github.com/valargroup/librustzcash", rev = "03d6d678d711f7a02a3bab07b3c2fe22570732ec" }
+zcash_protocol = { git = "https://github.com/valargroup/librustzcash", rev = "03d6d678d711f7a02a3bab07b3c2fe22570732ec" }
+zcash_transparent = { git = "https://github.com/valargroup/librustzcash", rev = "03d6d678d711f7a02a3bab07b3c2fe22570732ec" }
+# Use the SDK rev with the compact Zcash signature result registry type until it is published as a crate.
+ur-registry = { git = "https://github.com/valargroup/keystone-sdk-rust.git", rev = "97c1a5d5df5fb457a169cd66e0f91e40acb18c64" }

--- a/rust/apps/zcash/Cargo.toml
+++ b/rust/apps/zcash/Cargo.toml
@@ -26,7 +26,7 @@ serde_with = { version = "3.11.0", features = [
 
 [dev-dependencies]
 keystore = { path = "../../keystore" }
-pczt = { version = "0.7", default-features = false, features = ["orchard", "sapling", "transparent", "zcp-builder"] }
+pczt = { version = "0.7", default-features = false, features = ["orchard", "sapling", "transparent", "zcp-builder", "io-finalizer"] }
 zcash_primitives = { version = "0.28", default-features = false, features = ["circuits", "test-dependencies", "transparent-inputs"] }
 incrementalmerkletree = { version = "0.8.2", default-features = false }
 shardtree = "0.6.2"

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -8,10 +8,12 @@ pub mod version;
 use errors::{Result, ZcashError};
 
 use alloc::{
+    format,
     string::{String, ToString},
+    vec,
     vec::Vec,
 };
-use pczt::structs::ParsedPczt;
+use pczt::structs::{ParsedFrom, ParsedOrchard, ParsedPczt, ParsedTo};
 use zcash_vendor::{
     zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey},
     zcash_protocol::consensus::{self},
@@ -70,6 +72,18 @@ pub fn check_pczt_cypherpunk<P: consensus::Parameters>(
     account_index: u32,
 ) -> Result<()> {
     let pczt = pczt::parse_pczt(pczt)?;
+    check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
+    Ok(())
+}
+
+#[cfg(feature = "cypherpunk")]
+fn check_parsed_pczt_cypherpunk<P: consensus::Parameters>(
+    params: &P,
+    pczt: &Pczt,
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<(UnifiedFullViewingKey, zip32::AccountId)> {
     let account_index = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
     let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
@@ -86,7 +100,7 @@ pub fn check_pczt_cypherpunk<P: consensus::Parameters>(
         &pczt,
         false,
     )?;
-    Ok(())
+    Ok((ufvk, account_index))
 }
 
 #[cfg(feature = "multi_coins")]
@@ -182,6 +196,299 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
         .map_err(|e| ZcashError::InvalidDataError(e.to_string()))?;
     let pczt = pczt::parse_pczt(pczt)?;
     pczt::parse::parse_pczt_cypherpunk(params, seed_fingerprint, &ufvk, &pczt)
+}
+
+/// Checks a batch PCZT with the selected account and returns the display data
+/// using the same parsed PCZT and decoded UFVK.
+#[cfg(feature = "cypherpunk")]
+pub fn check_and_parse_batch_pczt_cypherpunk<P: consensus::Parameters>(
+    params: &P,
+    pczt: &[u8],
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<ParsedPczt> {
+    let pczt = pczt::parse_pczt(pczt)?;
+    let account_index = zip32::AccountId::try_from(account_index)
+        .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
+    let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
+        .map_err(|e| ZcashError::InvalidDataError(e.to_string()))?;
+    let xpub = ufvk.transparent().ok_or(ZcashError::InvalidDataError(
+        "transparent xpub is not present".to_string(),
+    ))?;
+    let checked_shielded = pczt::check::check_and_parse_pczt_shielded(
+        params,
+        seed_fingerprint,
+        account_index,
+        &ufvk,
+        &pczt,
+    )?;
+    pczt::check::check_pczt_transparent(
+        params,
+        seed_fingerprint,
+        account_index,
+        xpub,
+        &pczt,
+        false,
+    )?;
+    let signable_actions = signable_shielded_actions(
+        params,
+        pczt.clone(),
+        seed_fingerprint,
+        account_index,
+        ShieldedActionPolicy::Batch,
+    )?;
+
+    if signable_actions.is_empty() {
+        Err(ZcashError::PcztNoMyInputs)
+    } else {
+        pczt::parse::parse_pczt_cypherpunk_with_checked_shielded(
+            params,
+            seed_fingerprint,
+            &pczt,
+            checked_shielded.orchard,
+            checked_shielded.ironwood,
+        )
+    }
+}
+
+#[cfg(all(feature = "cypherpunk", zcash_unstable = "nu6.3"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BatchMigrationChildSummary {
+    pub input: u64,
+    pub output: u64,
+    pub fee: u64,
+}
+
+#[cfg(all(feature = "cypherpunk", zcash_unstable = "nu6.3"))]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct BatchMigrationSummary {
+    pub migrations: u32,
+    pub total_input: u64,
+    pub total_output: u64,
+    pub total_fee: u64,
+    pub children: Vec<BatchMigrationChildSummary>,
+}
+
+#[cfg(all(feature = "cypherpunk", zcash_unstable = "nu6.3"))]
+impl BatchMigrationSummary {
+    pub fn add_child(&mut self, child: &BatchMigrationSummary) -> Result<()> {
+        self.migrations = self
+            .migrations
+            .checked_add(child.migrations)
+            .ok_or_else(|| ZcashError::InvalidPczt("migration count overflow".to_string()))?;
+        self.total_input = self
+            .total_input
+            .checked_add(child.total_input)
+            .ok_or_else(|| ZcashError::InvalidPczt("migration input overflow".to_string()))?;
+        self.total_output = self
+            .total_output
+            .checked_add(child.total_output)
+            .ok_or_else(|| ZcashError::InvalidPczt("migration output overflow".to_string()))?;
+        self.total_fee = self
+            .total_fee
+            .checked_add(child.total_fee)
+            .ok_or_else(|| ZcashError::InvalidPczt("migration fee overflow".to_string()))?;
+        if child.children.is_empty() {
+            self.children.push(BatchMigrationChildSummary {
+                input: child.total_input,
+                output: child.total_output,
+                fee: child.total_fee,
+            });
+        } else {
+            self.children.extend(child.children.iter().copied());
+        }
+        Ok(())
+    }
+
+    pub fn to_parsed_pczt(&self) -> ParsedPczt {
+        let children = if self.children.is_empty() {
+            vec![BatchMigrationChildSummary {
+                input: self.total_input,
+                output: self.total_output,
+                fee: self.total_fee,
+            }]
+        } else {
+            self.children.clone()
+        };
+
+        let orchard = ParsedOrchard::new(
+            children
+                .iter()
+                .enumerate()
+                .map(|(index, child)| {
+                    ParsedFrom::new(
+                        Some(format!(
+                            "Migration #{} Orchard note from selected account",
+                            index + 1
+                        )),
+                        pczt::parse::format_zec_value(child.input as f64),
+                        child.input,
+                        true,
+                    )
+                })
+                .collect(),
+            Vec::new(),
+        );
+        let ironwood = ParsedOrchard::new(
+            Vec::new(),
+            children
+                .iter()
+                .enumerate()
+                .map(|(index, child)| {
+                    ParsedTo::new(
+                        format!("Migration #{} wallet Ironwood output", index + 1),
+                        pczt::parse::format_zec_value(child.output as f64),
+                        child.output,
+                        true,
+                        false,
+                        None,
+                    )
+                })
+                .collect(),
+        );
+
+        ParsedPczt::new(
+            None,
+            Some(orchard),
+            Some(ironwood),
+            pczt::parse::format_zec_value(self.total_output as f64),
+            pczt::parse::format_zec_value(self.total_fee as f64),
+            false,
+        )
+    }
+}
+
+/// Requires an action value to be present on the wire, returning it (zero is a
+/// valid value; callers classify zero themselves).
+#[cfg(all(feature = "cypherpunk", zcash_unstable = "nu6.3"))]
+fn require_action_value(value: &Option<u64>, label: &str) -> Result<u64> {
+    value
+        .as_ref()
+        .copied()
+        .ok_or_else(|| ZcashError::InvalidPczt(format!("missing {label} value")))
+}
+
+#[cfg(all(feature = "cypherpunk", zcash_unstable = "nu6.3"))]
+fn summarize_migration_actions(
+    ufvk: &UnifiedFullViewingKey,
+    pczt: &Pczt,
+) -> Result<BatchMigrationSummary> {
+    if !pczt.transparent().outputs().is_empty() {
+        return Err(ZcashError::InvalidPczt(
+            "migration summary does not support transparent outputs".to_string(),
+        ));
+    }
+
+    let mut orchard_spends = 0u32;
+    let mut orchard_outputs = 0u32;
+    let mut ironwood_spends = 0u32;
+    let mut ironwood_outputs = 0u32;
+    let mut total_input = 0u64;
+    let mut total_output = 0u64;
+
+    for action in pczt.orchard().actions() {
+        let spend_value = require_action_value(action.spend().value(), "Orchard spend")?;
+        if spend_value != 0 {
+            orchard_spends = orchard_spends.checked_add(1).ok_or_else(|| {
+                ZcashError::InvalidPczt("Orchard spend count overflow".to_string())
+            })?;
+            total_input = total_input
+                .checked_add(spend_value)
+                .ok_or_else(|| ZcashError::InvalidPczt("migration input overflow".to_string()))?;
+        }
+
+        let output_value = require_action_value(action.output().value(), "Orchard output")?;
+        if output_value != 0 {
+            orchard_outputs = orchard_outputs.checked_add(1).ok_or_else(|| {
+                ZcashError::InvalidPczt("Orchard output count overflow".to_string())
+            })?;
+        }
+    }
+
+    for action in pczt.ironwood().actions() {
+        let spend_value = require_action_value(action.spend().value(), "Ironwood spend")?;
+        if spend_value != 0 {
+            ironwood_spends = ironwood_spends.checked_add(1).ok_or_else(|| {
+                ZcashError::InvalidPczt("Ironwood spend count overflow".to_string())
+            })?;
+        }
+
+        let output_value = require_action_value(action.output().value(), "Ironwood output")?;
+        if output_value == 0 {
+            continue;
+        }
+
+        let recipient = action.output().recipient().ok_or_else(|| {
+            ZcashError::InvalidPczt("missing Ironwood output recipient".to_string())
+        })?;
+        let recipient = zcash_vendor::orchard::Address::from_raw_address_bytes(&recipient)
+            .into_option()
+            .ok_or_else(|| {
+                ZcashError::InvalidPczt("invalid Ironwood output recipient".to_string())
+            })?;
+        if !pczt::parse::is_wallet_orchard_address(ufvk, &recipient)? {
+            return Err(ZcashError::InvalidPczt(
+                "migration Ironwood output is not wallet-owned".to_string(),
+            ));
+        }
+
+        ironwood_outputs = ironwood_outputs
+            .checked_add(1)
+            .ok_or_else(|| ZcashError::InvalidPczt("Ironwood output count overflow".to_string()))?;
+        total_output = total_output
+            .checked_add(output_value)
+            .ok_or_else(|| ZcashError::InvalidPczt("migration output overflow".to_string()))?;
+    }
+
+    if orchard_spends != 1 || orchard_outputs != 0 || ironwood_spends != 0 || ironwood_outputs != 1
+    {
+        return Err(ZcashError::InvalidPczt(format!(
+            "unsupported migration summary shape orchard_spends={orchard_spends} orchard_outputs={orchard_outputs} ironwood_spends={ironwood_spends} ironwood_outputs={ironwood_outputs}"
+        )));
+    }
+
+    let total_fee = total_input
+        .checked_sub(total_output)
+        .ok_or_else(|| ZcashError::InvalidPczt("migration output exceeds input".to_string()))?;
+
+    Ok(BatchMigrationSummary {
+        migrations: 1,
+        total_input,
+        total_output,
+        total_fee,
+        children: vec![BatchMigrationChildSummary {
+            input: total_input,
+            output: total_output,
+            fee: total_fee,
+        }],
+    })
+}
+
+#[cfg(all(feature = "cypherpunk", zcash_unstable = "nu6.3"))]
+pub fn summarize_batch_migration_pczt_cypherpunk<P: consensus::Parameters>(
+    params: &P,
+    pczt: &[u8],
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<BatchMigrationSummary> {
+    let pczt = pczt::parse_pczt(pczt)?;
+    let (ufvk, account_index) =
+        check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
+
+    let signable_actions = signable_shielded_actions(
+        params,
+        pczt.clone(),
+        seed_fingerprint,
+        account_index,
+        ShieldedActionPolicy::Batch,
+    )?;
+    if signable_actions.is_empty() {
+        return Err(ZcashError::PcztNoMyInputs);
+    }
+
+    summarize_migration_actions(&ufvk, &pczt)
 }
 
 #[cfg(test)]
@@ -374,6 +681,19 @@ struct SignableShieldedAction {
 }
 
 #[cfg(feature = "cypherpunk")]
+pub const COMPACT_SIG_POOL_ORCHARD: u32 = 0;
+#[cfg(all(feature = "cypherpunk", zcash_unstable = "nu6.3"))]
+pub const COMPACT_SIG_POOL_IRONWOOD: u32 = 1;
+
+#[cfg(feature = "cypherpunk")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompactActionSig {
+    pub pool: u32,
+    pub action_index: u32,
+    pub sig: Vec<u8>,
+}
+
+#[cfg(feature = "cypherpunk")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ShieldedActionPolicy {
     Batch,
@@ -392,6 +712,38 @@ fn reject_unsupported_batch_pczt(pczt: &Pczt) -> Result<()> {
         return Err(ZcashError::InvalidPczt(
             "Zcash batch PCZT must not contain transparent inputs".to_string(),
         ));
+    }
+
+    Ok(())
+}
+
+/// Requires every action's `enc_ciphertext` to reach the ZIP-244 memo boundary
+/// so the signature-hash slicing in `zcash_vendor::pczt_ext` cannot panic on a
+/// truncated field.
+#[cfg(feature = "cypherpunk")]
+fn require_signature_hash_fields_for_bundle(
+    bundle: &zcash_vendor::pczt::orchard::Bundle,
+    pool: &str,
+) -> Result<()> {
+    for (index, action) in bundle.actions().iter().enumerate() {
+        let enc_ciphertext = action.output().enc_ciphertext();
+        if enc_ciphertext.len() < zcash_vendor::pczt_ext::ENC_CIPHERTEXT_MEMO_END {
+            return Err(ZcashError::InvalidPczt(format!(
+                "invalid {pool} action {index} enc_ciphertext length"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "cypherpunk")]
+fn require_signature_hash_fields(pczt: &Pczt) -> Result<()> {
+    require_signature_hash_fields_for_bundle(pczt.orchard(), "Orchard")?;
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    if pczt::pczt_should_process_ironwood(pczt) {
+        require_signature_hash_fields_for_bundle(pczt.ironwood(), "Ironwood")?;
     }
 
     Ok(())
@@ -420,10 +772,10 @@ fn collect_signable_shielded_actions<P: consensus::Parameters>(
                 pool.label(),
             )))
         })?;
-        if value.inner() == 0 {
-            continue;
-        }
 
+        // Ownership decides signability, never the value: restricted bundles pair
+        // change outputs with fabricated wallet-controlled zero-value spends that the
+        // device must sign, so zero value must not short-circuit the account check.
         let matches_account = pczt::matching_seed_supported_orchard_account(
             seed_fingerprint,
             action.spend().zip32_derivation().as_ref(),
@@ -433,6 +785,11 @@ fn collect_signable_shielded_actions<P: consensus::Parameters>(
         .map_err(OrchardError::Custom)?
             == Some(account_index);
         if !matches_account {
+            // Zero-value spends not owned by this account are tolerated dummies
+            // (their signatures travel wallet-side); anything else is foreign.
+            if value.inner() == 0 {
+                continue;
+            }
             if policy == ShieldedActionPolicy::Batch {
                 return Err(OrchardError::Custom(ZcashError::PcztNoMyInputs));
             }
@@ -590,6 +947,29 @@ pub fn ensure_pczt_has_signable_shielded_action<P: consensus::Parameters>(
     }
 }
 
+/// Signs a batch PCZT after applying the batch shielded action policy.
+///
+/// The UI review path already ran the expensive UFVK/output checks before the
+/// user approved the batch. This signer therefore keeps only cheap structural
+/// batch rejections, and the low-level signer itself enforces that any signed
+/// shielded action belongs to the selected account — signing consumes only the
+/// PCZT bytes, the seed material, and the selected account, never network
+/// parameters or the UFVK.
+#[cfg(feature = "cypherpunk")]
+pub fn sign_batch_pczt_cypherpunk(
+    pczt: &[u8],
+    seed: &[u8],
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<Vec<u8>> {
+    let pczt = pczt::parse_pczt(pczt)?;
+    reject_unsupported_batch_pczt(&pczt)?;
+    require_signature_hash_fields(&pczt)?;
+    let account_index = zip32::AccountId::try_from(account_index)
+        .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
+    pczt::sign::sign_batch_pczt_with_seed_fingerprint(pczt, seed, *seed_fingerprint, account_index)
+}
+
 /// Confirms that every signable supported shielded action in `unsigned_pczt`
 /// has a spend authorization signature in the same position in `signed_pczt`.
 #[cfg(feature = "cypherpunk")]
@@ -646,6 +1026,42 @@ pub fn ensure_owned_supported_shielded_actions_are_signed<P: consensus::Paramete
             .map_err(|_| ZcashError::InvalidPczt("invalid signed pczt data".to_string()))?;
         ensure_shielded_actions_are_signed(signed_pczt, &signable_actions)
     }
+}
+
+#[cfg(feature = "cypherpunk")]
+pub fn extract_compact_sigs_from_signed_pczt(signed_pczt: &[u8]) -> Result<Vec<CompactActionSig>> {
+    let signed_pczt = pczt::parse_pczt(signed_pczt)
+        .map_err(|_| ZcashError::InvalidPczt("invalid signed pczt data".to_string()))?;
+
+    let mut sigs = Vec::new();
+    for (index, action) in signed_pczt.orchard().actions().iter().enumerate() {
+        if let Some(sig) = action.spend().spend_auth_sig() {
+            sigs.push(CompactActionSig {
+                pool: COMPACT_SIG_POOL_ORCHARD,
+                action_index: index as u32,
+                sig: sig.to_vec(),
+            });
+        }
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    for (index, action) in signed_pczt.ironwood().actions().iter().enumerate() {
+        if let Some(sig) = action.spend().spend_auth_sig() {
+            sigs.push(CompactActionSig {
+                pool: COMPACT_SIG_POOL_IRONWOOD,
+                action_index: index as u32,
+                sig: sig.to_vec(),
+            });
+        }
+    }
+
+    if sigs.is_empty() {
+        return Err(ZcashError::SigningError(
+            "signed PCZT has no spend authorization signatures".to_string(),
+        ));
+    }
+
+    Ok(sigs)
 }
 
 #[cfg(feature = "cypherpunk")]
@@ -775,7 +1191,8 @@ mod tests {
         let ufvk = derive_ufvk(&MainNetwork, &seed, "m/32'/133'/0'").unwrap();
         let seed_fingerprint = calculate_seed_fingerprint(&seed).unwrap();
 
-        let result = check_pczt_cypherpunk(&MainNetwork, &malformed_pczt, &ufvk, &seed_fingerprint, 0);
+        let result =
+            check_pczt_cypherpunk(&MainNetwork, &malformed_pczt, &ufvk, &seed_fingerprint, 0);
 
         assert_invalid_pczt_message(
             result,
@@ -1155,8 +1572,22 @@ mod tests {
 
     #[cfg(zcash_unstable = "nu6.3")]
     fn pczt_with_sapling_output() -> pczt::test_support::SamplePczt {
-        let mut sample = pczt::test_support::sample_orchard_change_pczt();
-        let mut pczt: PcztMirror = postcard::from_bytes(&sample.bytes[8..]).unwrap();
+        let seed = [7u8; 32];
+        let ufvk_text =
+            derive_ufvk(&pczt::test_support::Nu6_3Network, &seed, "m/32'/133'/0'").unwrap();
+        let seed_fingerprint = calculate_seed_fingerprint(&seed).unwrap();
+        let mut bytes = ::pczt::roles::creator::Creator::new_v6(
+            zcash_vendor::zcash_protocol::consensus::BranchId::Nu6_3.into(),
+            10_000_000,
+            1,
+            [0; 32],
+            [0; 32],
+            [0; 32],
+        )
+        .build()
+        .serialize();
+
+        let mut pczt: PcztMirror = postcard::from_bytes(&bytes[8..]).unwrap();
         pczt.sapling.outputs.push(SaplingOutputMirror {
             cv: [0; 32],
             cmu: [0; 32],
@@ -1175,9 +1606,14 @@ mod tests {
         });
         pczt.sapling.value_sum = -1;
 
-        sample.bytes.truncate(8);
-        sample.bytes = postcard::to_extend(&pczt, sample.bytes).unwrap();
-        sample
+        bytes.truncate(8);
+        let bytes = postcard::to_extend(&pczt, bytes).unwrap();
+        pczt::test_support::SamplePczt {
+            bytes,
+            seed: seed.to_vec(),
+            ufvk_text,
+            seed_fingerprint,
+        }
     }
 
     fn assert_batch_unsupported_sapling_error<T: core::fmt::Debug>(result: Result<T>) {
@@ -1227,6 +1663,211 @@ mod tests {
         .unwrap();
     }
 
+    /// Batch twin of `test_sign_pczt_orchard_change_output_spend`: a post-NU6.3
+    /// restricted Orchard bundle pairs the change output with a fabricated
+    /// wallet-controlled zero-value spend that only this device's spend
+    /// authorizing key can sign, so batch signing must authorize it alongside
+    /// the real spend.
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_sign_orchard_change_output_spend() {
+        let sample = pczt::test_support::sample_orchard_change_pczt();
+
+        let signed =
+            sign_batch_pczt_cypherpunk(&sample.bytes, &sample.seed, &sample.seed_fingerprint, 0)
+                .expect("Orchard change batch PCZT should sign");
+        let parsed = Pczt::parse(&signed).expect("signed PCZT must parse");
+
+        let signed_actions = parsed
+            .orchard()
+            .actions()
+            .iter()
+            .filter(|action| action.spend().spend_auth_sig().is_some())
+            .count();
+        assert_eq!(
+            signed_actions, 2,
+            "real spend and wallet controlled zero value spend must be signed",
+        );
+    }
+
+    /// Faithful wire shape of a batch split entry: the wallet's batch redaction
+    /// strips every spend FVK and spend authorization signature before the QR
+    /// round trip. Both the real spend and the fabricated zero-value change
+    /// spend must still come back signed.
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_sign_redacted_orchard_change_output_spend() {
+        use zcash_vendor::pczt::roles::redactor::Redactor;
+
+        let sample = pczt::test_support::sample_orchard_change_pczt();
+        let redacted = Redactor::new(Pczt::parse(&sample.bytes).expect("sample PCZT should parse"))
+            .redact_orchard_with(|mut r| {
+                r.redact_actions(|mut ar| {
+                    ar.clear_spend_fvk();
+                    ar.clear_spend_auth_sig();
+                });
+            })
+            .finish()
+            .serialize();
+
+        let signed =
+            sign_batch_pczt_cypherpunk(&redacted, &sample.seed, &sample.seed_fingerprint, 0)
+                .expect("redacted Orchard change batch PCZT should sign");
+        let parsed = Pczt::parse(&signed).expect("signed PCZT must parse");
+
+        let signed_actions = parsed
+            .orchard()
+            .actions()
+            .iter()
+            .filter(|action| action.spend().spend_auth_sig().is_some())
+            .count();
+        assert_eq!(
+            signed_actions, 2,
+            "real spend and wallet controlled zero value spend must be signed",
+        );
+    }
+
+    /// Faithful wire shape of a migration child: dummies were signed wallet-side
+    /// by the IO Finalizer and the wallet strips `dummy_sk`, spend FVKs, and the
+    /// dummy signatures before the QR round trip. Batch signing must sign exactly
+    /// the real Orchard spend and tolerate the untagged zero-value actions
+    /// without erroring.
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_sign_migration_child_tolerates_redacted_dummies() {
+        use zcash_vendor::pczt::roles::redactor::Redactor;
+
+        let sample = pczt::test_support::sample_migration_pczt();
+        let pczt = Pczt::parse(&sample.bytes).expect("sample PCZT should parse");
+        let real_spend_index = pczt
+            .orchard()
+            .actions()
+            .iter()
+            .position(|action| matches!(action.spend().value(), Some(value) if *value != 0))
+            .expect("migration child must contain a real Orchard spend");
+        let redacted = Redactor::new(pczt)
+            .redact_orchard_with(|mut r| {
+                r.redact_actions(|mut ar| {
+                    ar.clear_spend_dummy_sk();
+                    ar.clear_spend_fvk();
+                    ar.clear_spend_auth_sig();
+                });
+            })
+            .redact_ironwood_with(|mut r| {
+                r.redact_actions(|mut ar| {
+                    ar.clear_spend_dummy_sk();
+                    ar.clear_spend_fvk();
+                    ar.clear_spend_auth_sig();
+                });
+            })
+            .finish()
+            .serialize();
+
+        let signed =
+            sign_batch_pczt_cypherpunk(&redacted, &sample.seed, &sample.seed_fingerprint, 0)
+                .expect("IO-finalized-shaped migration child should batch-sign");
+        let parsed = Pczt::parse(&signed).expect("signed PCZT must parse");
+
+        for (index, action) in parsed.orchard().actions().iter().enumerate() {
+            assert_eq!(
+                action.spend().spend_auth_sig().is_some(),
+                index == real_spend_index,
+                "exactly the real Orchard spend must be signed",
+            );
+        }
+        assert!(
+            parsed
+                .ironwood()
+                .actions()
+                .iter()
+                .all(|action| action.spend().spend_auth_sig().is_none()),
+            "output-only Ironwood bundle must stay unsigned",
+        );
+    }
+
+    /// A zero-value spend tagged for a different account of the same seed is
+    /// neither a tolerated dummy nor the selected account's change spend: the
+    /// reviewed batch must fail fast on-device instead of returning a response
+    /// whose extraction is guaranteed to fail on the phone.
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_sign_rejects_foreign_account_zero_value_spend() {
+        let sample = pczt::test_support::sample_orchard_change_pczt();
+        let retagged = pczt::test_support::orchard_pczt_with_zero_value_spend_derivation(
+            &sample.bytes,
+            sample.seed_fingerprint,
+            pczt::test_support::orchard_spend_path_for_account(1),
+        );
+
+        assert_eq!(
+            sign_batch_pczt_cypherpunk(&retagged, &sample.seed, &sample.seed_fingerprint, 0,)
+                .unwrap_err(),
+            ZcashError::PcztNoMyInputs
+        );
+    }
+
+    /// The fabricated zero-value change spend counts as signable in the batch
+    /// preflight, so the postflight must reject a response that left it unsigned
+    /// and accept a fully signed one.
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_postflight_requires_change_output_spend_signature() {
+        use zcash_vendor::pczt::roles::redactor::Redactor;
+
+        let sample = pczt::test_support::sample_orchard_change_pczt();
+
+        ensure_pczt_has_signable_shielded_action(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+
+        let signed =
+            sign_batch_pczt_cypherpunk(&sample.bytes, &sample.seed, &sample.seed_fingerprint, 0)
+                .expect("Orchard change batch PCZT should sign");
+        ensure_signable_shielded_actions_are_signed(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &signed,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+
+        // Simulate the pre-fix firmware response: real spend signed, fabricated
+        // zero-value change spend left unsigned.
+        let change_index = Pczt::parse(&sample.bytes)
+            .expect("sample PCZT should parse")
+            .orchard()
+            .actions()
+            .iter()
+            .position(|action| matches!(action.spend().value(), Some(0)))
+            .expect("change PCZT must contain the fabricated zero-value spend");
+        let missing_change_sig =
+            Redactor::new(Pczt::parse(&signed).expect("signed PCZT must parse"))
+                .redact_orchard_with(|mut r| {
+                    r.redact_action(change_index, |mut ar| {
+                        ar.clear_spend_auth_sig();
+                    });
+                })
+                .finish()
+                .serialize();
+
+        assert!(matches!(
+            ensure_signable_shielded_actions_are_signed(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &missing_change_sig,
+                &sample.seed_fingerprint,
+                0,
+            ),
+            Err(ZcashError::SigningError(message))
+                if message == "signed PCZT is missing an Orchard spend authorization signature"
+        ));
+    }
+
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_single_postflight_confirms_orchard_signature_when_present() {
@@ -1270,6 +1911,218 @@ mod tests {
 
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
+    fn test_batch_sign_rejects_sapling_outputs() {
+        let sample = pczt_with_sapling_output();
+
+        assert_batch_unsupported_sapling_error(sign_batch_pczt_cypherpunk(
+            &sample.bytes,
+            &sample.seed,
+            &sample.seed_fingerprint,
+            0,
+        ));
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_check_and_parse_accepts_ironwood_spend() {
+        let sample = pczt::test_support::sample_ironwood_pczt();
+
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("Ironwood batch PCZT should parse");
+        assert!(parsed.get_orchard().is_some() || parsed.get_ironwood().is_some());
+
+        assert_eq!(
+            check_and_parse_batch_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                1,
+            )
+            .unwrap_err(),
+            ZcashError::PcztNoMyInputs
+        );
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_check_and_parse_accepts_orchard_to_ironwood_migration() {
+        let sample = pczt::test_support::sample_migration_pczt();
+
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("migration batch PCZT should parse");
+        assert!(!parsed
+            .get_orchard()
+            .expect("migration must show Orchard inputs")
+            .get_from()
+            .is_empty());
+        assert!(!parsed
+            .get_ironwood()
+            .expect("migration must show Ironwood outputs")
+            .get_to()
+            .is_empty());
+        assert_eq!(parsed.get_fee_value(), "0.0002 ZEC");
+
+        assert_eq!(
+            check_and_parse_batch_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                1,
+            )
+            .unwrap_err(),
+            ZcashError::PcztNoMyInputs
+        );
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_migration_summary_accepts_orchard_to_ironwood_child() {
+        let sample = pczt::test_support::sample_migration_pczt();
+
+        let summary = summarize_batch_migration_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("migration child should summarize");
+
+        assert_eq!(
+            summary,
+            BatchMigrationSummary {
+                migrations: 1,
+                total_input: 1_010_000,
+                total_output: 990_000,
+                total_fee: 20_000,
+                children: vec![BatchMigrationChildSummary {
+                    input: 1_010_000,
+                    output: 990_000,
+                    fee: 20_000,
+                }],
+            }
+        );
+
+        let parsed = summary.to_parsed_pczt();
+        assert_eq!(parsed.get_total_transfer_value(), "0.0099 ZEC");
+        assert_eq!(parsed.get_fee_value(), "0.0002 ZEC");
+        assert_eq!(
+            parsed
+                .get_orchard()
+                .expect("summary should show Orchard inputs")
+                .get_from()
+                .len(),
+            1
+        );
+        assert_eq!(
+            parsed
+                .get_ironwood()
+                .expect("summary should show Ironwood outputs")
+                .get_to()
+                .len(),
+            1
+        );
+        assert_eq!(
+            parsed
+                .get_orchard()
+                .expect("summary should show Orchard inputs")
+                .get_from()[0]
+                .get_address()
+                .as_deref(),
+            Some("Migration #1 Orchard note from selected account")
+        );
+        assert_eq!(
+            parsed
+                .get_ironwood()
+                .expect("summary should show Ironwood outputs")
+                .get_to()[0]
+                .get_address(),
+            "Migration #1 wallet Ironwood output"
+        );
+        assert!(parsed
+            .get_ironwood()
+            .expect("summary should show Ironwood outputs")
+            .get_to()[0]
+            .get_is_change());
+
+        assert_eq!(
+            summarize_batch_migration_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                1,
+            )
+            .unwrap_err(),
+            ZcashError::PcztNoMyInputs
+        );
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_migration_summary_accepts_optional_spend_fvk() {
+        use zcash_vendor::pczt::{roles::redactor::Redactor, Pczt};
+
+        let sample = pczt::test_support::sample_migration_pczt();
+        let pczt = Pczt::parse(&sample.bytes).expect("sample PCZT should parse");
+        let redacted = Redactor::new(pczt)
+            .redact_orchard_with(|mut r| {
+                r.redact_actions(|mut ar| {
+                    ar.clear_spend_fvk();
+                });
+            })
+            .redact_ironwood_with(|mut r| {
+                r.redact_actions(|mut ar| {
+                    ar.clear_spend_fvk();
+                });
+            })
+            .finish()
+            .serialize();
+
+        let summary = summarize_batch_migration_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &redacted,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("redacted migration child should summarize");
+
+        assert_eq!(summary.migrations, 1);
+        assert_eq!(summary.total_input, 1_010_000);
+        assert_eq!(summary.total_output, 990_000);
+        assert_eq!(summary.total_fee, 20_000);
+
+        let signed =
+            sign_batch_pczt_cypherpunk(&redacted, &sample.seed, &sample.seed_fingerprint, 0)
+                .expect("request redacted only by optional spend FVK should sign");
+        let parsed = Pczt::parse(&signed).expect("signed PCZT should parse");
+        assert!(
+            parsed
+                .orchard()
+                .actions()
+                .iter()
+                .any(|action| action.spend().spend_auth_sig().is_some()),
+            "redacted migration request must still produce an Orchard spend signature"
+        );
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
     fn test_batch_postflight_rejects_sapling_outputs() {
         let sample = pczt_with_sapling_output();
 
@@ -1302,6 +2155,36 @@ mod tests {
                 1,
             )
             .unwrap_err(),
+            ZcashError::PcztNoMyInputs
+        );
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_sign_accepts_ironwood_spend() {
+        let sample = pczt::test_support::sample_ironwood_pczt();
+
+        let signed =
+            sign_batch_pczt_cypherpunk(&sample.bytes, &sample.seed, &sample.seed_fingerprint, 0)
+                .expect("Ironwood batch PCZT should sign");
+        let parsed = Pczt::parse(&signed).expect("signed PCZT must parse");
+
+        assert!(
+            parsed
+                .ironwood()
+                .actions()
+                .iter()
+                .any(|action| action.spend().spend_auth_sig().is_some()),
+            "Ironwood spend authorization signature must be present",
+        );
+        let compact_sigs =
+            extract_compact_sigs_from_signed_pczt(&signed).expect("compact sigs should extract");
+        assert!(compact_sigs
+            .iter()
+            .any(|sig| sig.pool == COMPACT_SIG_POOL_IRONWOOD && sig.sig.len() == 64));
+        assert_eq!(
+            sign_batch_pczt_cypherpunk(&sample.bytes, &sample.seed, &sample.seed_fingerprint, 1,)
+                .unwrap_err(),
             ZcashError::PcztNoMyInputs
         );
     }

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -2072,6 +2072,94 @@ mod tests {
         );
     }
 
+    /// A migration child whose single non-zero Ironwood output carries a valid
+    /// note commitment and a genuinely wallet-owned recipient, but an
+    /// `enc_ciphertext` that no key (wallet OVK or direct decryption) can
+    /// recover, must be REJECTED by the migration-summary review — exactly as
+    /// the ordinary per-message review (`parse_orchard_output`) already rejects
+    /// it. Before the shared-output-validation fix the summary path went through
+    /// the weaker `check_action_output`, which only tried the wallet OVKs and
+    /// silently accepted an output nothing could decrypt, arming the
+    /// reviewed-batch fingerprint for a migration whose funds the receiving
+    /// wallet can never detect by chain-scan.
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_batch_migration_summary_rejects_undecryptable_ironwood_output() {
+        use zcash_vendor::pczt::Pczt;
+
+        /// Flips a byte inside the first verbatim occurrence of `needle`.
+        fn corrupt_first_occurrence(haystack: &mut [u8], needle: &[u8]) -> bool {
+            if needle.is_empty() || needle.len() > haystack.len() {
+                return false;
+            }
+            for start in 0..=haystack.len() - needle.len() {
+                if &haystack[start..start + needle.len()] == needle {
+                    haystack[start + needle.len() / 2] ^= 0xff;
+                    return true;
+                }
+            }
+            false
+        }
+
+        let sample = pczt::test_support::sample_migration_pczt();
+
+        // The non-zero Ironwood output's ciphertext, as it appears on the wire.
+        let enc_ciphertext = {
+            let pczt = Pczt::parse(&sample.bytes).expect("sample PCZT should parse");
+            pczt.ironwood()
+                .actions()
+                .iter()
+                .find(|action| matches!(action.output().value(), Some(value) if *value != 0))
+                .expect("migration child must contain a non-zero Ironwood output")
+                .output()
+                .enc_ciphertext()
+                .to_vec()
+        };
+
+        // Corrupt only the ciphertext: cmx, cv_net, the value balance, and the
+        // plaintext recipient are all untouched, so every other check still
+        // passes and only decryption/recoverability fails.
+        let mut corrupted = sample.bytes.clone();
+        assert!(
+            corrupt_first_occurrence(&mut corrupted, &enc_ciphertext),
+            "sample must embed the Ironwood output enc_ciphertext verbatim"
+        );
+        assert!(
+            Pczt::parse(&corrupted).is_ok(),
+            "corruption must keep the PCZT structurally well-formed"
+        );
+
+        let summary_err = summarize_batch_migration_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &corrupted,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect_err("summary must reject a migration child with an undecryptable output");
+        assert!(
+            matches!(&summary_err, ZcashError::InvalidPczt(message) if message.contains("undecryptable")),
+            "expected an undecryptable-output rejection, got {summary_err:?}"
+        );
+
+        // Parity: the ordinary per-message review already rejected this shape, so
+        // the two review paths must now agree — no weaker path can arm the
+        // reviewed-batch fingerprint.
+        assert!(
+            matches!(
+                check_and_parse_batch_pczt_cypherpunk(
+                    &pczt::test_support::Nu6_3Network,
+                    &corrupted,
+                    &sample.ufvk_text,
+                    &sample.seed_fingerprint,
+                    0,
+                ),
+                Err(ZcashError::InvalidPczt(message)) if message.contains("undecryptable")
+            ),
+            "ordinary per-message review must also reject the undecryptable output"
+        );
+    }
+
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_batch_migration_summary_accepts_optional_spend_fvk() {

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -6,7 +6,7 @@ use crate::errors::ZcashError;
 
 #[cfg(feature = "cypherpunk")]
 use zcash_vendor::{
-    orchard::{self, keys::FullViewingKey, value::ValueSum, Address},
+    orchard::{self, keys::FullViewingKey, value::ValueSum},
     zcash_keys::keys::UnifiedFullViewingKey,
 };
 
@@ -554,16 +554,7 @@ fn check_action_spend<P: consensus::Parameters>(
 }
 
 #[cfg(feature = "cypherpunk")]
-fn is_wallet_orchard_address(fvk: &FullViewingKey, address: &Address) -> bool {
-    let external_ivk = fvk.to_ivk(zcash_vendor::zip32::Scope::External);
-    let internal_ivk = fvk.to_ivk(zcash_vendor::zip32::Scope::Internal);
-
-    external_ivk.diversifier_index(address).is_some()
-        || internal_ivk.diversifier_index(address).is_some()
-}
-
-#[cfg(feature = "cypherpunk")]
-// check output cmx and internal-ovk output ownership constraints
+// check output cmx, then share the parse path's output validation
 fn check_action_output<P: consensus::Parameters>(
     params: &P,
     ufvk: &UnifiedFullViewingKey,
@@ -576,41 +567,20 @@ fn check_action_output<P: consensus::Parameters>(
         .verify_note_commitment(action.spend())
         .map_err(|e| ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}")))?;
 
-    let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
-        "orchard fvk is not present".to_string(),
-    ))?;
-    let external_ovk = fvk.to_ovk(zcash_vendor::zip32::Scope::External).clone();
-    let internal_ovk = fvk.to_ovk(zcash_vendor::zip32::Scope::Internal).clone();
-    let transparent_internal_ovk = ufvk
-        .transparent()
-        .map(|k| orchard::keys::OutgoingViewingKey::from(k.internal_ovk().as_bytes()));
-
-    let mut keys = vec![(Some(external_ovk), false), (Some(internal_ovk), true)];
-    if let Some(ovk) = transparent_internal_ovk {
-        keys.push((Some(ovk), true));
-    }
-
-    for (vk, is_internal_ovk) in keys {
-        if let Some((_, address, _)) =
-            super::parse::decode_output_enc_ciphertext(action, vk.as_ref(), pool)?
-        {
-            if let Some(user_address) = action.output().user_address() {
-                super::parse::validate_orchard_user_address(params, user_address, &address)?;
-            }
-            if is_internal_ovk && !is_wallet_orchard_address(fvk, &address) {
-                return Err(ZcashError::InvalidPczt(format!(
-                    "{pool_label} output was recoverable with an internal OVK but does not belong to this wallet"
-                )));
-            }
-            break;
-        }
-    }
-
-    if let (Some(user_address), Some(recipient)) =
-        (action.output().user_address(), action.output().recipient())
-    {
-        super::parse::validate_orchard_user_address(params, user_address, recipient)?;
-    }
+    // Delegate the rest of output validation to `parse_orchard_output`, the
+    // single routine the parse/display path already uses, so this check path can
+    // never be weaker than it. The bespoke loop that used to live here tried only
+    // the wallet OVKs and *silently accepted* any output that no OVK could
+    // decrypt, skipping the direct-decryption "every non-zero output must be
+    // device-visible" requirement `parse_orchard_output` enforces (it returns
+    // `enc_ciphertext ... is undecryptable` for a non-zero output no key can
+    // recover). The Zcash migration-summary review reaches outputs through here
+    // (`check_pczt_orchard` -> `check_action_output`) instead of the parse path,
+    // so that gap let a malicious host arm the reviewed-batch fingerprint for a
+    // migration whose Ironwood output is committed to a wallet address but whose
+    // ciphertext the wallet can never rescan. The recovered display value is
+    // discarded here; this function only validates.
+    super::parse::parse_orchard_output(params, ufvk, action, pool)?;
 
     Ok(())
 }

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -24,6 +24,8 @@ use zcash_vendor::{
 use zcash_vendor::zcash_protocol::consensus::NetworkConstants;
 
 #[cfg(feature = "cypherpunk")]
+use super::structs::ParsedOrchard;
+#[cfg(feature = "cypherpunk")]
 use super::ShieldedPool;
 
 #[cfg(feature = "cypherpunk")]
@@ -79,6 +81,80 @@ pub fn check_pczt_orchard<P: consensus::Parameters>(
             .map_err(map_orchard_verifier_error)?;
     }
     Ok(())
+}
+
+/// The shielded display data (`orchard` / `ironwood`) produced as a side effect
+/// of the check pass, so the parse step does not have to decrypt every output a
+/// second time. Populated by [`check_and_parse_pczt_shielded`] and consumed by
+/// [`super::parse::parse_pczt_cypherpunk_with_checked_shielded`]. `None` for a
+/// pool means it had nothing to display (e.g. all-dummy bundle).
+#[cfg(feature = "cypherpunk")]
+pub(crate) struct CheckedShieldedParse {
+    pub(crate) orchard: Option<ParsedOrchard>,
+    pub(crate) ironwood: Option<ParsedOrchard>,
+}
+
+/// Runs the shielded validation and builds the display data in a SINGLE pass.
+///
+/// Previously the device validated a PCZT with `check_*` and then re-ran the
+/// Verifier in `parse_*` to build the display rows, decrypting every output
+/// twice. This checks and parses at once: it runs the Verifier once, and for
+/// each action both validates it and records its [`ParsedOrchard`] row. The
+/// result feeds [`super::parse::parse_pczt_cypherpunk_with_checked_shielded`],
+/// which only has to assemble the transparent bundle and totals. Behaviour is
+/// identical to the old check-then-reparse, minus the second decryption. Used by
+/// the batch review path (`check_and_parse_batch_pczt_cypherpunk`).
+#[cfg(feature = "cypherpunk")]
+pub(crate) fn check_and_parse_pczt_shielded<P: consensus::Parameters>(
+    params: &P,
+    seed_fingerprint: &[u8; 32],
+    account_index: zip32::AccountId,
+    ufvk: &UnifiedFullViewingKey,
+    pczt: &Pczt,
+) -> Result<CheckedShieldedParse, ZcashError> {
+    super::validate_supported_pczt(pczt)?;
+    let mut parsed_orchard = None;
+    let mut parsed_ironwood = None;
+    #[cfg(zcash_unstable = "nu6.3")]
+    let should_process_ironwood = super::pczt_should_process_ironwood(pczt);
+
+    let verifier = Verifier::new(pczt.clone())
+        .with_orchard(|bundle| {
+            parsed_orchard = check_and_parse_shielded_bundle(
+                params,
+                seed_fingerprint,
+                account_index,
+                ufvk,
+                bundle,
+                ShieldedPool::Orchard,
+            )
+            .map_err(pczt::roles::verifier::OrchardError::Custom)?;
+            Ok(())
+        })
+        .map_err(map_orchard_verifier_error)?;
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    if should_process_ironwood {
+        verifier
+            .with_ironwood(|bundle| {
+                parsed_ironwood = check_and_parse_shielded_bundle(
+                    params,
+                    seed_fingerprint,
+                    account_index,
+                    ufvk,
+                    bundle,
+                    ShieldedPool::Ironwood,
+                )
+                .map_err(pczt::roles::verifier::OrchardError::Custom)?;
+                Ok(())
+            })
+            .map_err(map_orchard_verifier_error)?;
+    }
+
+    Ok(CheckedShieldedParse {
+        orchard: parsed_orchard,
+        ironwood: parsed_ironwood,
+    })
 }
 
 pub fn check_pczt_transparent<P: consensus::Parameters>(
@@ -298,14 +374,7 @@ fn check_shielded_bundle<P: consensus::Parameters>(
 ) -> Result<(), ZcashError> {
     let pool_label = pool.label();
     bundle.actions().iter().try_for_each(|action| {
-        check_action(
-            params,
-            seed_fingerprint,
-            account_index,
-            ufvk,
-            action,
-            pool,
-        )?;
+        check_action(params, seed_fingerprint, account_index, ufvk, action, pool)?;
         Ok::<_, ZcashError>(())
     })?;
 
@@ -327,6 +396,86 @@ fn check_shielded_bundle<P: consensus::Parameters>(
     }
 }
 
+/// The check-and-parse twin of [`check_shielded_bundle`]: it runs the same
+/// per-action validation but also decodes each action into a [`ParsedOrchard`]
+/// display row. Returns `Ok(None)` when the bundle has nothing to show the user
+/// (all dummies), `Ok(Some(_))` otherwise. `check_shielded_bundle` stays as the
+/// check-only variant for paths that don't need display data; keep the two in
+/// sync. (GitHub renders these two similar functions as one mangled diff — they
+/// are separate: check-only vs check+parse.)
+#[cfg(feature = "cypherpunk")]
+fn check_and_parse_shielded_bundle<P: consensus::Parameters>(
+    params: &P,
+    seed_fingerprint: &[u8; 32],
+    account_index: zip32::AccountId,
+    ufvk: &UnifiedFullViewingKey,
+    bundle: &orchard::pczt::Bundle,
+    pool: ShieldedPool,
+) -> Result<Option<ParsedOrchard>, ZcashError> {
+    let pool_label = pool.label();
+    let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
+        "orchard fvk is not present".to_string(),
+    ))?;
+
+    let mut parsed_orchard = ParsedOrchard::new(vec![], vec![]);
+    bundle.actions().iter().try_for_each(|action| {
+        action.verify_cv_net().map_err(|e| {
+            ZcashError::InvalidPczt(format!("invalid cv_net in {pool_label} action: {e:?}"))
+        })?;
+
+        check_action_spend(
+            params,
+            seed_fingerprint,
+            account_index,
+            fvk,
+            action.spend(),
+            pool,
+        )?;
+        action
+            .output()
+            .verify_note_commitment(action.spend())
+            .map_err(|e| {
+                ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}"))
+            })?;
+
+        if let Some(value) = action.spend().value() {
+            if value.inner() != 0 {
+                let parsed_from =
+                    super::parse::parse_orchard_spend(seed_fingerprint, action.spend())?;
+                parsed_orchard.add_from(parsed_from);
+            }
+        }
+
+        let parsed_to = super::parse::parse_orchard_output(params, ufvk, action, pool)?;
+        if !parsed_to.get_is_dummy() {
+            parsed_orchard.add_to(parsed_to);
+        }
+
+        Ok::<_, ZcashError>(())
+    })?;
+
+    let calculated_value_balance = bundle
+        .actions()
+        .iter()
+        .map(|action| {
+            action.spend().value().expect("present") - action.output().value().expect("present")
+        })
+        .sum::<Result<ValueSum, _>>();
+
+    match calculated_value_balance {
+        Ok(value_balance) if &value_balance == bundle.value_sum() => {
+            if parsed_orchard.get_from().is_empty() && parsed_orchard.get_to().is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(parsed_orchard))
+            }
+        }
+        _ => Err(ZcashError::InvalidPczt(format!(
+            "invalid {pool_label} bundle value balance"
+        ))),
+    }
+}
+
 #[cfg(feature = "cypherpunk")]
 // check orchard action
 fn check_action<P: consensus::Parameters>(
@@ -341,9 +490,7 @@ fn check_action<P: consensus::Parameters>(
     // Check `cv_net` first so we know that the `value` fields for both the spend and the
     // output are present and correct.
     action.verify_cv_net().map_err(|e| {
-        ZcashError::InvalidPczt(format!(
-            "invalid cv_net in {pool_label} action: {e:?}"
-        ))
+        ZcashError::InvalidPczt(format!("invalid cv_net in {pool_label} action: {e:?}"))
     })?;
 
     let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
@@ -396,9 +543,7 @@ fn check_action_spend<P: consensus::Parameters>(
 
     if let Some(expected_fvk) = can_verify_nf_rk {
         spend.verify_nullifier(expected_fvk).map_err(|e| {
-            ZcashError::InvalidPczt(format!(
-                "invalid {pool_label} action nullifier: {e:?}"
-            ))
+            ZcashError::InvalidPczt(format!("invalid {pool_label} action nullifier: {e:?}"))
         })?;
         spend.verify_rk(expected_fvk).map_err(|e| {
             ZcashError::InvalidPczt(format!("invalid {pool_label} action rk: {e:?}"))
@@ -429,9 +574,7 @@ fn check_action_output<P: consensus::Parameters>(
     action
         .output()
         .verify_note_commitment(action.spend())
-        .map_err(|e| {
-            ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}"))
-        })?;
+        .map_err(|e| ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}")))?;
 
     let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
         "orchard fvk is not present".to_string(),
@@ -449,7 +592,7 @@ fn check_action_output<P: consensus::Parameters>(
 
     for (vk, is_internal_ovk) in keys {
         if let Some((_, address, _)) =
-            super::parse::decode_output_enc_ciphertext(action, vk.as_ref())?
+            super::parse::decode_output_enc_ciphertext(action, vk.as_ref(), pool)?
         {
             if let Some(user_address) = action.output().user_address() {
                 super::parse::validate_orchard_user_address(params, user_address, &address)?;

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -333,6 +333,52 @@ pub(crate) mod test_support {
             .serialize()
     }
 
+    /// Re-tags every zero-value Orchard spend in `bytes` with a ZIP 32 derivation
+    /// built from `seed_fingerprint` and `path`.
+    ///
+    /// Why this exists: post-NU6.3 restricted bundles pair each change output with a
+    /// fabricated wallet-controlled zero-value spend. The batch signer must sign the
+    /// ones for the *selected* account but must reject one tagged for a *different*
+    /// account of the same seed (signing it would produce a response the wallet
+    /// cannot extract). This helper builds exactly that adversarial case, and
+    /// `test_batch_sign_rejects_foreign_account_zero_value_spend` asserts the signer
+    /// refuses it with `PcztNoMyInputs`.
+    #[cfg(zcash_unstable = "nu6.3")]
+    pub(crate) fn orchard_pczt_with_zero_value_spend_derivation(
+        bytes: &[u8],
+        seed_fingerprint: [u8; 32],
+        path: Vec<u32>,
+    ) -> Vec<u8> {
+        Updater::new(Pczt::parse(bytes).unwrap())
+            .update_orchard_with(|mut bundle| {
+                let zero_value_indices = bundle
+                    .bundle()
+                    .actions()
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, action)| {
+                        matches!(action.spend().value().map(|value| value.inner()), Some(0))
+                            .then_some(index)
+                    })
+                    .collect::<Vec<_>>();
+                assert!(!zero_value_indices.is_empty());
+
+                for action_index in zero_value_indices {
+                    let derivation =
+                        orchard::pczt::Zip32Derivation::parse(seed_fingerprint, path.clone())
+                            .unwrap();
+                    bundle.update_action_with(action_index, |mut action| {
+                        action.set_spend_zip32_derivation(derivation);
+                        Ok(())
+                    })?;
+                }
+                Ok(())
+            })
+            .unwrap()
+            .finish()
+            .serialize()
+    }
+
     #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn sample_ironwood_pczt() -> SamplePczt {
         let params = Nu6_3Network;
@@ -346,11 +392,14 @@ pub(crate) mod test_support {
 
         let value = orchard::value::NoteValue::from_raw(1_000_000);
         let note = {
+            let bundle_version = orchard::bundle::BundleVersion::ironwood_v3();
             let mut orchard_builder = orchard::builder::Builder::new(
-                orchard::BundleProtocol::IronwoodPostNu6_3,
                 orchard::builder::BundleType::DEFAULT,
+                bundle_version,
+                bundle_version.default_flags(),
                 orchard::Anchor::empty_tree(),
-            );
+            )
+            .unwrap();
             orchard_builder
                 .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
                 .unwrap();
@@ -359,7 +408,7 @@ pub(crate) mod test_support {
                 .actions()
                 .get(meta.output_action_index(0).unwrap())
                 .unwrap();
-            let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+            let domain = orchard::note_encryption::IronwoodDomain::for_action(action);
             let (note, _, _) =
                 try_note_decryption(&domain, &orchard_ivk.prepare(), action).unwrap();
             note
@@ -457,10 +506,12 @@ pub(crate) mod test_support {
         let value = orchard::value::NoteValue::from_raw(1_010_000);
         let note = {
             let mut orchard_builder = orchard::builder::Builder::new(
-                orchard::BundleProtocol::OrchardPostNu6_3,
                 orchard::builder::BundleType::Coinbase,
+                orchard::bundle::BundleVersion::orchard_v2(),
+                orchard::bundle::Flags::SPENDS_DISABLED,
                 orchard::Anchor::empty_tree(),
-            );
+            )
+            .unwrap();
             orchard_builder
                 .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
                 .unwrap();
@@ -563,10 +614,12 @@ pub(crate) mod test_support {
         let value = orchard::value::NoteValue::from_raw(1_000_000);
         let note = {
             let mut orchard_builder = orchard::builder::Builder::new(
-                orchard::BundleProtocol::OrchardPostNu6_3,
                 orchard::builder::BundleType::Coinbase,
+                orchard::bundle::BundleVersion::orchard_v2(),
+                orchard::bundle::Flags::SPENDS_DISABLED,
                 orchard::Anchor::empty_tree(),
-            );
+            )
+            .unwrap();
             orchard_builder
                 .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
                 .unwrap();
@@ -598,11 +651,14 @@ pub(crate) mod test_support {
             (anchor.into(), merkle_path.into())
         };
 
+        let bundle_version = orchard::bundle::BundleVersion::orchard_v3();
         let mut builder = orchard::builder::Builder::new(
-            orchard::BundleProtocol::OrchardPostNu6_3,
             orchard::builder::BundleType::DEFAULT,
+            bundle_version,
+            bundle_version.default_flags(),
             anchor,
-        );
+        )
+        .unwrap();
         builder
             .add_spend(orchard_fvk.clone(), note, merkle_path)
             .unwrap();

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -21,7 +21,11 @@ use zcash_vendor::{
 use zcash_note_encryption::Domain;
 #[cfg(feature = "cypherpunk")]
 use zcash_vendor::orchard::{
-    self, keys::OutgoingViewingKey, note::Note, note_encryption::OrchardDomain, Address,
+    self,
+    keys::OutgoingViewingKey,
+    note::Note,
+    note_encryption::{IronwoodDomain, OrchardDomain},
+    Address,
 };
 #[cfg(feature = "cypherpunk")]
 use zcash_vendor::{
@@ -77,7 +81,7 @@ fn map_transparent_verifier_error(
     }
 }
 
-fn format_zec_value(value: f64) -> String {
+pub(crate) fn format_zec_value(value: f64) -> String {
     let zec_value = format!("{:.8}", value / ZEC_DIVIDER as f64);
     let zec_value = zec_value
         .trim_end_matches('0')
@@ -94,53 +98,77 @@ fn format_zec_value(value: f64) -> String {
 /// - `Ok(None)` if the output cannot be decrypted.
 /// - `Err(_)` if `ovk` is `None` and the PCZT is missing fields needed to directly
 ///   decrypt the output.
+///
+/// `pool` only selects the note-encryption domain — `OrchardDomain` for Orchard,
+/// `IronwoodDomain` for Ironwood. The recovery logic is identical for both, so
+/// the body is written once in the `decode_with_domain!` macro and instantiated
+/// per domain; this is why the diff looks larger than a plain "match on pool".
 #[cfg(feature = "cypherpunk")]
-pub fn decode_output_enc_ciphertext(
+pub(crate) fn decode_output_enc_ciphertext(
     action: &orchard::pczt::Action,
     ovk: Option<&OutgoingViewingKey>,
+    pool: ShieldedPool,
 ) -> Result<Option<(Note, Address, [u8; 512])>, ZcashError> {
-    let domain = OrchardDomain::for_pczt_action(action);
+    macro_rules! decode_with_domain {
+        ($domain_ty:ty) => {{
+            let domain = <$domain_ty>::for_pczt_action(action);
 
-    if let Some(ovk) = ovk {
-        Ok(try_output_recovery_with_ovk(
-            &domain,
-            ovk,
-            action,
-            action.cv_net(),
-            &action.output().encrypted_note().out_ciphertext,
-        ))
-    } else {
-        // If we reached here, none of our OVKs matched; recover directly as the fallback.
+            if let Some(ovk) = ovk {
+                Ok(try_output_recovery_with_ovk(
+                    &domain,
+                    ovk,
+                    action,
+                    action.cv_net(),
+                    &action.output().encrypted_note().out_ciphertext,
+                ))
+            } else {
+                // If we reached here, none of our OVKs matched; recover directly as the fallback.
+                let pool_label = pool.label();
 
-        let recipient = action.output().recipient().ok_or_else(|| {
-            ZcashError::InvalidPczt("Missing recipient field for Orchard action".into())
-        })?;
-        let value = action.output().value().ok_or_else(|| {
-            ZcashError::InvalidPczt("Missing value field for Orchard action".into())
-        })?;
-        let rho = orchard::note::Rho::from_bytes(&action.spend().nullifier().to_bytes())
-            .into_option()
-            .ok_or_else(|| {
-                ZcashError::InvalidPczt("Missing rho field for Orchard action".into())
-            })?;
-        let rseed = action.output().rseed().ok_or_else(|| {
-            ZcashError::InvalidPczt("Missing rseed field for Orchard action".into())
-        })?;
+                let recipient = action.output().recipient().ok_or_else(|| {
+                    ZcashError::InvalidPczt(format!(
+                        "Missing recipient field for {pool_label} action"
+                    ))
+                })?;
+                let value = action.output().value().ok_or_else(|| {
+                    ZcashError::InvalidPczt(format!("Missing value field for {pool_label} action"))
+                })?;
+                let rho = orchard::note::Rho::from_bytes(&action.spend().nullifier().to_bytes())
+                    .into_option()
+                    .ok_or_else(|| {
+                        ZcashError::InvalidPczt(format!(
+                            "Missing rho field for {pool_label} action"
+                        ))
+                    })?;
+                let rseed = action.output().rseed().ok_or_else(|| {
+                    ZcashError::InvalidPczt(format!("Missing rseed field for {pool_label} action"))
+                })?;
 
-        let note = orchard::Note::from_parts(
-            recipient,
-            value,
-            rho,
-            rseed,
-            (*action.output().note_version()).into(),
-        )
-        .into_option()
-        .ok_or_else(|| ZcashError::InvalidPczt("Orchard action contains invalid note".into()))?;
+                let note = orchard::Note::from_parts(
+                    recipient,
+                    value,
+                    rho,
+                    rseed,
+                    (*action.output().note_version()).into(),
+                )
+                .into_option()
+                .ok_or_else(|| {
+                    ZcashError::InvalidPczt(format!("{pool_label} action contains invalid note"))
+                })?;
 
-        let pk_d = OrchardDomain::get_pk_d(&note);
-        let esk = OrchardDomain::derive_esk(&note).expect("Orchard notes are post-ZIP 212");
+                let pk_d = <$domain_ty>::get_pk_d(&note);
+                let esk =
+                    <$domain_ty>::derive_esk(&note).expect("Orchard-shaped notes are post-ZIP 212");
 
-        Ok(try_output_recovery_with_pkd_esk(&domain, pk_d, esk, action))
+                Ok(try_output_recovery_with_pkd_esk(&domain, pk_d, esk, action))
+            }
+        }};
+    }
+
+    match pool {
+        ShieldedPool::Orchard => decode_with_domain!(OrchardDomain),
+        #[cfg(zcash_unstable = "nu6.3")]
+        ShieldedPool::Ironwood => decode_with_domain!(IronwoodDomain),
     }
 }
 
@@ -182,8 +210,14 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
 
     let verifier = Verifier::new(pczt.clone())
         .with_orchard(|bundle| {
-            parsed_orchard = parse_orchard(params, seed_fingerprint, ufvk, bundle, ShieldedPool::Orchard)
-                .map_err(pczt::roles::verifier::OrchardError::Custom)?;
+            parsed_orchard = parse_orchard(
+                params,
+                seed_fingerprint,
+                ufvk,
+                bundle,
+                ShieldedPool::Orchard,
+            )
+            .map_err(pczt::roles::verifier::OrchardError::Custom)?;
             Ok(())
         })
         .map_err(map_orchard_verifier_error)?;
@@ -191,8 +225,14 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
     let verifier = if should_process_ironwood {
         verifier
             .with_ironwood(|bundle| {
-                parsed_ironwood = parse_orchard(params, seed_fingerprint, ufvk, bundle, ShieldedPool::Ironwood)
-                    .map_err(pczt::roles::verifier::OrchardError::Custom)?;
+                parsed_ironwood = parse_orchard(
+                    params,
+                    seed_fingerprint,
+                    ufvk,
+                    bundle,
+                    ShieldedPool::Ironwood,
+                )
+                .map_err(pczt::roles::verifier::OrchardError::Custom)?;
                 Ok(())
             })
             .map_err(map_orchard_verifier_error)?
@@ -207,6 +247,48 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
         })
         .map_err(map_transparent_verifier_error)?;
 
+    #[cfg(not(zcash_unstable = "nu6.3"))]
+    let parsed_ironwood = None;
+
+    assemble_parsed_pczt(pczt, parsed_transparent, parsed_orchard, parsed_ironwood)
+}
+
+/// Finishes a parse whose shielded pools were ALREADY checked-and-parsed in one
+/// pass (`parsed_orchard`/`parsed_ironwood` come from
+/// [`super::check::check_and_parse_pczt_shielded`]). It only parses the
+/// transparent bundle and assembles the totals, reusing the shielded work rather
+/// than decrypting the outputs again. The full-from-scratch variant that decodes
+/// everything itself is [`parse_pczt_cypherpunk`]; both funnel into
+/// [`assemble_parsed_pczt`].
+#[cfg(feature = "cypherpunk")]
+pub(crate) fn parse_pczt_cypherpunk_with_checked_shielded<P: consensus::Parameters>(
+    params: &P,
+    seed_fingerprint: &[u8; 32],
+    pczt: &Pczt,
+    parsed_orchard: Option<ParsedOrchard>,
+    parsed_ironwood: Option<ParsedOrchard>,
+) -> Result<ParsedPczt, ZcashError> {
+    super::validate_supported_pczt(pczt)?;
+    let mut parsed_transparent = None;
+
+    Verifier::new(pczt.clone())
+        .with_transparent(|bundle| {
+            parsed_transparent = parse_transparent(params, seed_fingerprint, bundle)
+                .map_err(pczt::roles::verifier::TransparentError::Custom)?;
+            Ok(())
+        })
+        .map_err(map_transparent_verifier_error)?;
+
+    assemble_parsed_pczt(pczt, parsed_transparent, parsed_orchard, parsed_ironwood)
+}
+
+#[cfg(feature = "cypherpunk")]
+fn assemble_parsed_pczt(
+    pczt: &Pczt,
+    parsed_transparent: Option<ParsedTransparent>,
+    parsed_orchard: Option<ParsedOrchard>,
+    parsed_ironwood: Option<ParsedOrchard>,
+) -> Result<ParsedPczt, ZcashError> {
     let mut total_input_value = 0;
     let mut total_output_value = 0;
     let mut total_change_value = 0;
@@ -285,11 +367,6 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
     let fee_value = format_zec_value((total_input_value - total_output_value) as f64);
 
     let has_sapling = !pczt.sapling().spends().is_empty() || !pczt.sapling().outputs().is_empty();
-
-    #[cfg(zcash_unstable = "nu6.3")]
-    let parsed_ironwood = parsed_ironwood;
-    #[cfg(not(zcash_unstable = "nu6.3"))]
-    let parsed_ironwood = None;
 
     Ok(ParsedPczt::new(
         parsed_transparent,
@@ -547,7 +624,7 @@ fn parse_orchard<P: consensus::Parameters>(
 }
 
 #[cfg(feature = "cypherpunk")]
-fn parse_orchard_spend(
+pub(crate) fn parse_orchard_spend(
     seed_fingerprint: &[u8; 32],
     spend: &orchard::pczt::Spend,
 ) -> Result<ParsedFrom, ZcashError> {
@@ -568,7 +645,7 @@ fn parse_orchard_spend(
 }
 
 #[cfg(feature = "cypherpunk")]
-fn is_wallet_orchard_address(
+pub(crate) fn is_wallet_orchard_address(
     ufvk: &UnifiedFullViewingKey,
     address: &Address,
 ) -> Result<bool, ZcashError> {
@@ -616,7 +693,7 @@ pub(crate) fn validate_orchard_user_address<P: consensus::Parameters>(
 }
 
 #[cfg(feature = "cypherpunk")]
-fn parse_orchard_output<P: consensus::Parameters>(
+pub(crate) fn parse_orchard_output<P: consensus::Parameters>(
     params: &P,
     ufvk: &UnifiedFullViewingKey,
     action: &orchard::pczt::Action,
@@ -642,7 +719,7 @@ fn parse_orchard_output<P: consensus::Parameters>(
         .inner();
 
     let decode_output = |vk: Option<OutgoingViewingKey>, is_internal_ovk: bool| {
-        match decode_output_enc_ciphertext(action, vk.as_ref())? {
+        match decode_output_enc_ciphertext(action, vk.as_ref(), pool)? {
             Some((note, address, memo)) => {
                 let zec_value = format_zec_value(note.value().inner() as f64);
                 let memo = decode_memo(memo);

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -112,11 +112,21 @@ struct SeedSigner<'a> {
     seed: &'a [u8],
     seed_fingerprint: [u8; 32],
     pool: ShieldedPool,
+    /// Batch mode restricts signing to a single account. `Some(account)`
+    /// (`for_batch_account`): only spends tagged for that account are signed;
+    /// spends tagged for a different account of the same seed are refused. `None`
+    /// (`new`): ordinary signing — any account derivable from the seed.
+    selected_account: Option<zcash_vendor::zip32::AccountId>,
     /// Per-account spend authorizing key cache. The seed fingerprint and the account
     /// key depend only on (seed, account), not on the action, so a bundle with many
     /// actions for one account derives once. Interior mutability because the
     /// `PcztSigner` trait signs through `&self`.
-    ask_cache: RefCell<Vec<(zcash_vendor::zip32::AccountId, orchard::keys::SpendAuthorizingKey)>>,
+    ask_cache: RefCell<
+        Vec<(
+            zcash_vendor::zip32::AccountId,
+            orchard::keys::SpendAuthorizingKey,
+        )>,
+    >,
     /// Number of authorizations produced, so `sign_pczt` can distinguish "nothing of
     /// ours to sign" (`PcztNoMyInputs`) from a successful signing.
     signed: Cell<usize>,
@@ -129,6 +139,23 @@ impl<'a> SeedSigner<'a> {
             seed,
             seed_fingerprint,
             pool,
+            selected_account: None,
+            ask_cache: RefCell::new(Vec::new()),
+            signed: Cell::new(0),
+        }
+    }
+
+    fn for_batch_account(
+        seed: &'a [u8],
+        seed_fingerprint: [u8; 32],
+        pool: ShieldedPool,
+        selected_account: zcash_vendor::zip32::AccountId,
+    ) -> Self {
+        Self {
+            seed,
+            seed_fingerprint,
+            pool,
+            selected_account: Some(selected_account),
             ask_cache: RefCell::new(Vec::new()),
             signed: Cell::new(0),
         }
@@ -209,9 +236,19 @@ impl PcztSigner for SeedSigner<'_> {
                 }
             }
         }
-        if action.spend().value().is_none() {
-            return Ok(());
-        }
+        let Some(value) = action.spend().value() else {
+            return if self.selected_account.is_some() {
+                Err(ZcashError::InvalidPczt(format!(
+                    "missing {pool_label} spend value"
+                )))
+            } else {
+                Ok(())
+            };
+        };
+        // Ownership decides signing, never the value: post-NU6.3 restricted bundles
+        // pair each change output with a fabricated wallet-controlled zero-value spend
+        // that must be signed by the account spend authorizing key (see
+        // pczt_ext::sign_orchard_action: we "must NOT pre-filter by value").
         let Some(account_index) = super::matching_seed_supported_orchard_account(
             &self.seed_fingerprint,
             action.spend().zip32_derivation().as_ref(),
@@ -219,9 +256,21 @@ impl PcztSigner for SeedSigner<'_> {
             self.pool,
         )?
         else {
-            // Not derivable from this seed; not ours to sign.
-            return Ok(());
+            // Not derivable from this seed. Ordinary PCZT signing ignores it. A
+            // reviewed batch tolerates untagged zero-value spends (IO Finalizer-signed
+            // dummies whose signatures the wallet strips for the QR round trip) but
+            // must otherwise contain only selected-account spends.
+            return if self.selected_account.is_some() && value.inner() != 0 {
+                Err(ZcashError::PcztNoMyInputs)
+            } else {
+                Ok(())
+            };
         };
+        if let Some(selected_account) = self.selected_account {
+            if account_index != selected_account {
+                return Err(ZcashError::PcztNoMyInputs);
+            }
+        }
 
         let ask = self.spend_authorizing_key(account_index)?;
         action
@@ -238,19 +287,68 @@ impl PcztSigner for SeedSigner<'_> {
     }
 }
 
+// Ordinary and batch signing share one core, `sign_pczt_with_seed_fingerprint_inner`,
+// which threads an optional selected account (None = ordinary, Some = batch/restricted).
+// The three wrappers exist so callers can enter at the right level:
+//   sign_pczt                          -> public ordinary entry; computes the seed fingerprint
+//   sign_pczt_with_seed_fingerprint    -> ordinary, fingerprint already known (avoids recomputing)
+//   sign_batch_pczt_with_seed_fingerprint -> batch; restricts signing to `account_index`
+// The batch path already holds the fingerprint (validated during review), so it skips recomputing it.
+
+/// Public ordinary (non-batch) signing entry: signs every action derivable from
+/// the seed. Computes the seed fingerprint, then delegates to the shared core.
 #[cfg(feature = "cypherpunk")]
 pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
-    super::validate_supported_pczt(&pczt)?;
-
     let seed_fingerprint =
         calculate_seed_fingerprint(seed).map_err(|e| ZcashError::SigningError(e.to_string()))?;
+
+    sign_pczt_with_seed_fingerprint(pczt, seed, seed_fingerprint)
+}
+
+/// Ordinary signing with a precomputed seed fingerprint (no account restriction).
+#[cfg(feature = "cypherpunk")]
+pub(crate) fn sign_pczt_with_seed_fingerprint(
+    pczt: Pczt,
+    seed: &[u8],
+    seed_fingerprint: [u8; 32],
+) -> crate::Result<Vec<u8>> {
+    sign_pczt_with_seed_fingerprint_inner(pczt, seed, seed_fingerprint, None)
+}
+
+/// Batch signing: restricts signing to `account_index` (the device-selected
+/// account); spends tagged for another account of the same seed are refused.
+#[cfg(feature = "cypherpunk")]
+pub(crate) fn sign_batch_pczt_with_seed_fingerprint(
+    pczt: Pczt,
+    seed: &[u8],
+    seed_fingerprint: [u8; 32],
+    account_index: zcash_vendor::zip32::AccountId,
+) -> crate::Result<Vec<u8>> {
+    sign_pczt_with_seed_fingerprint_inner(pczt, seed, seed_fingerprint, Some(account_index))
+}
+
+/// Shared signing core for both ordinary and batch paths. `selected_account`
+/// distinguishes them: `None` signs any of the seed's accounts, `Some` restricts
+/// to that one.
+#[cfg(feature = "cypherpunk")]
+fn sign_pczt_with_seed_fingerprint_inner(
+    pczt: Pczt,
+    seed: &[u8],
+    seed_fingerprint: [u8; 32],
+    selected_account: Option<zcash_vendor::zip32::AccountId>,
+) -> crate::Result<Vec<u8>> {
+    super::validate_supported_pczt(&pczt)?;
 
     #[cfg(zcash_unstable = "nu6.3")]
     let process_ironwood = super::pczt_should_process_ironwood(&pczt);
 
     // The orchard signer handles both the transparent inputs and the Orchard bundle
     // (the pool only changes error labels for shielded actions). Ironwood gets its own.
-    let orchard_signer = SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Orchard);
+    let orchard_signer = if let Some(account_index) = selected_account {
+        SeedSigner::for_batch_account(seed, seed_fingerprint, ShieldedPool::Orchard, account_index)
+    } else {
+        SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Orchard)
+    };
 
     // Propagate the signer error directly (it is already a ZcashError): the strict
     // validation in SeedSigner::sign_orchard returns ZcashError::InvalidPczt for bad
@@ -260,7 +358,16 @@ pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
     let signer = pczt_ext::sign_orchard(signer, &orchard_signer)?;
 
     #[cfg(zcash_unstable = "nu6.3")]
-    let ironwood_signer = SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Ironwood);
+    let ironwood_signer = if let Some(account_index) = selected_account {
+        SeedSigner::for_batch_account(
+            seed,
+            seed_fingerprint,
+            ShieldedPool::Ironwood,
+            account_index,
+        )
+    } else {
+        SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Ironwood)
+    };
     #[cfg(zcash_unstable = "nu6.3")]
     let signer = if process_ironwood {
         pczt_ext::sign_ironwood(signer, &ironwood_signer)?
@@ -723,7 +830,6 @@ mod tests {
             .expect("wallet-set min key must survive round trip");
         assert_eq!(request_min.as_slice(), &[1u8, 2][..]);
     }
-
 }
 
 #[cfg(all(test, feature = "multi_coins", not(feature = "cypherpunk")))]

--- a/rust/rust_c/Cargo.toml
+++ b/rust/rust_c/Cargo.toml
@@ -26,6 +26,7 @@ aes = { workspace = true }
 cbc = { workspace = true }
 cipher = { workspace = true }
 minicbor = { workspace = true }
+spin = { workspace = true, optional = true }
 #keystone owned
 sim_qr_reader = { workspace = true, optional = true }
 keystore = { workspace = true, default-features = false }
@@ -120,7 +121,7 @@ multi-coins = [
 
 btc-only = ["bitcoin", "keystore/multi_coins"]
 
-cypherpunk = ["bitcoin", "zcash_cypherpunk", "monero", "keystore/cypherpunk"]
+cypherpunk = ["bitcoin", "zcash_cypherpunk", "monero", "keystore/cypherpunk", "dep:spin"]
 
 # build variants
 # production

--- a/rust/rust_c/src/common/ur.rs
+++ b/rust/rust_c/src/common/ur.rs
@@ -715,6 +715,8 @@ impl_response!(URParseMultiResult);
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
 
     #[test]
@@ -746,18 +748,35 @@ mod tests {
             full_result.free();
         }
 
-        let zcash_result = UREncodeResult::encode_full_response(
+        let zcash_sign_result = UREncodeResult::encode_full_response(
             vec![0; FRAGMENT_UNLIMITED_LENGTH + 1],
             "zcash-sign-result".to_string(),
         );
-        assert_eq!(zcash_result.error_code, ErrorCodes::Success as u32);
-        assert!(!zcash_result.is_multi_part);
-        assert!(zcash_result.encoder.is_null());
-        let zcash_data = unsafe { recover_c_char(zcash_result.data) };
+        assert_eq!(zcash_sign_result.error_code, ErrorCodes::Success as u32);
+        assert!(!zcash_sign_result.is_multi_part);
+        assert!(zcash_sign_result.encoder.is_null());
+        let zcash_data = unsafe { recover_c_char(zcash_sign_result.data) };
         assert!(zcash_data.starts_with("UR:ZCASH-SIGN-RESULT/"));
         assert!(!zcash_data.contains("/1-"));
         unsafe {
-            zcash_result.free();
+            zcash_sign_result.free();
+        }
+
+        let zcash_batch_sig_result = UREncodeResult::encode_full_response(
+            vec![0; FRAGMENT_UNLIMITED_LENGTH + 1],
+            "zcash-batch-sig-result".to_string(),
+        );
+        assert_eq!(
+            zcash_batch_sig_result.error_code,
+            ErrorCodes::Success as u32
+        );
+        assert!(!zcash_batch_sig_result.is_multi_part);
+        assert!(zcash_batch_sig_result.encoder.is_null());
+        let zcash_data = unsafe { recover_c_char(zcash_batch_sig_result.data) };
+        assert!(zcash_data.starts_with("UR:ZCASH-BATCH-SIG-RESULT/"));
+        assert!(!zcash_data.contains("/1-"));
+        unsafe {
+            zcash_batch_sig_result.free();
         }
     }
 }

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -22,12 +22,14 @@ use keystore::algorithms::{
 use structs::DisplayPczt;
 use structs::DisplayZcashBatch;
 use ur_registry::traits::RegistryItem;
+use ur_registry::zcash::zcash_batch_sig_result::{
+    ZcashActionSig, ZcashBatchSigResult, ZcashMsgSig, ZCASH_BATCH_SIG_RESULT_VERSION,
+};
 use ur_registry::zcash::zcash_pczt::ZcashPczt;
 use ur_registry::zcash::zcash_sign_batch::{
     ZcashSignBatch, ZcashSignMessage, ZCASH_SIGN_BATCH_NETWORK_MAINNET, ZCASH_SIGN_BATCH_VERSION,
     ZCASH_SIGN_MESSAGE_KIND_PCZT_V1,
 };
-use ur_registry::zcash::zcash_sign_result::{ZcashSignMessageResult, ZcashSignResult};
 use zcash_vendor::zcash_protocol::consensus::MainNetwork;
 use zeroize::Zeroize;
 
@@ -36,6 +38,41 @@ use zeroize::Zeroize;
 // about 35% of RAM on target hardware. Revisit this if new message kinds or
 // substantially larger payload encodings are added.
 const ZCASH_BATCH_MAX_MESSAGES: usize = 35;
+
+/// Fingerprint of the last Zcash batch that completed the review path
+/// (`parse_zcash_batch_tx_cypherpunk`), which verifies every message before
+/// the user approves what is displayed. The batch signer signs without
+/// re-running those checks, so it refuses any batch whose fingerprint differs
+/// from the reviewed one — making "the device signs exactly the bytes the user
+/// reviewed" an enforced invariant rather than a GUI control-flow assumption.
+///
+/// The fingerprint is cleared when a review starts (so a failed parse cannot
+/// leave a previous batch armed) and recorded on review success. It
+/// intentionally survives signing so the signature QR can be regenerated for
+/// the same reviewed batch. Recording at parse success rather than at user
+/// approval is sound because the GUI cannot start a new review while an
+/// approval screen is open: USB resolve-UR requests are refused outside the
+/// home/transport views, and reaching the QR scanner tears the review view
+/// down.
+///
+/// Locking discipline: the review path (the only writer) runs on the
+/// background task and locks unconditionally; the signer — which the USB flow
+/// runs on the higher-priority UI task — only `try_lock`s and refuses to sign
+/// on contention, so a higher-priority task can never spin-wait on a
+/// preempted lock holder (fail closed instead of livelock).
+#[cfg(feature = "cypherpunk")]
+static REVIEWED_BATCH_FINGERPRINT: spin::Mutex<Option<[u8; 32]>> = spin::Mutex::new(None);
+
+/// Confirms that `batch_fingerprint` is the reviewed batch's fingerprint.
+/// `try_lock` so the (possibly higher-priority) signing task never spin-waits
+/// on a preempted lock holder — an unobtainable lock means the reviewed
+/// fingerprint cannot be confirmed, so this reports unreviewed (fail closed).
+#[cfg(feature = "cypherpunk")]
+fn confirm_batch_reviewed(batch_fingerprint: &[u8; 32]) -> bool {
+    REVIEWED_BATCH_FINGERPRINT
+        .try_lock()
+        .is_some_and(|reviewed| reviewed.as_ref() == Some(batch_fingerprint))
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn derive_zcash_ufvk(
@@ -181,7 +218,12 @@ pub unsafe extern "C" fn parse_zcash_tx_multi_coins(
     }
 }
 
-fn validate_zcash_batch(batch: &ZcashSignBatch) -> Result<(), RustCError> {
+/// Validates the batch container and returns its fingerprint: one hash over
+/// the header fields plus a fixed-width (id digest, payload digest) pair per
+/// message, so any change to what the signer would consume changes the
+/// fingerprint. The per-payload digests are already needed for duplicate
+/// detection, so this adds no extra payload hashing.
+fn validate_zcash_batch(batch: &ZcashSignBatch) -> Result<[u8; 32], RustCError> {
     let messages = batch.get_messages();
     if batch.get_version() != ZCASH_SIGN_BATCH_VERSION {
         return Err(RustCError::UnsupportedTransaction(format!(
@@ -215,6 +257,12 @@ fn validate_zcash_batch(batch: &ZcashSignBatch) -> Result<(), RustCError> {
         )));
     }
 
+    let mut fingerprint_data = Vec::with_capacity(8 + 32 + messages.len() * 64);
+    fingerprint_data.extend_from_slice(&batch.get_version().to_le_bytes());
+    fingerprint_data.extend_from_slice(&batch.get_network().to_le_bytes());
+    fingerprint_data.extend_from_slice(&sha256(batch.get_request_id()));
+
+    let mut seen_messages: Vec<(&[u8], [u8; 32])> = Vec::new();
     for (index, message) in messages.iter().enumerate() {
         if message.get_kind() != ZCASH_SIGN_MESSAGE_KIND_PCZT_V1 {
             return Err(RustCError::UnsupportedTransaction(format!(
@@ -242,21 +290,24 @@ fn validate_zcash_batch(batch: &ZcashSignBatch) -> Result<(), RustCError> {
             }
         }
 
-        for previous in &messages[..index] {
-            if sha256(previous.get_payload()) == digest {
+        for (previous_id, previous_digest) in &seen_messages {
+            if previous_digest == &digest {
                 return Err(RustCError::InvalidData(
                     "Zcash batch contains duplicate payloads".to_string(),
                 ));
             }
-            if previous.get_id() == message.get_id() {
+            if *previous_id == message.get_id().as_slice() {
                 return Err(RustCError::InvalidData(
                     "Zcash batch contains duplicate message ids".to_string(),
                 ));
             }
         }
+        seen_messages.push((message.get_id().as_slice(), digest));
+        fingerprint_data.extend_from_slice(&sha256(message.get_id()));
+        fingerprint_data.extend_from_slice(&digest);
     }
 
-    Ok(())
+    Ok(sha256(&fingerprint_data))
 }
 
 #[cfg(feature = "cypherpunk")]
@@ -344,6 +395,9 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
     account_index: u32,
     disabled: bool,
 ) -> Ptr<TransactionParseResult<DisplayZcashBatch>> {
+    // Starting a new review disarms any previously reviewed batch — before
+    // any early return, so no parse attempt can leave an older batch armed.
+    *REVIEWED_BATCH_FINGERPRINT.lock() = None;
     if disabled {
         return TransactionParseResult::from(RustCError::UnsupportedTransaction(
             "Zcash requires at least 256-bit entropy (use 33-word Shamir shares)".to_string(),
@@ -355,38 +409,92 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
 
-    if let Err(e) = validate_zcash_batch(batch) {
-        return TransactionParseResult::from(e).c_ptr();
-    }
+    let batch_fingerprint = match validate_zcash_batch(batch) {
+        Ok(fingerprint) => fingerprint,
+        Err(e) => return TransactionParseResult::from(e).c_ptr(),
+    };
 
-    let mut display_items = Vec::new();
-    for message in batch.get_messages() {
-        if let Err(e) = check_zcash_batch_message_cypherpunk(
-            message,
+    #[cfg(zcash_unstable = "nu6.3")]
+    if batch.get_messages().len() > 1 {
+        match parse_zcash_batch_as_split_plus_migrations(
+            batch,
             &ufvk_text,
             seed_fingerprint,
             account_index,
         ) {
-            return TransactionParseResult::from(e).c_ptr();
+            Ok(display_items) => {
+                *REVIEWED_BATCH_FINGERPRINT.lock() = Some(batch_fingerprint);
+                return TransactionParseResult::success(
+                    DisplayZcashBatch::from(display_items).c_ptr(),
+                )
+                .c_ptr();
+            }
+            Err(_) => {}
         }
-        match app_zcash::parse_pczt_cypherpunk(
+    }
+
+    let mut display_items = Vec::new();
+    for message in batch.get_messages() {
+        match app_zcash::check_and_parse_batch_pczt_cypherpunk(
             &MainNetwork,
             message.get_payload(),
             &ufvk_text,
-            seed_fingerprint,
+            &seed_fingerprint,
+            account_index,
         ) {
             Ok(pczt) => display_items.push(DisplayPczt::from(&pczt)),
             Err(e) => return TransactionParseResult::from(e).c_ptr(),
         }
     }
 
+    *REVIEWED_BATCH_FINGERPRINT.lock() = Some(batch_fingerprint);
     TransactionParseResult::success(DisplayZcashBatch::from(display_items).c_ptr()).c_ptr()
 }
 
+#[cfg(all(feature = "cypherpunk", zcash_unstable = "nu6.3"))]
+fn parse_zcash_batch_as_split_plus_migrations(
+    batch: &ZcashSignBatch,
+    ufvk_text: &str,
+    seed_fingerprint: [u8; 32],
+    account_index: u32,
+) -> app_zcash::errors::Result<Vec<DisplayPczt>> {
+    let messages = batch.get_messages();
+    let mut display_items = Vec::new();
+
+    let split_message = &messages[0];
+    let split_pczt = app_zcash::check_and_parse_batch_pczt_cypherpunk(
+        &MainNetwork,
+        split_message.get_payload(),
+        ufvk_text,
+        &seed_fingerprint,
+        account_index,
+    )?;
+    display_items.push(DisplayPczt::from(&split_pczt));
+
+    let mut summary = app_zcash::BatchMigrationSummary::default();
+    for message in messages.iter().skip(1) {
+        let child = app_zcash::summarize_batch_migration_pczt_cypherpunk(
+            &MainNetwork,
+            message.get_payload(),
+            ufvk_text,
+            &seed_fingerprint,
+            account_index,
+        )?;
+        summary.add_child(&child)?;
+    }
+
+    let summary_pczt = summary.to_parsed_pczt();
+    display_items.push(DisplayPczt::from(&summary_pczt));
+
+    Ok(display_items)
+}
+
 #[cfg(feature = "cypherpunk")]
+// `_ufvk` stays in the FFI signature for C-side call compatibility, but batch
+// signing consumes only the PCZT bytes, seed material, and selected account.
 unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
     tx: PtrUR,
-    ufvk: PtrString,
+    _ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
     disabled: bool,
@@ -402,13 +510,23 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
         .c_ptr();
     }
     let batch = extract_ptr_with_type!(tx, ZcashSignBatch);
-    let ufvk_text = unsafe { recover_c_char(ufvk) };
     let expected_seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let expected_seed_fingerprint: &[u8; 32] = expected_seed_fingerprint.try_into().unwrap();
     let mut seed = extract_array_mut!(seed, u8, seed_len as usize);
 
     let result = match validate_zcash_batch(batch) {
-        Ok(()) => {
+        Ok(batch_fingerprint) => {
+            // Only sign the exact batch the user reviewed and approved: the
+            // review path verified every message and recorded this
+            // fingerprint, and this signer intentionally re-runs only cheap
+            // structural checks.
+            if !confirm_batch_reviewed(&batch_fingerprint) {
+                seed.zeroize();
+                return UREncodeResult::from(RustCError::InvalidData(
+                    "Zcash batch does not match the reviewed batch".to_string(),
+                ))
+                .c_ptr();
+            }
             let seed_fingerprint = calculate_seed_fingerprint(seed);
             match seed_fingerprint {
                 Ok(seed_fingerprint) => {
@@ -419,38 +537,35 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
 
                     let mut results = Vec::new();
                     for message in batch.get_messages() {
-                        if let Err(e) = check_zcash_batch_message_cypherpunk(
-                            message,
-                            &ufvk_text,
+                        match app_zcash::sign_batch_pczt_cypherpunk(
+                            message.get_payload(),
+                            seed,
                             &seed_fingerprint,
                             account_index,
                         ) {
-                            seed.zeroize();
-                            return UREncodeResult::from(e).c_ptr();
-                        }
-
-                        match app_zcash::sign_pczt(message.get_payload(), seed) {
                             Ok(payload) => {
-                                if let Err(e) =
-                                    app_zcash::ensure_signable_shielded_actions_are_signed(
-                                        &MainNetwork,
-                                        message.get_payload(),
-                                        &payload,
-                                        &seed_fingerprint,
-                                        account_index,
-                                    )
-                                {
-                                    seed.zeroize();
-                                    return UREncodeResult::from(e).c_ptr();
+                                match app_zcash::extract_compact_sigs_from_signed_pczt(&payload) {
+                                    Ok(compact_sigs) => {
+                                        let action_sigs = compact_sigs
+                                            .into_iter()
+                                            .map(|sig| {
+                                                ZcashActionSig::new(
+                                                    sig.pool,
+                                                    sig.action_index,
+                                                    sig.sig,
+                                                )
+                                            })
+                                            .collect();
+                                        results.push(ZcashMsgSig::new(
+                                            message.get_id().clone(),
+                                            action_sigs,
+                                        ));
+                                    }
+                                    Err(e) => {
+                                        seed.zeroize();
+                                        return UREncodeResult::from(e).c_ptr();
+                                    }
                                 }
-
-                                let payload_digest = sha256(&payload).to_vec();
-                                results.push(ZcashSignMessageResult::signed(
-                                    message.get_id().clone(),
-                                    message.get_kind(),
-                                    payload,
-                                    payload_digest,
-                                ));
                             }
                             Err(e) => {
                                 seed.zeroize();
@@ -459,20 +574,20 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
                         }
                     }
 
-                    let result = ZcashSignResult::new(
-                        ZCASH_SIGN_BATCH_VERSION,
+                    let result = ZcashBatchSigResult::new(
+                        ZCASH_BATCH_SIG_RESULT_VERSION,
                         batch.get_request_id().clone(),
                         results,
                     );
                     match TryInto::<Vec<u8>>::try_into(result) {
                         Ok(bytes) => {
-                            let registry_type = ZcashSignResult::get_registry_type().get_type();
-                            let encode_result = if allow_multipart {
+                            let registry_type = ZcashBatchSigResult::get_registry_type().get_type();
+                            if allow_multipart {
                                 UREncodeResult::encode(bytes, registry_type, max_fragment_length)
                             } else {
                                 UREncodeResult::encode_full_response(bytes, registry_type)
-                            };
-                            encode_result.c_ptr()
+                            }
+                            .c_ptr()
                         }
                         Err(e) => UREncodeResult::from(e).c_ptr(),
                     }
@@ -797,6 +912,100 @@ mod tests {
         ]);
 
         validate_zcash_batch(&batch).unwrap();
+    }
+
+    #[test]
+    fn test_validate_zcash_batch_fingerprint_binds_reviewed_bytes() {
+        let batch = test_zcash_batch(vec![
+            test_zcash_message(b"one", b"pczt-one"),
+            test_zcash_message(b"two", b"pczt-two"),
+        ]);
+        let fingerprint = validate_zcash_batch(&batch).unwrap();
+
+        assert_eq!(
+            validate_zcash_batch(&batch).unwrap(),
+            fingerprint,
+            "identical batch bytes must produce the reviewed fingerprint"
+        );
+
+        // The signing gate itself: refuse with nothing reviewed, sign only the
+        // reviewed batch, follow re-reviews, and disarm on clear. One test
+        // exercises the whole lifecycle because the static is shared state.
+        let other = validate_zcash_batch(&test_zcash_batch(vec![test_zcash_message(
+            b"one",
+            b"pczt-other",
+        )]))
+        .unwrap();
+        *REVIEWED_BATCH_FINGERPRINT.lock() = None;
+        assert!(
+            !confirm_batch_reviewed(&fingerprint),
+            "no review armed: refuse"
+        );
+        *REVIEWED_BATCH_FINGERPRINT.lock() = Some(fingerprint);
+        assert!(
+            confirm_batch_reviewed(&fingerprint),
+            "the reviewed batch signs"
+        );
+        assert!(
+            !confirm_batch_reviewed(&other),
+            "a different batch is refused while another is armed"
+        );
+        *REVIEWED_BATCH_FINGERPRINT.lock() = Some(other);
+        assert!(
+            !confirm_batch_reviewed(&fingerprint),
+            "a new review replaces the armed fingerprint"
+        );
+        *REVIEWED_BATCH_FINGERPRINT.lock() = None;
+        assert!(
+            !confirm_batch_reviewed(&other),
+            "a cleared review disarms signing"
+        );
+
+        let changed_payload = test_zcash_batch(vec![
+            test_zcash_message(b"one", b"pczt-one"),
+            test_zcash_message(b"two", b"pczt-2wo"),
+        ]);
+        assert_ne!(
+            validate_zcash_batch(&changed_payload).unwrap(),
+            fingerprint,
+            "a changed payload is a different batch"
+        );
+
+        let changed_id = test_zcash_batch(vec![
+            test_zcash_message(b"one", b"pczt-one"),
+            test_zcash_message(b"2wo", b"pczt-two"),
+        ]);
+        assert_ne!(
+            validate_zcash_batch(&changed_id).unwrap(),
+            fingerprint,
+            "a changed message id is a different batch"
+        );
+
+        let reordered = test_zcash_batch(vec![
+            test_zcash_message(b"two", b"pczt-two"),
+            test_zcash_message(b"one", b"pczt-one"),
+        ]);
+        assert_ne!(
+            validate_zcash_batch(&reordered).unwrap(),
+            fingerprint,
+            "reordered messages are a different batch"
+        );
+
+        let changed_request_id = ZcashSignBatch::new(
+            ZCASH_SIGN_BATCH_VERSION,
+            b"other-request".to_vec(),
+            ZCASH_SIGN_BATCH_NETWORK_MAINNET,
+            vec![
+                test_zcash_message(b"one", b"pczt-one"),
+                test_zcash_message(b"two", b"pczt-two"),
+            ],
+            Some(true),
+        );
+        assert_ne!(
+            validate_zcash_batch(&changed_request_id).unwrap(),
+            fingerprint,
+            "a changed request id is a different batch"
+        );
     }
 
     #[test]

--- a/rust/zcash_vendor/Cargo.toml
+++ b/rust/zcash_vendor/Cargo.toml
@@ -41,7 +41,7 @@ chacha20poly1305 = { version = "0.10.1", default-features = false, features = [
 ] }
 postcard = { version = "1.0.3", features = ["alloc"] }
 getset = { version = "0.1.3" }
-orchard = { version = "0.14", default-features = false, optional = true }
+orchard = { version = "0.15.0-pre.1", default-features = false, optional = true }
 pczt = { version = "0.7", default-features = false }
 serde = { workspace = true }
 serde_with = { version = "3.11.0", features = [

--- a/rust/zcash_vendor/src/pczt_ext.rs
+++ b/rust/zcash_vendor/src/pczt_ext.rs
@@ -188,6 +188,17 @@ fn hash_transparent_tx_id(t_digests: Option<TransparentDigests>) -> Hash {
     h.finalize()
 }
 
+/// Byte layout of a Sapling/Orchard `enc_ciphertext` as the ZIP-244 digests
+/// consume it: the first [`ENC_CIPHERTEXT_COMPACT_LEN`] bytes are the compact
+/// note ciphertext (the `*CHash` digests), bytes up to
+/// [`ENC_CIPHERTEXT_MEMO_END`] are the encrypted memo (the `*MHash` digests),
+/// and the remainder is hashed with the non-compact fields. Any signing
+/// precondition that keeps these slices panic-free must use the same
+/// constants (see `app_zcash`'s `require_signature_hash_fields`).
+pub const ENC_CIPHERTEXT_COMPACT_LEN: usize = 52;
+/// See [`ENC_CIPHERTEXT_COMPACT_LEN`]: 52 compact bytes + 512 memo bytes.
+pub const ENC_CIPHERTEXT_MEMO_END: usize = ENC_CIPHERTEXT_COMPACT_LEN + 512;
+
 fn digest_orchard(pczt: &Pczt) -> Hash {
     let mut h = hasher(ZCASH_ORCHARD_HASH_PERSONALIZATION);
 
@@ -196,16 +207,18 @@ fn digest_orchard(pczt: &Pczt) -> Hash {
     let mut nh = hasher(ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION);
 
     for action in pczt.orchard().actions().iter() {
+        let enc_ciphertext = action.output().enc_ciphertext();
+
         ch.update(action.spend().nullifier());
         ch.update(action.output().cmx());
         ch.update(action.output().ephemeral_key());
-        ch.update(&action.output().enc_ciphertext()[..52]);
+        ch.update(&enc_ciphertext[..ENC_CIPHERTEXT_COMPACT_LEN]);
 
-        mh.update(&action.output().enc_ciphertext()[52..564]);
+        mh.update(&enc_ciphertext[ENC_CIPHERTEXT_COMPACT_LEN..ENC_CIPHERTEXT_MEMO_END]);
 
         nh.update(action.cv_net());
         nh.update(action.spend().rk());
-        nh.update(&action.output().enc_ciphertext()[564..]);
+        nh.update(&enc_ciphertext[ENC_CIPHERTEXT_MEMO_END..]);
         nh.update(action.output().out_ciphertext());
     }
 
@@ -257,12 +270,12 @@ fn hash_sapling_outputs(pczt: &Pczt) -> Hash {
         for s_out in pczt.sapling().outputs() {
             ch.update(s_out.cmu());
             ch.update(s_out.ephemeral_key());
-            ch.update(&s_out.enc_ciphertext()[..52]);
+            ch.update(&s_out.enc_ciphertext()[..ENC_CIPHERTEXT_COMPACT_LEN]);
 
-            mh.update(&s_out.enc_ciphertext()[52..564]);
+            mh.update(&s_out.enc_ciphertext()[ENC_CIPHERTEXT_COMPACT_LEN..ENC_CIPHERTEXT_MEMO_END]);
 
             nh.update(s_out.cv());
-            nh.update(&s_out.enc_ciphertext()[564..]);
+            nh.update(&s_out.enc_ciphertext()[ENC_CIPHERTEXT_MEMO_END..]);
             nh.update(s_out.out_ciphertext());
         }
 
@@ -351,16 +364,18 @@ fn digest_orchard_shaped_v6(
     let mut nh = hasher(noncompact_personalization);
 
     for action in bundle.actions().iter() {
+        let enc_ciphertext = action.output().enc_ciphertext();
+
         ch.update(action.spend().nullifier());
         ch.update(action.output().cmx());
         ch.update(action.output().ephemeral_key());
-        ch.update(&action.output().enc_ciphertext()[..52]);
+        ch.update(&enc_ciphertext[..ENC_CIPHERTEXT_COMPACT_LEN]);
 
-        mh.update(&action.output().enc_ciphertext()[52..564]);
+        mh.update(&enc_ciphertext[ENC_CIPHERTEXT_COMPACT_LEN..ENC_CIPHERTEXT_MEMO_END]);
 
         nh.update(action.cv_net());
         nh.update(action.spend().rk());
-        nh.update(&action.output().enc_ciphertext()[564..]);
+        nh.update(&enc_ciphertext[ENC_CIPHERTEXT_MEMO_END..]);
         nh.update(action.output().out_ciphertext());
     }
 
@@ -460,7 +475,11 @@ fn shielded_sig_commitment_v6(
 /// `pub` so the `app_zcash` consensus oracle tests can assert it stays bit-exact against
 /// the upstream RoleSigner sighash (any divergence turns CI red rather than producing
 /// wrong on-device signatures).
-pub fn shielded_sig_commitment(pczt: &Pczt, lock_time: u32, input_info: Option<SignableInput>) -> Hash {
+pub fn shielded_sig_commitment(
+    pczt: &Pczt,
+    lock_time: u32,
+    input_info: Option<SignableInput>,
+) -> Hash {
     #[cfg(zcash_unstable = "nu6.3")]
     if is_v6(pczt) {
         return shielded_sig_commitment_v6(pczt, lock_time, input_info);
@@ -611,8 +630,9 @@ where
     llsigner.sign_orchard_with::<T::Error, _>(|pczt, signable, tx_modifiable| {
         let lock_time = determine_lock_time(pczt.global(), pczt.transparent().inputs())
             .ok_or(transparent::pczt::ParseError::InvalidRequiredHeightLocktime)?;
+        let shielded_hash = shielded_sig_commitment(pczt, lock_time, None);
         signable.actions_mut().iter_mut().try_for_each(|action| {
-            sign_orchard_action(pczt, lock_time, signer, action, tx_modifiable)
+            sign_orchard_action(signer, action, &shielded_hash, tx_modifiable)
         })
     })
 }
@@ -622,12 +642,17 @@ where
 /// derivation and signs wallet-controlled spends, including zero-value ones), so we
 /// must NOT pre-filter by value here — that would drop a wallet-controlled zero-value
 /// spend. `tx_modifiable` is cleared only when this call adds a new signature.
+///
+/// Takes the precomputed `shielded_hash` rather than `(pczt, lock_time)`: the
+/// Orchard sighash is transaction-wide (the same for every action in the bundle
+/// and unaffected by the signatures being added), so the caller computes it ONCE
+/// before the action loop instead of re-deriving it per action. This is a large
+/// part of the signing speedup and is behaviour-preserving.
 #[cfg(feature = "orchard")]
 fn sign_orchard_action<T>(
-    pczt: &Pczt,
-    lock_time: u32,
     signer: &T,
     action: &mut orchard::pczt::Action,
+    shielded_hash: &Hash,
     tx_modifiable: &mut u8,
 ) -> Result<(), T::Error>
 where
@@ -638,7 +663,7 @@ where
         return Ok(());
     }
     let had_sig = action.spend().spend_auth_sig().is_some();
-    signer.sign_orchard(action, shielded_sig_commitment(pczt, lock_time, None))?;
+    signer.sign_orchard(action, shielded_hash.clone())?;
     if !had_sig && action.spend().spend_auth_sig().is_some() {
         *tx_modifiable &= !(FLAG_TRANSPARENT_INPUTS_MODIFIABLE
             | FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE
@@ -664,8 +689,9 @@ where
     llsigner.sign_ironwood_with::<T::Error, _>(|pczt, signable, tx_modifiable| {
         let lock_time = determine_lock_time(pczt.global(), pczt.transparent().inputs())
             .ok_or(transparent::pczt::ParseError::InvalidRequiredHeightLocktime)?;
+        let shielded_hash = shielded_sig_commitment(pczt, lock_time, None);
         signable.actions_mut().iter_mut().try_for_each(|action| {
-            sign_orchard_action(pczt, lock_time, signer, action, tx_modifiable)
+            sign_orchard_action(signer, action, &shielded_hash, tx_modifiable)
         })
     })
 }

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
@@ -382,6 +382,7 @@ static void *GuiParseZcashBatchData(void)
 
 void GuiZcashBatchWidgetsTransactionParseSuccess(void)
 {
+    ClearLockScreenTime();
     g_displayZcashBatch = g_parseResult->data;
     g_txCount = g_displayZcashBatch->txs->size;
     g_currentTxIndex = 0;
@@ -390,6 +391,7 @@ void GuiZcashBatchWidgetsTransactionParseSuccess(void)
 
 void GuiZcashBatchWidgetsTransactionParseFail(void)
 {
+    ClearLockScreenTime();
     printf("GuiZcashBatchWidgetsTransactionParseFail\n");
     if (g_parseResult != NULL) {
         printf("error: %s\n", g_parseResult->error_message);


### PR DESCRIPTION
## Summary

Optimizes the Zcash migration signing flow: a 10-note Orchard-to-Ironwood migration that took ~15 minutes end to end (with ~9 minutes of signing) now completes in ~2.5 minutes. The device reviews a migration batch as one split transaction plus a single aggregate migration summary instead of one full page per child, signs the batch with the selected account only, and returns a compact signatures-only response instead of echoing full signed PCZTs.

## What changed

- **Aggregate migration review**: render the split transaction plus one migration summary (totals and per-child input/output/fee) instead of one full page per child. Every migration child is still fully verified on-device (spend ownership, nullifier/rk, cv_net, note commitment, value balance, wallet-owned outputs, and output recoverability); only the display is aggregated.
- **Reviewed-batch fingerprint binding**: the review path records a fingerprint over the validated batch, and the signer refuses to sign any batch whose fingerprint differs, so "the device signs exactly the bytes the user reviewed" is enforced rather than assumed from GUI control flow.
- **Sign wallet-controlled zero-value change spends**: ownership decides signability, never value, so post-NU6.3 restricted bundles (which pair each change output with a fabricated wallet-controlled zero-value spend) extract correctly.
- **Compact signatures-only response**: return the pool, action index, and 64-byte signature per action instead of full signed PCZTs, cutting the response to far fewer QR frames.
- **Output recoverability in the migration summary**: the final commit makes the summary review reject a migration child whose Ironwood output is committed to a wallet address but whose ciphertext no key can recover, matching the guarantee the ordinary per-message review already enforces (a review-vs-sign parity gap caught in review).
- Reset the lock timer after a long batch parse so the device does not auto-lock mid-review; name the ZIP-244 enc_ciphertext slice boundaries as shared constants; run the rust_c Zcash FFI tests in CI (new macOS job) and widen the workflow path filter to zcash_vendor and the rust_c zcash module.
