### PR TITLE
refactor(zcash): checked-PCZT lifecycle — check once, C stores normalized bytes

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "hex",
  "incrementalmerkletree",
  "keystore",
+ "orchard",
  "pczt",
  "postcard",
  "rand_core 0.6.4",
@@ -1676,7 +1677,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=644b1ecf4679e17a9166782f57a795a4f4194d5e#644b1ecf4679e17a9166782f57a795a4f4194d5e"
+source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1803,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/valargroup/librustzcash?rev=644b1ecf4679e17a9166782f57a795a4f4194d5e#644b1ecf4679e17a9166782f57a795a4f4194d5e"
+source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3039,9 +3040,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "orchard"
-version = "0.15.0-pre.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e277dd4b46f5d06deae3ffb8af1a951e8622368f028c2a4d6fe59339566403"
+version = "0.15.0-pre.2"
+source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
 dependencies = [
  "aes",
  "bitvec",
@@ -3142,7 +3142,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.7.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=644b1ecf4679e17a9166782f57a795a4f4194d5e#644b1ecf4679e17a9166782f57a795a4f4194d5e"
+source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -5409,13 +5409,13 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.12.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=644b1ecf4679e17a9166782f57a795a4f4194d5e#644b1ecf4679e17a9166782f57a795a4f4194d5e"
+version = "0.13.0-pre.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (git+https://github.com/valargroup/librustzcash?rev=644b1ecf4679e17a9166782f57a795a4f4194d5e)",
+ "f4jumble 0.1.1 (git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f)",
  "zcash_encoding",
  "zcash_protocol",
 ]
@@ -5423,7 +5423,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=644b1ecf4679e17a9166782f57a795a4f4194d5e#644b1ecf4679e17a9166782f57a795a4f4194d5e"
+source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
 dependencies = [
  "corez",
  "hex",
@@ -5432,8 +5432,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.14.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=644b1ecf4679e17a9166782f57a795a4f4194d5e#644b1ecf4679e17a9166782f57a795a4f4194d5e"
+version = "0.15.0-pre.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
 dependencies = [
  "bech32 0.11.0",
  "bip32",
@@ -5471,8 +5471,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.28.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=644b1ecf4679e17a9166782f57a795a4f4194d5e#644b1ecf4679e17a9166782f57a795a4f4194d5e"
+version = "0.29.0-pre.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5501,8 +5501,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.9.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=644b1ecf4679e17a9166782f57a795a4f4194d5e#644b1ecf4679e17a9166782f57a795a4f4194d5e"
+version = "0.10.0-pre.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
 dependencies = [
  "corez",
  "hex",
@@ -5540,8 +5540,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=644b1ecf4679e17a9166782f57a795a4f4194d5e#644b1ecf4679e17a9166782f57a795a4f4194d5e"
+version = "0.9.0-pre.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
 dependencies = [
  "bip32",
  "bs58",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -129,9 +129,7 @@ zcash_keys = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7
 zcash_primitives = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
 zcash_protocol = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
 zcash_transparent = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
-# Redirect every crates.io `orchard` requirement onto the merged
-# unpadded-bundles head so the graph resolves to a single orchard node,
-# matching the pczt pin.
+# Keep `orchard` aligned with the pinned PCZT/librustzcash revision.
 orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }
 # Use the upstream SDK rev with the Zcash batch registry types until they are published as a crate.
 ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust.git", rev = "0884de4b2e927bc3f95a98dff62045e0d492e574" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -122,12 +122,16 @@ zeroize = { version = "1.8.2", default-features = false }
 # third party dependencies end
 
 [patch.crates-io]
-pczt = { git = "https://github.com/valargroup/librustzcash", rev = "644b1ecf4679e17a9166782f57a795a4f4194d5e" }
-zcash_address = { git = "https://github.com/valargroup/librustzcash", rev = "644b1ecf4679e17a9166782f57a795a4f4194d5e" }
-zcash_encoding = { git = "https://github.com/valargroup/librustzcash", rev = "644b1ecf4679e17a9166782f57a795a4f4194d5e" }
-zcash_keys = { git = "https://github.com/valargroup/librustzcash", rev = "644b1ecf4679e17a9166782f57a795a4f4194d5e" }
-zcash_primitives = { git = "https://github.com/valargroup/librustzcash", rev = "644b1ecf4679e17a9166782f57a795a4f4194d5e" }
-zcash_protocol = { git = "https://github.com/valargroup/librustzcash", rev = "644b1ecf4679e17a9166782f57a795a4f4194d5e" }
-zcash_transparent = { git = "https://github.com/valargroup/librustzcash", rev = "644b1ecf4679e17a9166782f57a795a4f4194d5e" }
+pczt = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
+zcash_address = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
+zcash_encoding = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
+zcash_keys = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
+zcash_primitives = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
+zcash_protocol = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
+zcash_transparent = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
+# Redirect every crates.io `orchard` requirement onto the merged
+# unpadded-bundles head so the graph resolves to a single orchard node,
+# matching the pczt pin.
+orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }
 # Use the upstream SDK rev with the Zcash batch registry types until they are published as a crate.
 ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust.git", rev = "0884de4b2e927bc3f95a98dff62045e0d492e574" }

--- a/rust/apps/zcash/Cargo.toml
+++ b/rust/apps/zcash/Cargo.toml
@@ -27,9 +27,13 @@ serde_with = { version = "3.11.0", features = [
 [dev-dependencies]
 keystore = { path = "../../keystore" }
 pczt = { version = "0.7", default-features = false, features = ["orchard", "sapling", "transparent", "zcp-builder"] }
-zcash_primitives = { version = "0.28", default-features = false, features = ["circuits", "test-dependencies", "transparent-inputs"] }
+zcash_primitives = { version = "0.29.0-pre.0", default-features = false, features = ["circuits", "test-dependencies", "transparent-inputs"] }
 incrementalmerkletree = { version = "0.8.2", default-features = false }
 shardtree = "0.6.2"
+# Nameable only so the transparent-only `legacy_test_support` can spell the
+# `BuildConfig::orchard_pool_bundle_type` value; orchard is already built transitively
+# via the `zcash_primitives` dev-dependency.
+orchard = { version = "0.15.0-pre.2", default-features = false }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/rust/apps/zcash/src/errors.rs
+++ b/rust/apps/zcash/src/errors.rs
@@ -30,8 +30,8 @@ impl From<orchard::pczt::ParseError> for ZcashError {
 }
 
 #[cfg(feature = "cypherpunk")]
-impl From<zcash_vendor::pczt::orchard::BundleParseError> for ZcashError {
-    fn from(e: zcash_vendor::pczt::orchard::BundleParseError) -> Self {
+impl From<zcash_vendor::pczt::roles::low_level_signer::OrchardParseError> for ZcashError {
+    fn from(e: zcash_vendor::pczt::roles::low_level_signer::OrchardParseError) -> Self {
         Self::InvalidPczt(alloc::format!("Invalid Orchard bundle: {e:?}"))
     }
 }

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -72,9 +72,14 @@ pub fn check_pczt_cypherpunk<P: consensus::Parameters>(
     seed_fingerprint: &[u8; 32],
     account_index: u32,
 ) -> Result<Vec<u8>> {
-    let pczt = pczt::parse_pczt(pczt_bytes)?;
-    // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
-    // mutating `pczt` so the normalized bytes carry the verified values forward.
+    let mut pczt = pczt::parse_pczt(pczt_bytes)?;
+    // Resolve compact field representations (memo-plaintext ciphertexts,
+    // omitted cv_net) once, up front: the checks below then see complete
+    // actions, and `serialize()` bakes the resolved values into the
+    // normalized bytes so display and signing never re-resolve.
+    pczt.resolve_fields().map_err(|e| {
+        ZcashError::InvalidPczt(alloc::format!("resolve compact PCZT fields: {e:?}"))
+    })?;
     check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
     pczt.serialize()
         .map_err(|e| ZcashError::InvalidPczt(alloc::format!("serialize normalized PCZT: {e:?}")))
@@ -121,9 +126,14 @@ pub fn preflight_batch_pczt_cypherpunk<P: consensus::Parameters>(
     seed_fingerprint: &[u8; 32],
     account_index: u32,
 ) -> Result<Vec<u8>> {
-    let pczt = pczt::parse_pczt(pczt_bytes)?;
-    // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
-    // as in check_pczt_cypherpunk.
+    let mut pczt = pczt::parse_pczt(pczt_bytes)?;
+    // Resolve compact field representations (memo-plaintext ciphertexts,
+    // omitted cv_net) once, up front: the checks below then see complete
+    // actions, and `serialize()` bakes the resolved values into the
+    // normalized bytes so display and signing never re-resolve.
+    pczt.resolve_fields().map_err(|e| {
+        ZcashError::InvalidPczt(alloc::format!("resolve compact PCZT fields: {e:?}"))
+    })?;
     check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
     let account_id = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
@@ -158,6 +168,7 @@ pub fn check_pczt_multi_coins<P: consensus::Parameters>(
     let pczt = pczt::parse_pczt(pczt_bytes)?;
     // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
     // mutating `pczt` so the normalized bytes carry the verified values forward.
+    // transparent-only build: pczt's orchard feature (and resolve_fields) is not compiled here.
     check_parsed_pczt_multi_coins(params, &pczt, xpub, seed_fingerprint, account_index)?;
     pczt.serialize()
         .map_err(|e| ZcashError::InvalidPczt(alloc::format!("serialize normalized PCZT: {e:?}")))
@@ -1495,6 +1506,83 @@ mod tests {
                 ZcashError::PcztNoMyInputs
             );
         }
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_preflight_resolves_compact_pczt_and_signs() {
+        use zcash_vendor::pczt::roles::redactor::Redactor;
+
+        let sample = pczt::test_support::sample_migration_pczt();
+        // Compact the sample the way the wallet's batch redaction will: drop cv_net and
+        // the v6 anchors, and swap each Ironwood output's ciphertext down to its memo
+        // plaintext. `resolve_fields` in the preflight must undo all of it.
+        let compact = {
+            let parsed = Pczt::parse(&sample.bytes).unwrap();
+            let redacted = Redactor::new(parsed)
+                .redact_orchard_with(|mut r| {
+                    r.redact_actions(|mut ar| ar.clear_cv_net());
+                    r.clear_anchor();
+                })
+                .redact_ironwood_with(|mut r| {
+                    r.redact_actions(|mut ar| {
+                        ar.clear_cv_net();
+                        ar.replace_enc_ciphertext_with_decrypted_memo_plaintext(
+                            orchard::note::NoteVersion::V3,
+                        );
+                    });
+                    r.clear_anchor();
+                })
+                .finish();
+            redacted.serialize().unwrap()
+        };
+        assert!(compact.len() < sample.bytes.len());
+        // Confirm the swap actually compacted an Ironwood output (otherwise the
+        // ciphertext round-trip below would be vacuous).
+        assert!(Pczt::parse(&compact)
+            .unwrap()
+            .ironwood()
+            .actions()
+            .iter()
+            .any(|action| matches!(
+                action.output().enc_ciphertext(),
+                ::pczt::orchard::EncCiphertext::MemoPlaintext(_)
+            )));
+
+        let normalized = check_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &compact,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("preflight must resolve compact fields before checking");
+
+        let reparsed = Pczt::parse(&normalized).expect("normalized bytes must parse");
+        assert!(reparsed
+            .orchard()
+            .actions()
+            .iter()
+            .all(|action| action.cv_net().is_some()));
+        // resolve_fields recomputed every Ironwood output's full ciphertext.
+        assert!(reparsed.ironwood().actions().iter().all(|action| matches!(
+            action.output().enc_ciphertext(),
+            ::pczt::orchard::EncCiphertext::Encrypted(_)
+        )));
+        let signed = sign_checked_pczt(
+            &pczt::test_support::Nu6_3Network,
+            &normalized,
+            &sample.seed,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("resolved normalized PCZT must sign");
+        assert!(Pczt::parse(&signed)
+            .unwrap()
+            .orchard()
+            .actions()
+            .iter()
+            .any(|action| action.spend().spend_auth_sig().is_some()));
     }
 
     #[cfg(zcash_unstable = "nu6.3")]

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -722,7 +722,7 @@ fn sign_checked_pczt_with_policy<P: consensus::Parameters>(
     if policy == ShieldedActionPolicy::Batch && signable_actions.is_empty() {
         return Err(ZcashError::PcztNoMyInputs);
     }
-    let signed = pczt::sign::sign_pczt_to_pczt(pczt, seed)?;
+    let signed = pczt::sign::sign_and_redact_pczt(pczt, seed)?;
     let signed = if signable_actions.is_empty() {
         signed
     } else {

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -663,98 +663,6 @@ fn ensure_shielded_actions_are_signed(
     Ok(verifier.finish())
 }
 
-/// Checks whether the PCZT contains at least one non-dummy supported shielded
-/// action that can be signed by the account identified by `seed_fingerprint` and
-/// `account_index`.
-///
-/// `sign_pczt` intentionally returns a redacted PCZT even when no key matched.
-/// Batch signing needs this explicit preflight so one approval cannot silently
-/// produce a result with zero shielded signatures for an entry.
-#[cfg(feature = "cypherpunk")]
-pub fn ensure_pczt_has_signable_shielded_action<P: consensus::Parameters>(
-    params: &P,
-    pczt: &[u8],
-    seed_fingerprint: &[u8; 32],
-    account_index: u32,
-) -> Result<()> {
-    let pczt = pczt::parse_pczt(pczt)?;
-    let account_index = zip32::AccountId::try_from(account_index)
-        .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
-
-    let (signable_actions, _pczt) = signable_shielded_actions(
-        params,
-        pczt,
-        seed_fingerprint,
-        account_index,
-        ShieldedActionPolicy::Batch,
-    )?;
-    if signable_actions.is_empty() {
-        Err(ZcashError::PcztNoMyInputs)
-    } else {
-        Ok(())
-    }
-}
-
-/// Confirms that every signable supported shielded action in `unsigned_pczt`
-/// has a spend authorization signature in the same position in `signed_pczt`.
-#[cfg(feature = "cypherpunk")]
-pub fn ensure_signable_shielded_actions_are_signed<P: consensus::Parameters>(
-    params: &P,
-    unsigned_pczt: &[u8],
-    signed_pczt: &[u8],
-    seed_fingerprint: &[u8; 32],
-    account_index: u32,
-) -> Result<()> {
-    let unsigned_pczt = pczt::parse_pczt(unsigned_pczt)?;
-    let account_index = zip32::AccountId::try_from(account_index)
-        .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
-    let (signable_actions, _pczt) = signable_shielded_actions(
-        params,
-        unsigned_pczt,
-        seed_fingerprint,
-        account_index,
-        ShieldedActionPolicy::Batch,
-    )?;
-    if signable_actions.is_empty() {
-        Err(ZcashError::PcztNoMyInputs)
-    } else {
-        let signed_pczt = pczt::parse_pczt(signed_pczt)
-            .map_err(|_| ZcashError::InvalidPczt("invalid signed pczt data".to_string()))?;
-        ensure_shielded_actions_are_signed(signed_pczt, &signable_actions)?;
-        Ok(())
-    }
-}
-
-/// Confirms that supported shielded actions owned by this account were signed
-/// without applying the batch-only shielded input policy to ordinary PCZTs.
-#[cfg(feature = "cypherpunk")]
-pub fn ensure_owned_supported_shielded_actions_are_signed<P: consensus::Parameters>(
-    params: &P,
-    unsigned_pczt: &[u8],
-    signed_pczt: &[u8],
-    seed_fingerprint: &[u8; 32],
-    account_index: u32,
-) -> Result<()> {
-    let unsigned_pczt = pczt::parse_pczt(unsigned_pczt)?;
-    let account_index = zip32::AccountId::try_from(account_index)
-        .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
-    let (signable_actions, _pczt) = signable_shielded_actions(
-        params,
-        unsigned_pczt,
-        seed_fingerprint,
-        account_index,
-        ShieldedActionPolicy::Single,
-    )?;
-    if signable_actions.is_empty() {
-        Ok(())
-    } else {
-        let signed_pczt = pczt::parse_pczt(signed_pczt)
-            .map_err(|_| ZcashError::InvalidPczt("invalid signed pczt data".to_string()))?;
-        ensure_shielded_actions_are_signed(signed_pczt, &signable_actions)?;
-        Ok(())
-    }
-}
-
 /// Signs a preflight-checked, normalized PCZT and confirms in memory that every
 /// supported shielded action owned by (`seed_fingerprint`, `account_index`)
 /// received a spend authorization signature. Single-transaction policy: a PCZT
@@ -1417,137 +1325,30 @@ mod tests {
 
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
-    fn test_batch_preflight_accepts_orchard_spend() {
-        let sample = pczt::test_support::sample_orchard_change_pczt();
-
-        ensure_pczt_has_signable_shielded_action(
-            &pczt::test_support::Nu6_3Network,
-            &sample.bytes,
-            &sample.seed_fingerprint,
-            0,
-        )
-        .unwrap();
-        assert_eq!(
-            ensure_pczt_has_signable_shielded_action(
-                &pczt::test_support::Nu6_3Network,
-                &sample.bytes,
-                &sample.seed_fingerprint,
-                1,
-            )
-            .unwrap_err(),
-            ZcashError::PcztNoMyInputs
-        );
-    }
-
-    #[cfg(zcash_unstable = "nu6.3")]
-    #[test]
-    fn test_batch_postflight_confirms_orchard_signature() {
-        let sample = pczt::test_support::sample_orchard_change_pczt();
-        let signed = sign_pczt(&sample.bytes, &sample.seed).expect("Orchard PCZT should sign");
-
-        ensure_signable_shielded_actions_are_signed(
-            &pczt::test_support::Nu6_3Network,
-            &sample.bytes,
-            &signed,
-            &sample.seed_fingerprint,
-            0,
-        )
-        .unwrap();
-    }
-
-    #[cfg(zcash_unstable = "nu6.3")]
-    #[test]
-    fn test_single_postflight_confirms_orchard_signature_when_present() {
-        let sample = pczt::test_support::sample_orchard_change_pczt();
-
-        assert!(matches!(
-            ensure_owned_supported_shielded_actions_are_signed(
-                &pczt::test_support::Nu6_3Network,
-                &sample.bytes,
-                &sample.bytes,
-                &sample.seed_fingerprint,
-                0,
-            ),
-            Err(ZcashError::SigningError(message))
-                if message == "signed PCZT is missing an Orchard spend authorization signature"
-        ));
-
-        let signed = sign_pczt(&sample.bytes, &sample.seed).expect("Orchard PCZT should sign");
-        ensure_owned_supported_shielded_actions_are_signed(
-            &pczt::test_support::Nu6_3Network,
-            &sample.bytes,
-            &signed,
-            &sample.seed_fingerprint,
-            0,
-        )
-        .unwrap();
-    }
-
-    #[cfg(zcash_unstable = "nu6.3")]
-    #[test]
-    fn test_batch_preflight_rejects_sapling_outputs() {
-        let sample = pczt_with_sapling_output();
-
-        assert_batch_unsupported_sapling_error(ensure_pczt_has_signable_shielded_action(
-            &pczt::test_support::Nu6_3Network,
-            &sample.bytes,
-            &sample.seed_fingerprint,
-            0,
-        ));
-    }
-
-    #[cfg(zcash_unstable = "nu6.3")]
-    #[test]
-    fn test_batch_postflight_rejects_sapling_outputs() {
-        let sample = pczt_with_sapling_output();
-
-        assert_batch_unsupported_sapling_error(ensure_signable_shielded_actions_are_signed(
-            &pczt::test_support::Nu6_3Network,
-            &sample.bytes,
-            &sample.bytes,
-            &sample.seed_fingerprint,
-            0,
-        ));
-    }
-
-    #[cfg(zcash_unstable = "nu6.3")]
-    #[test]
-    fn test_batch_preflight_accepts_ironwood_spend() {
+    fn test_sign_checked_batch_pczt_signs_ironwood_spend() {
         let sample = pczt::test_support::sample_ironwood_pczt();
-
-        ensure_pczt_has_signable_shielded_action(
+        let normalized = preflight_batch_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
+            &sample.ufvk_text,
             &sample.seed_fingerprint,
             0,
         )
         .unwrap();
-        assert_eq!(
-            ensure_pczt_has_signable_shielded_action(
-                &pczt::test_support::Nu6_3Network,
-                &sample.bytes,
-                &sample.seed_fingerprint,
-                1,
-            )
-            .unwrap_err(),
-            ZcashError::PcztNoMyInputs
-        );
-    }
-
-    #[cfg(zcash_unstable = "nu6.3")]
-    #[test]
-    fn test_batch_postflight_confirms_ironwood_signature() {
-        let sample = pczt::test_support::sample_ironwood_pczt();
-        let signed = sign_pczt(&sample.bytes, &sample.seed).expect("Ironwood PCZT should sign");
-
-        ensure_signable_shielded_actions_are_signed(
+        let signed = sign_checked_batch_pczt(
             &pczt::test_support::Nu6_3Network,
-            &sample.bytes,
-            &signed,
+            &normalized,
+            &sample.seed,
             &sample.seed_fingerprint,
             0,
         )
         .unwrap();
+        assert!(Pczt::parse(&signed)
+            .unwrap()
+            .ironwood()
+            .actions()
+            .iter()
+            .any(|action| action.spend().spend_auth_sig().is_some()));
     }
 
     #[cfg(zcash_unstable = "nu6.3")]

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -733,13 +733,11 @@ mod tests {
     use super::*;
     extern crate std;
 
-    // Head of the v2 PCZT wire layout (`pczt::Pczt`'s v2 encoding), up to and including
-    // the Sapling bundle; empty bundles are omitted (`None`). The trailing Orchard and
-    // Ironwood bundles are captured as raw bytes via `postcard::take_from_bytes` and
-    // re-appended unchanged, so these fixtures only decode the fields at/before the one
-    // they mutate and never need the crate-private `orchard::v2::Bundle` layout.
+    // Test-only decoder for the v2 postcard prefix these fixtures mutate. The
+    // trailing Orchard and Ironwood bundles use private wire types, so callers
+    // preserve those bytes unchanged via `postcard::take_from_bytes`.
     #[derive(Serialize, Deserialize)]
-    struct PcztHead {
+    struct PcztWirePrefix {
         global: GlobalMirror,
         transparent: Option<::pczt::transparent::Bundle>,
         sapling: Option<SaplingBundleMirror>,
@@ -805,13 +803,13 @@ mod tests {
             .ironwood()
             .actions()
             .is_empty());
-        let (mut head, rest) = postcard::take_from_bytes::<PcztHead>(&bytes[8..]).unwrap();
+        let (mut prefix, rest) = postcard::take_from_bytes::<PcztWirePrefix>(&bytes[8..]).unwrap();
 
-        head.global.tx_version = constants::V5_TX_VERSION;
-        head.global.version_group_id = constants::V5_VERSION_GROUP_ID;
+        prefix.global.tx_version = constants::V5_TX_VERSION;
+        prefix.global.version_group_id = constants::V5_VERSION_GROUP_ID;
 
         let mut out = bytes[..8].to_vec();
-        out = postcard::to_extend(&head, out).unwrap();
+        out = postcard::to_extend(&prefix, out).unwrap();
         out.extend_from_slice(rest);
         out
     }
@@ -838,11 +836,11 @@ mod tests {
         .build()
         .serialize()
         .unwrap();
-        let (mut head, rest) = postcard::take_from_bytes::<PcztHead>(&bytes[8..]).unwrap();
+        let (mut prefix, rest) = postcard::take_from_bytes::<PcztWirePrefix>(&bytes[8..]).unwrap();
         // v2 omits empty bundles, so the freshly created PCZT has no Sapling bundle.
         // Attach one that is empty except for a non-zero value sum, which `check` rejects.
-        assert!(head.sapling.is_none());
-        head.sapling = Some(SaplingBundleMirror {
+        assert!(prefix.sapling.is_none());
+        prefix.sapling = Some(SaplingBundleMirror {
             spends: Vec::new(),
             outputs: Vec::new(),
             value_sum: 1,
@@ -851,7 +849,7 @@ mod tests {
         });
 
         let mut out = bytes[..8].to_vec();
-        out = postcard::to_extend(&head, out).unwrap();
+        out = postcard::to_extend(&prefix, out).unwrap();
         out.extend_from_slice(rest);
         out
     }
@@ -1293,10 +1291,11 @@ mod tests {
     #[cfg(zcash_unstable = "nu6.3")]
     fn pczt_with_sapling_output() -> pczt::test_support::SamplePczt {
         let mut sample = pczt::test_support::sample_orchard_change_pczt();
-        let (mut head, rest) = postcard::take_from_bytes::<PcztHead>(&sample.bytes[8..]).unwrap();
+        let (mut prefix, rest) =
+            postcard::take_from_bytes::<PcztWirePrefix>(&sample.bytes[8..]).unwrap();
         // The orchard-change sample carries no Sapling bundle (v2 omits it); synthesize one
         // with a single output and negative value sum so the batch check rejects it.
-        let mut sapling = head.sapling.take().unwrap_or(SaplingBundleMirror {
+        let mut sapling = prefix.sapling.take().unwrap_or(SaplingBundleMirror {
             spends: Vec::new(),
             outputs: Vec::new(),
             value_sum: 0,
@@ -1320,10 +1319,10 @@ mod tests {
             proprietary: BTreeMap::new(),
         });
         sapling.value_sum = -1;
-        head.sapling = Some(sapling);
+        prefix.sapling = Some(sapling);
 
         let mut out = sample.bytes[..8].to_vec();
-        out = postcard::to_extend(&head, out).unwrap();
+        out = postcard::to_extend(&prefix, out).unwrap();
         out.extend_from_slice(rest);
         sample.bytes = out;
         sample

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -556,7 +556,7 @@ fn signable_shielded_actions<P: consensus::Parameters>(
     seed_fingerprint: &[u8; 32],
     account_index: zip32::AccountId,
     policy: ShieldedActionPolicy,
-) -> Result<Vec<SignableShieldedAction>> {
+) -> Result<(Vec<SignableShieldedAction>, Pczt)> {
     use zcash_vendor::pczt::roles::verifier::Verifier;
 
     if policy == ShieldedActionPolicy::Batch {
@@ -598,16 +598,16 @@ fn signable_shielded_actions<P: consensus::Parameters>(
     } else {
         verifier
     };
-    drop(verifier);
+    let pczt = verifier.finish();
 
-    Ok(actions)
+    Ok((actions, pczt))
 }
 
 #[cfg(feature = "cypherpunk")]
 fn ensure_shielded_actions_are_signed(
     signed_pczt: Pczt,
     signable_actions: &[SignableShieldedAction],
-) -> Result<()> {
+) -> Result<Pczt> {
     use zcash_vendor::pczt::roles::verifier::Verifier;
 
     #[cfg(zcash_unstable = "nu6.3")]
@@ -628,9 +628,8 @@ fn ensure_shielded_actions_are_signed(
     } else {
         verifier
     };
-    drop(verifier);
 
-    Ok(())
+    Ok(verifier.finish())
 }
 
 /// Checks whether the PCZT contains at least one non-dummy supported shielded
@@ -651,15 +650,14 @@ pub fn ensure_pczt_has_signable_shielded_action<P: consensus::Parameters>(
     let account_index = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
 
-    if signable_shielded_actions(
+    let (signable_actions, _pczt) = signable_shielded_actions(
         params,
         pczt,
         seed_fingerprint,
         account_index,
         ShieldedActionPolicy::Batch,
-    )?
-    .is_empty()
-    {
+    )?;
+    if signable_actions.is_empty() {
         Err(ZcashError::PcztNoMyInputs)
     } else {
         Ok(())
@@ -679,7 +677,7 @@ pub fn ensure_signable_shielded_actions_are_signed<P: consensus::Parameters>(
     let unsigned_pczt = pczt::parse_pczt(unsigned_pczt)?;
     let account_index = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
-    let signable_actions = signable_shielded_actions(
+    let (signable_actions, _pczt) = signable_shielded_actions(
         params,
         unsigned_pczt,
         seed_fingerprint,
@@ -691,7 +689,8 @@ pub fn ensure_signable_shielded_actions_are_signed<P: consensus::Parameters>(
     } else {
         let signed_pczt = pczt::parse_pczt(signed_pczt)
             .map_err(|_| ZcashError::InvalidPczt("invalid signed pczt data".to_string()))?;
-        ensure_shielded_actions_are_signed(signed_pczt, &signable_actions)
+        ensure_shielded_actions_are_signed(signed_pczt, &signable_actions)?;
+        Ok(())
     }
 }
 
@@ -708,7 +707,7 @@ pub fn ensure_owned_supported_shielded_actions_are_signed<P: consensus::Paramete
     let unsigned_pczt = pczt::parse_pczt(unsigned_pczt)?;
     let account_index = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
-    let signable_actions = signable_shielded_actions(
+    let (signable_actions, _pczt) = signable_shielded_actions(
         params,
         unsigned_pczt,
         seed_fingerprint,
@@ -720,8 +719,83 @@ pub fn ensure_owned_supported_shielded_actions_are_signed<P: consensus::Paramete
     } else {
         let signed_pczt = pczt::parse_pczt(signed_pczt)
             .map_err(|_| ZcashError::InvalidPczt("invalid signed pczt data".to_string()))?;
-        ensure_shielded_actions_are_signed(signed_pczt, &signable_actions)
+        ensure_shielded_actions_are_signed(signed_pczt, &signable_actions)?;
+        Ok(())
     }
+}
+
+/// Signs a preflight-checked, normalized PCZT and confirms in memory that every
+/// supported shielded action owned by (`seed_fingerprint`, `account_index`)
+/// received a spend authorization signature. Single-transaction policy: a PCZT
+/// with no owned shielded action still signs if any action matched the seed.
+/// Parses `checked_pczt` exactly once and returns the redacted, version-stamped
+/// response bytes.
+#[cfg(feature = "cypherpunk")]
+pub fn sign_checked_pczt<P: consensus::Parameters>(
+    params: &P,
+    checked_pczt: &[u8],
+    seed: &[u8],
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<Vec<u8>> {
+    sign_checked_pczt_with_policy(
+        params,
+        checked_pczt,
+        seed,
+        seed_fingerprint,
+        account_index,
+        ShieldedActionPolicy::Single,
+    )
+}
+
+/// Signs a preflight-checked, normalized PCZT and confirms in memory that every
+/// supported shielded action owned by (`seed_fingerprint`, `account_index`)
+/// received a spend authorization signature. Batch policy: additionally rejects
+/// PCZT shapes the batch flow does not support and requires at least one owned
+/// signable shielded action. Parses `checked_pczt` exactly once and returns the
+/// redacted, version-stamped response bytes.
+#[cfg(feature = "cypherpunk")]
+pub fn sign_checked_batch_pczt<P: consensus::Parameters>(
+    params: &P,
+    checked_pczt: &[u8],
+    seed: &[u8],
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<Vec<u8>> {
+    sign_checked_pczt_with_policy(
+        params,
+        checked_pczt,
+        seed,
+        seed_fingerprint,
+        account_index,
+        ShieldedActionPolicy::Batch,
+    )
+}
+
+#[cfg(feature = "cypherpunk")]
+fn sign_checked_pczt_with_policy<P: consensus::Parameters>(
+    params: &P,
+    checked_pczt: &[u8],
+    seed: &[u8],
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+    policy: ShieldedActionPolicy,
+) -> Result<Vec<u8>> {
+    let pczt = pczt::parse_pczt(checked_pczt)?;
+    let account_index = zip32::AccountId::try_from(account_index)
+        .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
+    let (signable_actions, pczt) =
+        signable_shielded_actions(params, pczt, seed_fingerprint, account_index, policy)?;
+    if policy == ShieldedActionPolicy::Batch && signable_actions.is_empty() {
+        return Err(ZcashError::PcztNoMyInputs);
+    }
+    let signed = pczt::sign::sign_pczt_to_pczt(pczt, seed)?;
+    let signed = if signable_actions.is_empty() {
+        signed
+    } else {
+        ensure_shielded_actions_are_signed(signed, &signable_actions)?
+    };
+    Ok(signed.serialize())
 }
 
 #[cfg(feature = "cypherpunk")]
@@ -1443,5 +1517,104 @@ mod tests {
             0,
         )
         .unwrap();
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_sign_checked_pczt_signs_owned_orchard_actions() {
+        let sample = pczt::test_support::sample_orchard_change_pczt();
+        let normalized = preflight_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+
+        let signed = sign_checked_pczt(
+            &pczt::test_support::Nu6_3Network,
+            &normalized,
+            &sample.seed,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+
+        let parsed = Pczt::parse(&signed).expect("signed PCZT must parse");
+        let signed_actions = parsed
+            .orchard()
+            .actions()
+            .iter()
+            .filter(|action| action.spend().spend_auth_sig().is_some())
+            .count();
+        assert_eq!(signed_actions, 2);
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_sign_checked_pczt_rejects_foreign_seed() {
+        let sample = pczt::test_support::sample_orchard_change_pczt();
+        let normalized = preflight_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+        let foreign_seed = [9u8; 32];
+        let foreign_fingerprint = calculate_seed_fingerprint(&foreign_seed).unwrap();
+
+        let result = sign_checked_pczt(
+            &pczt::test_support::Nu6_3Network,
+            &normalized,
+            &foreign_seed,
+            &foreign_fingerprint,
+            0,
+        );
+        assert!(matches!(result, Err(ZcashError::PcztNoMyInputs)));
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_sign_checked_batch_pczt_signs_and_rejects_sapling() {
+        let sample = pczt::test_support::sample_orchard_change_pczt();
+        let signed = sign_checked_batch_pczt(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.seed,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+        assert!(Pczt::parse(&signed)
+            .unwrap()
+            .orchard()
+            .actions()
+            .iter()
+            .any(|action| action.spend().spend_auth_sig().is_some()));
+
+        // Batch policy: account 1 owns nothing in this PCZT.
+        assert_eq!(
+            sign_checked_batch_pczt(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.seed,
+                &sample.seed_fingerprint,
+                1,
+            )
+            .unwrap_err(),
+            ZcashError::PcztNoMyInputs
+        );
+
+        let sapling_sample = pczt_with_sapling_output();
+        assert_batch_unsupported_sapling_error(sign_checked_batch_pczt(
+            &pczt::test_support::Nu6_3Network,
+            &sapling_sample.bytes,
+            &sapling_sample.seed,
+            &sapling_sample.seed_fingerprint,
+            0,
+        ));
     }
 }

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -122,6 +122,37 @@ pub fn preflight_pczt_cypherpunk<P: consensus::Parameters>(
     Ok(pczt.serialize())
 }
 
+/// Batch preflight for one `ZcashSignBatch` message: parses once, runs the full
+/// policy checks, enforces the batch shielded-action policy (the PCZT must be
+/// batch-signable by this account), and returns the normalized encoding. See
+/// `preflight_pczt_cypherpunk` for the normalization contract.
+#[cfg(feature = "cypherpunk")]
+pub fn preflight_batch_pczt_cypherpunk<P: consensus::Parameters>(
+    params: &P,
+    pczt_bytes: &[u8],
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<Vec<u8>> {
+    let pczt = pczt::parse_pczt(pczt_bytes)?;
+    // FUTURE(qr-v2-omitted-fields): recompute-or-check omitted fields here, as
+    // in preflight_pczt_cypherpunk.
+    check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
+    let account_id = zip32::AccountId::try_from(account_index)
+        .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
+    let (actions, pczt) = signable_shielded_actions(
+        params,
+        pczt,
+        seed_fingerprint,
+        account_id,
+        ShieldedActionPolicy::Batch,
+    )?;
+    if actions.is_empty() {
+        return Err(ZcashError::PcztNoMyInputs);
+    }
+    Ok(pczt.serialize())
+}
+
 #[cfg(feature = "multi_coins")]
 pub fn check_pczt_multi_coins<P: consensus::Parameters>(
     params: &P,
@@ -1614,6 +1645,51 @@ mod tests {
             &sapling_sample.bytes,
             &sapling_sample.seed,
             &sapling_sample.seed_fingerprint,
+            0,
+        ));
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_preflight_batch_pczt_accepts_orchard_and_ironwood_spends() {
+        for sample in [
+            pczt::test_support::sample_orchard_change_pczt(),
+            pczt::test_support::sample_ironwood_pczt(),
+        ] {
+            let normalized = preflight_batch_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                0,
+            )
+            .unwrap();
+            assert!(Pczt::parse(&normalized).is_ok());
+
+            // Account 1 owns nothing in these PCZTs: batch policy rejects.
+            assert_eq!(
+                preflight_batch_pczt_cypherpunk(
+                    &pczt::test_support::Nu6_3Network,
+                    &sample.bytes,
+                    &sample.ufvk_text,
+                    &sample.seed_fingerprint,
+                    1,
+                )
+                .unwrap_err(),
+                ZcashError::PcztNoMyInputs
+            );
+        }
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_preflight_batch_pczt_rejects_sapling_outputs() {
+        let sample = pczt_with_sapling_output();
+        assert_batch_unsupported_sapling_error(preflight_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
             0,
         ));
     }

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -72,46 +72,14 @@ pub fn check_pczt_cypherpunk<P: consensus::Parameters>(
     seed_fingerprint: &[u8; 32],
     account_index: u32,
 ) -> Result<Vec<u8>> {
-    let mut pczt = pczt::parse_pczt(pczt_bytes)?;
-    // Resolve compact field representations (memo-plaintext ciphertexts,
-    // omitted cv_net) once, up front: the checks below then see complete
-    // actions, and `serialize()` bakes the resolved values into the
-    // normalized bytes so display and signing never re-resolve.
-    pczt.resolve_fields().map_err(|e| {
-        ZcashError::InvalidPczt(alloc::format!("resolve compact PCZT fields: {e:?}"))
-    })?;
-    check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
-    pczt.serialize()
-        .map_err(|e| ZcashError::InvalidPczt(alloc::format!("serialize normalized PCZT: {e:?}")))
-}
-
-/// `check_pczt_cypherpunk` against an already-parsed PCZT, so callers can parse
-/// once and reuse the parsed value for normalization.
-#[cfg(feature = "cypherpunk")]
-fn check_parsed_pczt_cypherpunk<P: consensus::Parameters>(
-    params: &P,
-    pczt: &Pczt,
-    ufvk_text: &str,
-    seed_fingerprint: &[u8; 32],
-    account_index: u32,
-) -> Result<()> {
-    let account_index = zip32::AccountId::try_from(account_index)
-        .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
-    let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
-        .map_err(|e| ZcashError::InvalidDataError(e.to_string()))?;
-    let xpub = ufvk.transparent().ok_or(ZcashError::InvalidDataError(
-        "transparent xpub is not present".to_string(),
-    ))?;
-    pczt::check::check_pczt_orchard(params, seed_fingerprint, account_index, &ufvk, pczt)?;
-    pczt::check::check_pczt_transparent(
+    check_pczt_cypherpunk_with_policy(
         params,
+        pczt_bytes,
+        ufvk_text,
         seed_fingerprint,
         account_index,
-        xpub,
-        pczt,
-        false,
-    )?;
-    Ok(())
+        ShieldedActionPolicy::Single,
+    )
 }
 
 /// Batch check for one `ZcashSignBatch` message: parses once, runs the full
@@ -126,6 +94,25 @@ pub fn check_batch_pczt_cypherpunk<P: consensus::Parameters>(
     seed_fingerprint: &[u8; 32],
     account_index: u32,
 ) -> Result<Vec<u8>> {
+    check_pczt_cypherpunk_with_policy(
+        params,
+        pczt_bytes,
+        ufvk_text,
+        seed_fingerprint,
+        account_index,
+        ShieldedActionPolicy::Batch,
+    )
+}
+
+#[cfg(feature = "cypherpunk")]
+fn check_pczt_cypherpunk_with_policy<P: consensus::Parameters>(
+    params: &P,
+    pczt_bytes: &[u8],
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+    policy: ShieldedActionPolicy,
+) -> Result<Vec<u8>> {
     let mut pczt = pczt::parse_pczt(pczt_bytes)?;
     // Resolve compact field representations (memo-plaintext ciphertexts,
     // omitted cv_net) once, up front: the checks below then see complete
@@ -134,19 +121,36 @@ pub fn check_batch_pczt_cypherpunk<P: consensus::Parameters>(
     pczt.resolve_fields().map_err(|e| {
         ZcashError::InvalidPczt(alloc::format!("resolve compact PCZT fields: {e:?}"))
     })?;
-    check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
-    let account_id = zip32::AccountId::try_from(account_index)
+
+    let account_index = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
-    let (actions, pczt) = signable_shielded_actions(
+    let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
+        .map_err(|e| ZcashError::InvalidDataError(e.to_string()))?;
+    let xpub = ufvk.transparent().ok_or(ZcashError::InvalidDataError(
+        "transparent xpub is not present".to_string(),
+    ))?;
+    pczt::check::check_pczt_orchard(params, seed_fingerprint, account_index, &ufvk, &pczt)?;
+    pczt::check::check_pczt_transparent(
         params,
-        pczt,
         seed_fingerprint,
-        account_id,
-        ShieldedActionPolicy::Batch,
+        account_index,
+        xpub,
+        &pczt,
+        false,
     )?;
-    if actions.is_empty() {
-        return Err(ZcashError::PcztNoMyInputs);
-    }
+
+    let pczt = match policy {
+        ShieldedActionPolicy::Single => pczt,
+        ShieldedActionPolicy::Batch => {
+            let (actions, pczt) =
+                signable_shielded_actions(params, pczt, seed_fingerprint, account_index, policy)?;
+            if actions.is_empty() {
+                return Err(ZcashError::PcztNoMyInputs);
+            }
+            pczt
+        }
+    };
+
     pczt.serialize()
         .map_err(|e| ZcashError::InvalidPczt(alloc::format!("serialize normalized PCZT: {e:?}")))
 }
@@ -169,22 +173,7 @@ pub fn check_pczt_multi_coins<P: consensus::Parameters>(
     // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
     // mutating `pczt` so the normalized bytes carry the verified values forward.
     // transparent-only build: pczt's orchard feature (and resolve_fields) is not compiled here.
-    check_parsed_pczt_multi_coins(params, &pczt, xpub, seed_fingerprint, account_index)?;
-    pczt.serialize()
-        .map_err(|e| ZcashError::InvalidPczt(alloc::format!("serialize normalized PCZT: {e:?}")))
-}
-
-/// `check_pczt_multi_coins` against an already-parsed PCZT, so callers can
-/// parse once and reuse the parsed value for normalization.
-#[cfg(feature = "multi_coins")]
-fn check_parsed_pczt_multi_coins<P: consensus::Parameters>(
-    params: &P,
-    pczt: &Pczt,
-    xpub: &str,
-    seed_fingerprint: &[u8; 32],
-    account_index: u32,
-) -> Result<()> {
-    reject_legacy_check_unsupported_pczt(pczt)?;
+    reject_legacy_check_unsupported_pczt(&pczt)?;
     let account_pubkey = transparent_account_pubkey_from_xpub(xpub)?;
     let account_index = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
@@ -194,10 +183,11 @@ fn check_parsed_pczt_multi_coins<P: consensus::Parameters>(
         seed_fingerprint,
         account_index,
         &account_pubkey,
-        pczt,
+        &pczt,
         true,
     )?;
-    Ok(())
+    pczt.serialize()
+        .map_err(|e| ZcashError::InvalidPczt(alloc::format!("serialize normalized PCZT: {e:?}")))
 }
 
 #[cfg(feature = "multi_coins")]

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -114,12 +114,12 @@ fn check_parsed_pczt_cypherpunk<P: consensus::Parameters>(
     Ok(())
 }
 
-/// Batch preflight for one `ZcashSignBatch` message: parses once, runs the full
+/// Batch check for one `ZcashSignBatch` message: parses once, runs the full
 /// policy checks, enforces the batch shielded-action policy (the PCZT must be
 /// batch-signable by this account), and returns the normalized encoding. See
 /// `check_pczt_cypherpunk` for the normalization contract.
 #[cfg(feature = "cypherpunk")]
-pub fn preflight_batch_pczt_cypherpunk<P: consensus::Parameters>(
+pub fn check_batch_pczt_cypherpunk<P: consensus::Parameters>(
     params: &P,
     pczt_bytes: &[u8],
     ufvk_text: &str,
@@ -369,7 +369,7 @@ mod legacy_tests {
             &sample.seed_fingerprint,
             0,
         )
-        .expect("selected account PCZT should preflight");
+        .expect("selected account PCZT should pass the check");
         assert!(
             parse_pczt_multi_coins(&MainNetwork, &normalized, &sample.seed_fingerprint).is_ok()
         );
@@ -657,7 +657,7 @@ fn ensure_shielded_actions_are_signed(
     Ok(verifier.finish())
 }
 
-/// Signs a preflight-checked, normalized PCZT and confirms in memory that every
+/// Signs a checked, normalized PCZT and confirms in memory that every
 /// supported shielded action owned by (`seed_fingerprint`, `account_index`)
 /// received a spend authorization signature. Single-transaction policy: a PCZT
 /// with no owned shielded action still signs if any action matched the seed.
@@ -681,7 +681,7 @@ pub fn sign_checked_pczt<P: consensus::Parameters>(
     )
 }
 
-/// Signs a preflight-checked, normalized PCZT and confirms in memory that every
+/// Signs a checked, normalized PCZT and confirms in memory that every
 /// supported shielded action owned by (`seed_fingerprint`, `account_index`)
 /// received a spend authorization signature. Batch policy: additionally rejects
 /// PCZT shapes the batch flow does not support and requires at least one owned
@@ -1353,7 +1353,7 @@ mod tests {
     #[test]
     fn test_sign_checked_batch_pczt_signs_ironwood_spend() {
         let sample = pczt::test_support::sample_ironwood_pczt();
-        let normalized = preflight_batch_pczt_cypherpunk(
+        let normalized = check_batch_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
             &sample.ufvk_text,
@@ -1478,12 +1478,12 @@ mod tests {
 
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
-    fn test_preflight_batch_pczt_accepts_orchard_and_ironwood_spends() {
+    fn test_check_batch_pczt_accepts_orchard_and_ironwood_spends() {
         for sample in [
             pczt::test_support::sample_orchard_change_pczt(),
             pczt::test_support::sample_ironwood_pczt(),
         ] {
-            let normalized = preflight_batch_pczt_cypherpunk(
+            let normalized = check_batch_pczt_cypherpunk(
                 &pczt::test_support::Nu6_3Network,
                 &sample.bytes,
                 &sample.ufvk_text,
@@ -1495,7 +1495,7 @@ mod tests {
 
             // Account 1 owns nothing in these PCZTs: batch policy rejects.
             assert_eq!(
-                preflight_batch_pczt_cypherpunk(
+                check_batch_pczt_cypherpunk(
                     &pczt::test_support::Nu6_3Network,
                     &sample.bytes,
                     &sample.ufvk_text,
@@ -1510,13 +1510,13 @@ mod tests {
 
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
-    fn test_preflight_resolves_compact_pczt_and_signs() {
+    fn test_check_resolves_compact_pczt_and_signs() {
         use zcash_vendor::pczt::roles::redactor::Redactor;
 
         let sample = pczt::test_support::sample_migration_pczt();
         // Compact the sample the way the wallet's batch redaction will: drop cv_net and
         // the v6 anchors, and swap each Ironwood output's ciphertext down to its memo
-        // plaintext. `resolve_fields` in the preflight must undo all of it.
+        // plaintext. `resolve_fields` in the check must undo all of it.
         let compact = {
             let parsed = Pczt::parse(&sample.bytes).unwrap();
             let redacted = Redactor::new(parsed)
@@ -1556,7 +1556,7 @@ mod tests {
             &sample.seed_fingerprint,
             0,
         )
-        .expect("preflight must resolve compact fields before checking");
+        .expect("the check must resolve compact fields first");
 
         let reparsed = Pczt::parse(&normalized).expect("normalized bytes must parse");
         assert!(reparsed
@@ -1587,9 +1587,9 @@ mod tests {
 
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
-    fn test_preflight_batch_pczt_rejects_sapling_outputs() {
+    fn test_check_batch_pczt_rejects_sapling_outputs() {
         let sample = pczt_with_sapling_output();
-        assert_batch_unsupported_sapling_error(preflight_batch_pczt_cypherpunk(
+        assert_batch_unsupported_sapling_error(check_batch_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
             &sample.ufvk_text,

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -381,7 +381,9 @@ mod legacy_tests {
             0,
         )
         .expect("selected account PCZT should preflight");
-        assert!(parse_pczt_multi_coins(&MainNetwork, &normalized, &sample.seed_fingerprint).is_ok());
+        assert!(
+            parse_pczt_multi_coins(&MainNetwork, &normalized, &sample.seed_fingerprint).is_ok()
+        );
 
         let account_one_pczt =
             pczt::legacy_test_support::legacy_transparent_pczt_with_input_derivation(

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -45,36 +45,42 @@ pub fn get_address<P: consensus::Parameters>(params: &P, ufvk_text: &str) -> Res
     Ok(address.encode(params))
 }
 
-/// Validates a Partially Created Zcash Transaction (PCZT) against a Unified Full Viewing Key.
+/// Parses a PCZT, checks policy, and serializes it again in one pass.
 ///
 /// # Parameters
 /// * `params` - The consensus parameters for the Zcash network (mainnet or testnet)
-/// * `pczt` - The binary representation of the PCZT to validate
+/// * `pczt_bytes` - The binary representation of the PCZT to validate
 /// * `ufvk_text` - The string representation of the Unified Full Viewing Key
 /// * `seed_fingerprint` - A 32-byte fingerprint of the seed used to derive keys
 /// * `account_index` - The account index for the keys to check against
 ///
 /// # Returns
-/// * `Result<()>` - Ok if the PCZT is valid for the given UFVK, or an error otherwise
+/// * `Result<Vec<u8>>` - The normalized encoding of the checked PCZT
 ///
 /// # Errors
 /// * `ZcashError::InvalidDataError` - If the UFVK cannot be decoded or the account index is invalid
 /// * `ZcashError::InvalidPczt` - If the PCZT data is malformed or cannot be parsed
 /// * Other errors from the underlying validation process
+///
+/// The returned bytes are what C retains as the `checked_PCZT`, which display
+/// and signing consume without re-running these checks.
 #[cfg(feature = "cypherpunk")]
 pub fn check_pczt_cypherpunk<P: consensus::Parameters>(
     params: &P,
-    pczt: &[u8],
+    pczt_bytes: &[u8],
     ufvk_text: &str,
     seed_fingerprint: &[u8; 32],
     account_index: u32,
-) -> Result<()> {
-    let pczt = pczt::parse_pczt(pczt)?;
-    check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)
+) -> Result<Vec<u8>> {
+    let pczt = pczt::parse_pczt(pczt_bytes)?;
+    // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
+    // mutating `pczt` so the normalized bytes carry the verified values forward.
+    check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
+    Ok(pczt.serialize())
 }
 
-/// `check_pczt_cypherpunk` against an already-parsed PCZT, so preflight can
-/// parse once and reuse the parsed value for normalization.
+/// `check_pczt_cypherpunk` against an already-parsed PCZT, so callers can parse
+/// once and reuse the parsed value for normalization.
 #[cfg(feature = "cypherpunk")]
 fn check_parsed_pczt_cypherpunk<P: consensus::Parameters>(
     params: &P,
@@ -102,30 +108,10 @@ fn check_parsed_pczt_cypherpunk<P: consensus::Parameters>(
     Ok(())
 }
 
-/// Parses, policy-checks, and re-serializes a PCZT in one pass.
-///
-/// Returns the normalized (current-version) encoding of the checked PCZT: the
-/// bytes C retains as the `checked_PCZT`, which display and signing consume
-/// without re-running these checks.
-#[cfg(feature = "cypherpunk")]
-pub fn preflight_pczt_cypherpunk<P: consensus::Parameters>(
-    params: &P,
-    pczt_bytes: &[u8],
-    ufvk_text: &str,
-    seed_fingerprint: &[u8; 32],
-    account_index: u32,
-) -> Result<Vec<u8>> {
-    let pczt = pczt::parse_pczt(pczt_bytes)?;
-    // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
-    // mutating `pczt` so the normalized bytes carry the verified values forward.
-    check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
-    Ok(pczt.serialize())
-}
-
 /// Batch preflight for one `ZcashSignBatch` message: parses once, runs the full
 /// policy checks, enforces the batch shielded-action policy (the PCZT must be
 /// batch-signable by this account), and returns the normalized encoding. See
-/// `preflight_pczt_cypherpunk` for the normalization contract.
+/// `check_pczt_cypherpunk` for the normalization contract.
 #[cfg(feature = "cypherpunk")]
 pub fn preflight_batch_pczt_cypherpunk<P: consensus::Parameters>(
     params: &P,
@@ -136,7 +122,7 @@ pub fn preflight_batch_pczt_cypherpunk<P: consensus::Parameters>(
 ) -> Result<Vec<u8>> {
     let pczt = pczt::parse_pczt(pczt_bytes)?;
     // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
-    // as in preflight_pczt_cypherpunk.
+    // as in check_pczt_cypherpunk.
     check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
     let account_id = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
@@ -153,19 +139,28 @@ pub fn preflight_batch_pczt_cypherpunk<P: consensus::Parameters>(
     Ok(pczt.serialize())
 }
 
+/// Parses a multi-coins PCZT, checks policy, and serializes it again in one
+/// pass.
+///
+/// Returns the normalized encoding of the checked PCZT. The returned bytes are
+/// what C retains as the `checked_PCZT`, which display and signing consume
+/// without re-running these checks.
 #[cfg(feature = "multi_coins")]
 pub fn check_pczt_multi_coins<P: consensus::Parameters>(
     params: &P,
-    pczt: &[u8],
+    pczt_bytes: &[u8],
     xpub: &str,
     seed_fingerprint: &[u8; 32],
     account_index: u32,
-) -> Result<()> {
-    let pczt = pczt::parse_pczt(pczt)?;
-    check_parsed_pczt_multi_coins(params, &pczt, xpub, seed_fingerprint, account_index)
+) -> Result<Vec<u8>> {
+    let pczt = pczt::parse_pczt(pczt_bytes)?;
+    // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
+    // mutating `pczt` so the normalized bytes carry the verified values forward.
+    check_parsed_pczt_multi_coins(params, &pczt, xpub, seed_fingerprint, account_index)?;
+    Ok(pczt.serialize())
 }
 
-/// `check_pczt_multi_coins` against an already-parsed PCZT, so preflight can
+/// `check_pczt_multi_coins` against an already-parsed PCZT, so callers can
 /// parse once and reuse the parsed value for normalization.
 #[cfg(feature = "multi_coins")]
 fn check_parsed_pczt_multi_coins<P: consensus::Parameters>(
@@ -189,26 +184,6 @@ fn check_parsed_pczt_multi_coins<P: consensus::Parameters>(
         true,
     )?;
     Ok(())
-}
-
-/// Parses, policy-checks, and re-serializes a PCZT in one pass.
-///
-/// Returns the normalized (current-version) encoding of the checked PCZT: the
-/// bytes C retains as the `checked_PCZT`, which display and signing consume
-/// without re-running these checks.
-#[cfg(feature = "multi_coins")]
-pub fn preflight_pczt_multi_coins<P: consensus::Parameters>(
-    params: &P,
-    pczt_bytes: &[u8],
-    xpub: &str,
-    seed_fingerprint: &[u8; 32],
-    account_index: u32,
-) -> Result<Vec<u8>> {
-    let pczt = pczt::parse_pczt(pczt_bytes)?;
-    // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
-    // mutating `pczt` so the normalized bytes carry the verified values forward.
-    check_parsed_pczt_multi_coins(params, &pczt, xpub, seed_fingerprint, account_index)?;
-    Ok(pczt.serialize())
 }
 
 #[cfg(feature = "multi_coins")]
@@ -373,7 +348,7 @@ mod legacy_tests {
         )
         .expect("selected account PCZT should check");
 
-        let normalized = preflight_pczt_multi_coins(
+        let normalized = check_pczt_multi_coins(
             &MainNetwork,
             &sample.bytes,
             &sample.xpub,
@@ -866,7 +841,8 @@ mod tests {
         let ufvk = derive_ufvk(&MainNetwork, &seed, "m/32'/133'/0'").unwrap();
         let seed_fingerprint = calculate_seed_fingerprint(&seed).unwrap();
 
-        let result = check_pczt_cypherpunk(&MainNetwork, &malformed_pczt, &ufvk, &seed_fingerprint, 0);
+        let result =
+            check_pczt_cypherpunk(&MainNetwork, &malformed_pczt, &ufvk, &seed_fingerprint, 0);
 
         assert_invalid_pczt_message(
             result,
@@ -981,11 +957,6 @@ mod tests {
         match check_pczt_cypherpunk(&params, &pczt_bytes, &ufvk_text, &seed_fingerprint, 0) {
             Err(ZcashError::InvalidPczt(msg)) if msg.contains(expected) => {}
             other => panic!("check must reject internal-OVK change spoofing, got: {other:?}"),
-        }
-
-        match preflight_pczt_cypherpunk(&params, &pczt_bytes, &ufvk_text, &seed_fingerprint, 0) {
-            Err(ZcashError::InvalidPczt(msg)) if msg.contains(expected) => {}
-            other => panic!("preflight must reject internal-OVK change spoofing, got: {other:?}"),
         }
     }
 
@@ -1221,9 +1192,9 @@ mod tests {
 
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
-    fn test_preflight_pczt_normalizes_and_is_idempotent() {
+    fn test_check_pczt_normalizes_and_is_idempotent() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
-        let normalized = preflight_pczt_cypherpunk(
+        let normalized = check_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
             &sample.ufvk_text,
@@ -1232,9 +1203,9 @@ mod tests {
         )
         .unwrap();
 
-        // Normalized bytes are a valid PCZT that passes the same preflight and
+        // Normalized bytes are a valid PCZT that passes the same check and
         // re-normalizes to identical bytes.
-        let renormalized = preflight_pczt_cypherpunk(
+        let renormalized = check_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &normalized,
             &sample.ufvk_text,
@@ -1246,12 +1217,12 @@ mod tests {
     }
 
     #[test]
-    fn test_preflight_pczt_rejects_invalid_data() {
+    fn test_check_pczt_rejects_invalid_data() {
         let seed = [7u8; 32];
         let ufvk = derive_ufvk(&MainNetwork, &seed, "m/32'/133'/0'").unwrap();
         let seed_fingerprint = calculate_seed_fingerprint(&seed).unwrap();
 
-        let result = preflight_pczt_cypherpunk(
+        let result = check_pczt_cypherpunk(
             &MainNetwork,
             b"invalid_pczt_data",
             &ufvk,
@@ -1357,7 +1328,7 @@ mod tests {
     #[test]
     fn test_sign_checked_pczt_signs_owned_orchard_actions() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
-        let normalized = preflight_pczt_cypherpunk(
+        let normalized = check_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
             &sample.ufvk_text,
@@ -1389,7 +1360,7 @@ mod tests {
     #[test]
     fn test_sign_checked_pczt_rejects_foreign_seed() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
-        let normalized = preflight_pczt_cypherpunk(
+        let normalized = check_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
             &sample.ufvk_text,

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -76,7 +76,8 @@ pub fn check_pczt_cypherpunk<P: consensus::Parameters>(
     // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
     // mutating `pczt` so the normalized bytes carry the verified values forward.
     check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
-    Ok(pczt.serialize())
+    pczt.serialize()
+        .map_err(|e| ZcashError::InvalidPczt(alloc::format!("serialize normalized PCZT: {e:?}")))
 }
 
 /// `check_pczt_cypherpunk` against an already-parsed PCZT, so callers can parse
@@ -136,7 +137,8 @@ pub fn preflight_batch_pczt_cypherpunk<P: consensus::Parameters>(
     if actions.is_empty() {
         return Err(ZcashError::PcztNoMyInputs);
     }
-    Ok(pczt.serialize())
+    pczt.serialize()
+        .map_err(|e| ZcashError::InvalidPczt(alloc::format!("serialize normalized PCZT: {e:?}")))
 }
 
 /// Parses a multi-coins PCZT, checks policy, and serializes it again in one
@@ -157,7 +159,8 @@ pub fn check_pczt_multi_coins<P: consensus::Parameters>(
     // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
     // mutating `pczt` so the normalized bytes carry the verified values forward.
     check_parsed_pczt_multi_coins(params, &pczt, xpub, seed_fingerprint, account_index)?;
-    Ok(pczt.serialize())
+    pczt.serialize()
+        .map_err(|e| ZcashError::InvalidPczt(alloc::format!("serialize normalized PCZT: {e:?}")))
 }
 
 /// `check_pczt_multi_coins` against an already-parsed PCZT, so callers can
@@ -385,19 +388,22 @@ mod legacy_tests {
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_check_rejects_v6_pczt() {
-        let pczt = Creator::new_v6(
+        // `Creator::new(Nu6_3, ..)` alone yields a V6 PCZT (tx_version V6); the legacy
+        // path rejects it on version, so no Ironwood anchor is needed (and
+        // `with_ironwood_anchor` is orchard-feature-gated, unavailable in this build).
+        let pczt = Creator::new(
             BranchId::Nu6_3.into(),
             10,
             MainNetwork.coin_type(),
             [0; 32],
             [0; 32],
-            [1; 32],
         )
+        .unwrap()
         .build();
 
         let result = check_pczt_multi_coins(
             &MainNetwork,
-            &pczt.serialize(),
+            &pczt.serialize().unwrap(),
             "not-an-xpub",
             &[7u8; 32],
             0,
@@ -711,7 +717,9 @@ fn sign_checked_pczt_with_policy<P: consensus::Parameters>(
     } else {
         ensure_shielded_actions_are_signed(signed, &signable_actions)?
     };
-    Ok(signed.serialize())
+    signed
+        .serialize()
+        .map_err(|e| ZcashError::SigningError(alloc::format!("serialize signed PCZT: {e:?}")))
 }
 
 #[cfg(feature = "cypherpunk")]
@@ -727,14 +735,16 @@ mod tests {
     use super::*;
     extern crate std;
 
+    // Head of the v2 PCZT wire layout (`pczt::Pczt`'s v2 encoding), up to and including
+    // the Sapling bundle; empty bundles are omitted (`None`). The trailing Orchard and
+    // Ironwood bundles are captured as raw bytes via `postcard::take_from_bytes` and
+    // re-appended unchanged, so these fixtures only decode the fields at/before the one
+    // they mutate and never need the crate-private `orchard::v2::Bundle` layout.
     #[derive(Serialize, Deserialize)]
-    struct PcztMirror {
+    struct PcztHead {
         global: GlobalMirror,
-        transparent: ::pczt::transparent::Bundle,
-        sapling: SaplingBundleMirror,
-        orchard: ::pczt::orchard::Bundle,
-        #[cfg(zcash_unstable = "nu6.3")]
-        ironwood: ::pczt::orchard::Bundle,
+        transparent: Option<::pczt::transparent::Bundle>,
+        sapling: Option<SaplingBundleMirror>,
     }
 
     #[derive(Serialize, Deserialize)]
@@ -791,15 +801,21 @@ mod tests {
     #[cfg(zcash_unstable = "nu6.3")]
     fn v5_pczt_with_ironwood_actions() -> Vec<u8> {
         let sample = pczt::test_support::sample_ironwood_pczt();
-        let mut bytes = sample.bytes;
-        let mut pczt: PcztMirror = postcard::from_bytes(&bytes[8..]).unwrap();
-        assert!(!pczt.ironwood.actions().is_empty());
+        let bytes = sample.bytes;
+        assert!(!::pczt::Pczt::parse(&bytes)
+            .unwrap()
+            .ironwood()
+            .actions()
+            .is_empty());
+        let (mut head, rest) = postcard::take_from_bytes::<PcztHead>(&bytes[8..]).unwrap();
 
-        pczt.global.tx_version = constants::V5_TX_VERSION;
-        pczt.global.version_group_id = constants::V5_VERSION_GROUP_ID;
+        head.global.tx_version = constants::V5_TX_VERSION;
+        head.global.version_group_id = constants::V5_VERSION_GROUP_ID;
 
-        bytes.truncate(8);
-        postcard::to_extend(&pczt, bytes).unwrap()
+        let mut out = bytes[..8].to_vec();
+        out = postcard::to_extend(&head, out).unwrap();
+        out.extend_from_slice(rest);
+        out
     }
 
     fn assert_invalid_pczt_message<T: core::fmt::Debug>(result: Result<T>, expected: &str) {
@@ -813,23 +829,33 @@ mod tests {
         use ::pczt::roles::creator::Creator;
         use zcash_vendor::zcash_protocol::consensus::{BranchId, NetworkConstants};
 
-        let mut bytes = Creator::new(
+        let bytes = Creator::new(
             BranchId::Nu6.into(),
             10,
             MainNetwork.coin_type(),
             [0; 32],
             [0; 32],
         )
+        .unwrap()
         .build()
-        .serialize();
-        let mut pczt: PcztMirror = postcard::from_bytes(&bytes[8..]).unwrap();
-        assert!(pczt.sapling.spends.is_empty());
-        assert!(pczt.sapling.outputs.is_empty());
+        .serialize()
+        .unwrap();
+        let (mut head, rest) = postcard::take_from_bytes::<PcztHead>(&bytes[8..]).unwrap();
+        // v2 omits empty bundles, so the freshly created PCZT has no Sapling bundle.
+        // Attach one that is empty except for a non-zero value sum, which `check` rejects.
+        assert!(head.sapling.is_none());
+        head.sapling = Some(SaplingBundleMirror {
+            spends: Vec::new(),
+            outputs: Vec::new(),
+            value_sum: 1,
+            anchor: [0u8; 32],
+            bsk: None,
+        });
 
-        pczt.sapling.value_sum = 1;
-
-        bytes.truncate(8);
-        postcard::to_extend(&pczt, bytes).unwrap()
+        let mut out = bytes[..8].to_vec();
+        out = postcard::to_extend(&head, out).unwrap();
+        out.extend_from_slice(rest);
+        out
     }
 
     /// A PCZT whose Sapling bundle is empty but declares a non-zero value sum is malformed
@@ -912,6 +938,7 @@ mod tests {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         builder
@@ -943,7 +970,10 @@ mod tests {
         let PcztResult { pczt_parts, .. } = builder
             .build_for_pczt(OsRng, &zip317::FeeRule::standard())
             .unwrap();
-        let pczt_bytes = Creator::build_from_parts(pczt_parts).unwrap().serialize();
+        let pczt_bytes = Creator::build_from_parts(pczt_parts)
+            .unwrap()
+            .serialize()
+            .unwrap();
         let seed_fingerprint = calculate_seed_fingerprint(&victim_seed).unwrap();
 
         let expected =
@@ -1265,8 +1295,17 @@ mod tests {
     #[cfg(zcash_unstable = "nu6.3")]
     fn pczt_with_sapling_output() -> pczt::test_support::SamplePczt {
         let mut sample = pczt::test_support::sample_orchard_change_pczt();
-        let mut pczt: PcztMirror = postcard::from_bytes(&sample.bytes[8..]).unwrap();
-        pczt.sapling.outputs.push(SaplingOutputMirror {
+        let (mut head, rest) = postcard::take_from_bytes::<PcztHead>(&sample.bytes[8..]).unwrap();
+        // The orchard-change sample carries no Sapling bundle (v2 omits it); synthesize one
+        // with a single output and negative value sum so the batch check rejects it.
+        let mut sapling = head.sapling.take().unwrap_or(SaplingBundleMirror {
+            spends: Vec::new(),
+            outputs: Vec::new(),
+            value_sum: 0,
+            anchor: [0u8; 32],
+            bsk: None,
+        });
+        sapling.outputs.push(SaplingOutputMirror {
             cv: [0; 32],
             cmu: [0; 32],
             ephemeral_key: [0; 32],
@@ -1282,10 +1321,13 @@ mod tests {
             user_address: None,
             proprietary: BTreeMap::new(),
         });
-        pczt.sapling.value_sum = -1;
+        sapling.value_sum = -1;
+        head.sapling = Some(sapling);
 
-        sample.bytes.truncate(8);
-        sample.bytes = postcard::to_extend(&pczt, sample.bytes).unwrap();
+        let mut out = sample.bytes[..8].to_vec();
+        out = postcard::to_extend(&head, out).unwrap();
+        out.extend_from_slice(rest);
+        sample.bytes = out;
         sample
     }
 

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -116,7 +116,7 @@ pub fn preflight_pczt_cypherpunk<P: consensus::Parameters>(
     account_index: u32,
 ) -> Result<Vec<u8>> {
     let pczt = pczt::parse_pczt(pczt_bytes)?;
-    // FUTURE(qr-v2-omitted-fields): recompute-or-check omitted fields here,
+    // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
     // mutating `pczt` so the normalized bytes carry the verified values forward.
     check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
     Ok(pczt.serialize())
@@ -135,8 +135,8 @@ pub fn preflight_batch_pczt_cypherpunk<P: consensus::Parameters>(
     account_index: u32,
 ) -> Result<Vec<u8>> {
     let pczt = pczt::parse_pczt(pczt_bytes)?;
-    // FUTURE(qr-v2-omitted-fields): recompute-or-check omitted fields here, as
-    // in preflight_pczt_cypherpunk.
+    // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
+    // as in preflight_pczt_cypherpunk.
     check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
     let account_id = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
@@ -205,7 +205,7 @@ pub fn preflight_pczt_multi_coins<P: consensus::Parameters>(
     account_index: u32,
 ) -> Result<Vec<u8>> {
     let pczt = pczt::parse_pczt(pczt_bytes)?;
-    // FUTURE(qr-v2-omitted-fields): recompute-or-check omitted fields here,
+    // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
     // mutating `pczt` so the normalized bytes carry the verified values forward.
     check_parsed_pczt_multi_coins(params, &pczt, xpub, seed_fingerprint, account_index)?;
     Ok(pczt.serialize())

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -1293,8 +1293,8 @@ mod tests {
         let mut sample = pczt::test_support::sample_orchard_change_pczt();
         let (mut prefix, rest) =
             postcard::take_from_bytes::<PcztWirePrefix>(&sample.bytes[8..]).unwrap();
-        // The orchard-change sample carries no Sapling bundle (v2 omits it); synthesize one
-        // with a single output and negative value sum so the batch check rejects it.
+        // The orchard-change sample has an empty Sapling bundle, which v2 omits on the wire;
+        // synthesize one with a single output so the batch check rejects it.
         let mut sapling = prefix.sapling.take().unwrap_or(SaplingBundleMirror {
             spends: Vec::new(),
             outputs: Vec::new(),

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -399,9 +399,6 @@ mod legacy_tests {
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_check_rejects_v6_pczt() {
-        // `Creator::new(Nu6_3, ..)` alone yields a V6 PCZT (tx_version V6); the legacy
-        // path rejects it on version, so no Ironwood anchor is needed (and
-        // `with_ironwood_anchor` is orchard-feature-gated, unavailable in this build).
         let pczt = Creator::new(
             BranchId::Nu6_3.into(),
             10,

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -70,6 +70,19 @@ pub fn check_pczt_cypherpunk<P: consensus::Parameters>(
     account_index: u32,
 ) -> Result<()> {
     let pczt = pczt::parse_pczt(pczt)?;
+    check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)
+}
+
+/// `check_pczt_cypherpunk` against an already-parsed PCZT, so preflight can
+/// parse once and reuse the parsed value for normalization.
+#[cfg(feature = "cypherpunk")]
+fn check_parsed_pczt_cypherpunk<P: consensus::Parameters>(
+    params: &P,
+    pczt: &Pczt,
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<()> {
     let account_index = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
     let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
@@ -77,16 +90,36 @@ pub fn check_pczt_cypherpunk<P: consensus::Parameters>(
     let xpub = ufvk.transparent().ok_or(ZcashError::InvalidDataError(
         "transparent xpub is not present".to_string(),
     ))?;
-    pczt::check::check_pczt_orchard(params, seed_fingerprint, account_index, &ufvk, &pczt)?;
+    pczt::check::check_pczt_orchard(params, seed_fingerprint, account_index, &ufvk, pczt)?;
     pczt::check::check_pczt_transparent(
         params,
         seed_fingerprint,
         account_index,
         xpub,
-        &pczt,
+        pczt,
         false,
     )?;
     Ok(())
+}
+
+/// Parses, policy-checks, and re-serializes a PCZT in one pass.
+///
+/// Returns the normalized (current-version) encoding of the checked PCZT: the
+/// bytes C retains as the `checked_PCZT`, which display and signing consume
+/// without re-running these checks.
+#[cfg(feature = "cypherpunk")]
+pub fn preflight_pczt_cypherpunk<P: consensus::Parameters>(
+    params: &P,
+    pczt_bytes: &[u8],
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<Vec<u8>> {
+    let pczt = pczt::parse_pczt(pczt_bytes)?;
+    // FUTURE(qr-v2-omitted-fields): recompute-or-check omitted fields here,
+    // mutating `pczt` so the normalized bytes carry the verified values forward.
+    check_parsed_pczt_cypherpunk(params, &pczt, ufvk_text, seed_fingerprint, account_index)?;
+    Ok(pczt.serialize())
 }
 
 #[cfg(feature = "multi_coins")]
@@ -98,7 +131,20 @@ pub fn check_pczt_multi_coins<P: consensus::Parameters>(
     account_index: u32,
 ) -> Result<()> {
     let pczt = pczt::parse_pczt(pczt)?;
-    reject_legacy_check_unsupported_pczt(&pczt)?;
+    check_parsed_pczt_multi_coins(params, &pczt, xpub, seed_fingerprint, account_index)
+}
+
+/// `check_pczt_multi_coins` against an already-parsed PCZT, so preflight can
+/// parse once and reuse the parsed value for normalization.
+#[cfg(feature = "multi_coins")]
+fn check_parsed_pczt_multi_coins<P: consensus::Parameters>(
+    params: &P,
+    pczt: &Pczt,
+    xpub: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<()> {
+    reject_legacy_check_unsupported_pczt(pczt)?;
     let account_pubkey = transparent_account_pubkey_from_xpub(xpub)?;
     let account_index = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
@@ -108,10 +154,30 @@ pub fn check_pczt_multi_coins<P: consensus::Parameters>(
         seed_fingerprint,
         account_index,
         &account_pubkey,
-        &pczt,
+        pczt,
         true,
     )?;
     Ok(())
+}
+
+/// Parses, policy-checks, and re-serializes a PCZT in one pass.
+///
+/// Returns the normalized (current-version) encoding of the checked PCZT: the
+/// bytes C retains as the `checked_PCZT`, which display and signing consume
+/// without re-running these checks.
+#[cfg(feature = "multi_coins")]
+pub fn preflight_pczt_multi_coins<P: consensus::Parameters>(
+    params: &P,
+    pczt_bytes: &[u8],
+    xpub: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<Vec<u8>> {
+    let pczt = pczt::parse_pczt(pczt_bytes)?;
+    // FUTURE(qr-v2-omitted-fields): recompute-or-check omitted fields here,
+    // mutating `pczt` so the normalized bytes carry the verified values forward.
+    check_parsed_pczt_multi_coins(params, &pczt, xpub, seed_fingerprint, account_index)?;
+    Ok(pczt.serialize())
 }
 
 #[cfg(feature = "multi_coins")]
@@ -275,6 +341,16 @@ mod legacy_tests {
             0,
         )
         .expect("selected account PCZT should check");
+
+        let normalized = preflight_pczt_multi_coins(
+            &MainNetwork,
+            &sample.bytes,
+            &sample.xpub,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("selected account PCZT should preflight");
+        assert!(parse_pczt_multi_coins(&MainNetwork, &normalized, &sample.seed_fingerprint).is_ok());
 
         let account_one_pczt =
             pczt::legacy_test_support::legacy_transparent_pczt_with_input_derivation(
@@ -891,6 +967,11 @@ mod tests {
             Err(ZcashError::InvalidPczt(msg)) if msg.contains(expected) => {}
             other => panic!("check must reject internal-OVK change spoofing, got: {other:?}"),
         }
+
+        match preflight_pczt_cypherpunk(&params, &pczt_bytes, &ufvk_text, &seed_fingerprint, 0) {
+            Err(ZcashError::InvalidPczt(msg)) if msg.contains(expected) => {}
+            other => panic!("preflight must reject internal-OVK change spoofing, got: {other:?}"),
+        }
     }
 
     #[test]
@@ -1120,6 +1201,48 @@ mod tests {
             0,
         );
         assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ZcashError::InvalidPczt(_)));
+    }
+
+    #[cfg(zcash_unstable = "nu6.3")]
+    #[test]
+    fn test_preflight_pczt_normalizes_and_is_idempotent() {
+        let sample = pczt::test_support::sample_orchard_change_pczt();
+        let normalized = preflight_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+
+        // Normalized bytes are a valid PCZT that passes the same preflight and
+        // re-normalizes to identical bytes.
+        let renormalized = preflight_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &normalized,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+        assert_eq!(normalized, renormalized);
+    }
+
+    #[test]
+    fn test_preflight_pczt_rejects_invalid_data() {
+        let seed = [7u8; 32];
+        let ufvk = derive_ufvk(&MainNetwork, &seed, "m/32'/133'/0'").unwrap();
+        let seed_fingerprint = calculate_seed_fingerprint(&seed).unwrap();
+
+        let result = preflight_pczt_cypherpunk(
+            &MainNetwork,
+            b"invalid_pczt_data",
+            &ufvk,
+            &seed_fingerprint,
+            0,
+        );
         assert!(matches!(result.unwrap_err(), ZcashError::InvalidPczt(_)));
     }
 

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -298,14 +298,7 @@ fn check_shielded_bundle<P: consensus::Parameters>(
 ) -> Result<(), ZcashError> {
     let pool_label = pool.label();
     bundle.actions().iter().try_for_each(|action| {
-        check_action(
-            params,
-            seed_fingerprint,
-            account_index,
-            ufvk,
-            action,
-            pool,
-        )?;
+        check_action(params, seed_fingerprint, account_index, ufvk, action, pool)?;
         Ok::<_, ZcashError>(())
     })?;
 
@@ -341,9 +334,7 @@ fn check_action<P: consensus::Parameters>(
     // Check `cv_net` first so we know that the `value` fields for both the spend and the
     // output are present and correct.
     action.verify_cv_net().map_err(|e| {
-        ZcashError::InvalidPczt(format!(
-            "invalid cv_net in {pool_label} action: {e:?}"
-        ))
+        ZcashError::InvalidPczt(format!("invalid cv_net in {pool_label} action: {e:?}"))
     })?;
 
     let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
@@ -396,9 +387,7 @@ fn check_action_spend<P: consensus::Parameters>(
 
     if let Some(expected_fvk) = can_verify_nf_rk {
         spend.verify_nullifier(expected_fvk).map_err(|e| {
-            ZcashError::InvalidPczt(format!(
-                "invalid {pool_label} action nullifier: {e:?}"
-            ))
+            ZcashError::InvalidPczt(format!("invalid {pool_label} action nullifier: {e:?}"))
         })?;
         spend.verify_rk(expected_fvk).map_err(|e| {
             ZcashError::InvalidPczt(format!("invalid {pool_label} action rk: {e:?}"))
@@ -429,9 +418,7 @@ fn check_action_output<P: consensus::Parameters>(
     action
         .output()
         .verify_note_commitment(action.spend())
-        .map_err(|e| {
-            ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}"))
-        })?;
+        .map_err(|e| ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}")))?;
 
     let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
         "orchard fvk is not present".to_string(),

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -295,6 +295,7 @@ pub(crate) mod test_support {
             .unwrap()
             .finish()
             .serialize()
+            .unwrap()
     }
 
     #[cfg(zcash_unstable = "nu6.3")]
@@ -331,6 +332,7 @@ pub(crate) mod test_support {
             .unwrap()
             .finish()
             .serialize()
+            .unwrap()
     }
 
     #[cfg(zcash_unstable = "nu6.3")]
@@ -391,6 +393,7 @@ pub(crate) mod test_support {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: Some(anchor),
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         builder
@@ -433,7 +436,7 @@ pub(crate) mod test_support {
             .finish();
 
         SamplePczt {
-            bytes: pczt.serialize(),
+            bytes: pczt.serialize().unwrap(),
             seed: seed.to_vec(),
             ufvk_text,
             seed_fingerprint,
@@ -503,6 +506,7 @@ pub(crate) mod test_support {
                 sapling_anchor: None,
                 orchard_anchor: Some(anchor),
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         builder
@@ -545,7 +549,7 @@ pub(crate) mod test_support {
             .finish();
 
         SamplePczt {
-            bytes: pczt.serialize(),
+            bytes: pczt.serialize().unwrap(),
             seed: seed.to_vec(),
             ufvk_text,
             seed_fingerprint,
@@ -667,7 +671,7 @@ pub(crate) mod test_support {
             .finish();
 
         SamplePczt {
-            bytes: pczt.serialize(),
+            bytes: pczt.serialize().unwrap(),
             seed: seed.to_vec(),
             ufvk_text,
             seed_fingerprint,
@@ -743,6 +747,7 @@ pub(crate) mod legacy_test_support {
             .unwrap()
             .finish()
             .serialize()
+            .unwrap()
     }
 
     pub(crate) fn legacy_transparent_sample() -> LegacyTransparentSample {
@@ -780,6 +785,7 @@ pub(crate) mod legacy_test_support {
                 sapling_anchor: None,
                 orchard_anchor: None,
                 ironwood_anchor: None,
+                orchard_pool_bundle_type: orchard::builder::BundleType::DEFAULT,
             },
         );
         builder
@@ -822,7 +828,7 @@ pub(crate) mod legacy_test_support {
             .to_string();
 
         LegacyTransparentSample {
-            bytes: pczt.serialize(),
+            bytes: pczt.serialize().unwrap(),
             seed: seed.to_vec(),
             seed_fingerprint,
             xpub,

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -813,9 +813,6 @@ mod legacy_tests {
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_parse_rejects_v6_pczt() {
-        // `Creator::new(Nu6_3, ..)` alone yields a V6 PCZT (tx_version V6); the legacy
-        // path rejects it on version, so no Ironwood anchor is needed (and
-        // `with_ironwood_anchor` is orchard-feature-gated, unavailable in this build).
         let pczt = Creator::new(
             BranchId::Nu6_3.into(),
             10,

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -813,14 +813,17 @@ mod legacy_tests {
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_parse_rejects_v6_pczt() {
-        let pczt = Creator::new_v6(
+        // `Creator::new(Nu6_3, ..)` alone yields a V6 PCZT (tx_version V6); the legacy
+        // path rejects it on version, so no Ironwood anchor is needed (and
+        // `with_ironwood_anchor` is orchard-feature-gated, unavailable in this build).
+        let pczt = Creator::new(
             BranchId::Nu6_3.into(),
             10,
             MainNetwork.coin_type(),
             [0; 32],
             [0; 32],
-            [1; 32],
         )
+        .unwrap()
         .build();
 
         let result = parse_pczt_multi_coins(&MainNetwork, &[7u8; 32], &pczt);

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -216,8 +216,14 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
 
     let verifier = Verifier::new(pczt.clone())
         .with_orchard(|bundle| {
-            parsed_orchard = parse_orchard(params, seed_fingerprint, ufvk, bundle, ShieldedPool::Orchard)
-                .map_err(pczt::roles::verifier::OrchardError::Custom)?;
+            parsed_orchard = parse_orchard(
+                params,
+                seed_fingerprint,
+                ufvk,
+                bundle,
+                ShieldedPool::Orchard,
+            )
+            .map_err(pczt::roles::verifier::OrchardError::Custom)?;
             Ok(())
         })
         .map_err(map_orchard_verifier_error)?;
@@ -225,8 +231,14 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
     let verifier = if should_process_ironwood {
         verifier
             .with_ironwood(|bundle| {
-                parsed_ironwood = parse_orchard(params, seed_fingerprint, ufvk, bundle, ShieldedPool::Ironwood)
-                    .map_err(pczt::roles::verifier::OrchardError::Custom)?;
+                parsed_ironwood = parse_orchard(
+                    params,
+                    seed_fingerprint,
+                    ufvk,
+                    bundle,
+                    ShieldedPool::Ironwood,
+                )
+                .map_err(pczt::roles::verifier::OrchardError::Custom)?;
                 Ok(())
             })
             .map_err(map_orchard_verifier_error)?

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -547,10 +547,11 @@ mod tests {
         let base_sighash = RoleSigner::new(pczt.clone())
             .expect("Ironwood PCZT signer should initialize")
             .shielded_sighash();
-        // The v6 Ironwood sighash must not commit the anchor, so clearing it
-        // (the elided wire form batch children use) must leave the shielded
-        // sighash unchanged; a client-provided anchor may equally stay on the
-        // wire.
+        // Mirror the wallet's batch redaction: clearing the anchor rebuilds the
+        // anchor-elided request the wallet sends for batch children, with the
+        // full-anchor PCZT as its own oracle. The v6 Ironwood sighash does not
+        // commit the anchor, so the elided form must leave the shielded sighash
+        // unchanged; a client-provided anchor may equally stay on the wire.
         let cleared_anchor_pczt = Redactor::new(pczt.clone())
             .redact_ironwood_with(|mut r| r.clear_anchor())
             .finish();

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -238,8 +238,19 @@ impl PcztSigner for SeedSigner<'_> {
     }
 }
 
+/// Signs `pczt` and serializes the stamped, redacted response.
+///
+/// Thin wrapper over `sign_pczt_to_pczt`; see it for the full contract.
 #[cfg(feature = "cypherpunk")]
 pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
+    Ok(sign_pczt_to_pczt(pczt, seed)?.serialize())
+}
+
+/// `sign_pczt`, but returns the stamped, redacted PCZT without serializing it,
+/// so callers that still need the parsed value (in-memory post-sign
+/// verification) avoid a byte round trip.
+#[cfg(feature = "cypherpunk")]
+pub fn sign_pczt_to_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
     super::validate_supported_pczt(&pczt)?;
 
     let seed_fingerprint =
@@ -277,7 +288,7 @@ pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
         return Err(ZcashError::PcztNoMyInputs);
     }
 
-    Ok(stamp_and_redact(signer.finish()).serialize())
+    Ok(stamp_and_redact(signer.finish()))
 }
 
 fn stamp_and_redact(pczt: Pczt) -> Pczt {

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -242,10 +242,10 @@ impl PcztSigner for SeedSigner<'_> {
 
 /// Signs `pczt` and serializes the stamped, redacted response.
 ///
-/// Thin wrapper over `sign_pczt_to_pczt`; see it for the full contract.
+/// Thin wrapper over `sign_and_redact_pczt`; see it for the full contract.
 #[cfg(feature = "cypherpunk")]
 pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
-    sign_pczt_to_pczt(pczt, seed)?
+    sign_and_redact_pczt(pczt, seed)?
         .serialize()
         .map_err(|e| ZcashError::SigningError(format!("serialize signed PCZT: {e:?}")))
 }
@@ -254,7 +254,7 @@ pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
 /// so callers that still need the parsed value (in-memory post-sign
 /// verification) avoid a byte round trip.
 #[cfg(feature = "cypherpunk")]
-pub fn sign_pczt_to_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
+pub fn sign_and_redact_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
     super::validate_supported_pczt(&pczt)?;
 
     let seed_fingerprint =

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -118,7 +118,12 @@ struct SeedSigner<'a> {
     /// key depend only on (seed, account), not on the action, so a bundle with many
     /// actions for one account derives once. Interior mutability because the
     /// `PcztSigner` trait signs through `&self`.
-    ask_cache: RefCell<Vec<(zcash_vendor::zip32::AccountId, orchard::keys::SpendAuthorizingKey)>>,
+    ask_cache: RefCell<
+        Vec<(
+            zcash_vendor::zip32::AccountId,
+            orchard::keys::SpendAuthorizingKey,
+        )>,
+    >,
     /// Number of authorizations produced, so `sign_pczt` can distinguish "nothing of
     /// ours to sign" (`PcztNoMyInputs`) from a successful signing.
     signed: Cell<usize>,
@@ -742,7 +747,6 @@ mod tests {
             .expect("wallet-set min key must survive round trip");
         assert_eq!(request_min.as_slice(), &[1u8, 2][..]);
     }
-
 }
 
 #[cfg(all(test, feature = "multi_coins", not(feature = "cypherpunk")))]

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -83,7 +83,9 @@ pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
     let signer = pczt_ext::sign_transparent(signer, &SeedSigner { seed })
         .map_err(|e| ZcashError::SigningError(e.to_string()))?;
 
-    Ok(stamp_and_redact(signer.finish()).serialize())
+    stamp_and_redact(signer.finish())
+        .serialize()
+        .map_err(|e| ZcashError::SigningError(format!("serialize signed PCZT: {e:?}")))
 }
 
 #[cfg(not(feature = "cypherpunk"))]
@@ -243,7 +245,9 @@ impl PcztSigner for SeedSigner<'_> {
 /// Thin wrapper over `sign_pczt_to_pczt`; see it for the full contract.
 #[cfg(feature = "cypherpunk")]
 pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
-    Ok(sign_pczt_to_pczt(pczt, seed)?.serialize())
+    sign_pczt_to_pczt(pczt, seed)?
+        .serialize()
+        .map_err(|e| ZcashError::SigningError(format!("serialize signed PCZT: {e:?}")))
 }
 
 /// `sign_pczt`, but returns the stamped, redacted PCZT without serializing it,
@@ -427,6 +431,7 @@ mod tests {
     use super::*;
     // RoleSigner is the upstream reference signer; tests use its sighash as the
     // bit-exact oracle for the lean pczt_ext::shielded_sig_commitment.
+    use zcash_vendor::pczt::roles::redactor::Redactor;
     use zcash_vendor::pczt::roles::signer::Signer as RoleSigner;
 
     fn assert_invalid_pczt_message<T: core::fmt::Debug>(result: crate::Result<T>, expected: &str) {
@@ -542,19 +547,20 @@ mod tests {
         let base_sighash = RoleSigner::new(pczt.clone())
             .expect("Ironwood PCZT signer should initialize")
             .shielded_sighash();
-        let updated_anchor = orchard::Anchor::from_bytes([6u8; 32]).unwrap();
-        let updated_anchor_pczt = Updater::new(pczt.clone())
-            .set_v6_ironwood_anchor(updated_anchor)
-            .expect("v6 Ironwood anchor should be replaceable before proving")
+        // The v6 Ironwood sighash must not commit the anchor. The new stack has no
+        // post-parse anchor setter, so redact the anchor instead: parse substitutes a
+        // version-gated placeholder, and the shielded sighash must be unchanged.
+        let cleared_anchor_pczt = Redactor::new(pczt.clone())
+            .redact_ironwood_with(|mut r| r.clear_anchor())
             .finish();
         assert_ne!(
             pczt.ironwood().anchor(),
-            updated_anchor_pczt.ironwood().anchor()
+            cleared_anchor_pczt.ironwood().anchor()
         );
         assert_eq!(
             base_sighash,
-            RoleSigner::new(updated_anchor_pczt)
-                .expect("anchor-updated Ironwood PCZT signer should initialize")
+            RoleSigner::new(cleared_anchor_pczt)
+                .expect("anchor-cleared Ironwood PCZT signer should initialize")
                 .shielded_sighash(),
             "v6 Ironwood spend signatures must not commit to the anchor"
         );
@@ -748,14 +754,17 @@ mod legacy_tests {
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_signing_rejects_v6_pczt() {
-        let pczt = Creator::new_v6(
+        // `Creator::new(Nu6_3, ..)` alone yields a V6 PCZT (tx_version V6); the legacy
+        // path rejects it on version, so no Ironwood anchor is needed (and
+        // `with_ironwood_anchor` is orchard-feature-gated, unavailable in this build).
+        let pczt = Creator::new(
             BranchId::Nu6_3.into(),
             10,
             MainNetwork.coin_type(),
             [0; 32],
             [0; 32],
-            [1; 32],
         )
+        .unwrap()
         .build();
 
         let result = sign_pczt(pczt, &[7u8; 32]);

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -756,9 +756,6 @@ mod legacy_tests {
     #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_signing_rejects_v6_pczt() {
-        // `Creator::new(Nu6_3, ..)` alone yields a V6 PCZT (tx_version V6); the legacy
-        // path rejects it on version, so no Ironwood anchor is needed (and
-        // `with_ironwood_anchor` is orchard-feature-gated, unavailable in this build).
         let pczt = Creator::new(
             BranchId::Nu6_3.into(),
             10,

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -547,9 +547,10 @@ mod tests {
         let base_sighash = RoleSigner::new(pczt.clone())
             .expect("Ironwood PCZT signer should initialize")
             .shielded_sighash();
-        // The v6 Ironwood sighash must not commit the anchor. The new stack has no
-        // post-parse anchor setter, so redact the anchor instead: parse substitutes a
-        // version-gated placeholder, and the shielded sighash must be unchanged.
+        // The v6 Ironwood sighash must not commit the anchor, so clearing it
+        // (the elided wire form batch children use) must leave the shielded
+        // sighash unchanged; a client-provided anchor may equally stay on the
+        // wire.
         let cleared_anchor_pczt = Redactor::new(pczt.clone())
             .redact_ironwood_with(|mut r| r.clear_anchor())
             .finish();

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -21,6 +21,7 @@ use keystore::algorithms::{
 };
 use structs::DisplayPczt;
 use structs::DisplayZcashBatch;
+use structs::ZcashCheckedPczt;
 use ur_registry::traits::RegistryItem;
 use ur_registry::zcash::zcash_pczt::ZcashPczt;
 use ur_registry::zcash::zcash_sign_batch::{
@@ -701,6 +702,16 @@ pub unsafe extern "C" fn sign_zcash_tx_cypherpunk_unlimited(
 
 make_free_method!(TransactionParseResult<DisplayPczt>);
 make_free_method!(TransactionParseResult<DisplayZcashBatch>);
+
+/// Frees a `ZcashCheckedPczt` previously returned through a check FFI out-param.
+#[no_mangle]
+pub unsafe extern "C" fn free_zcash_checked_pczt(ptr: PtrT<ZcashCheckedPczt>) {
+    if ptr.is_null() {
+        return;
+    }
+    let checked = alloc::boxed::Box::from_raw(ptr);
+    checked.free();
+}
 
 use aes::cipher::block_padding::Pkcs7;
 use aes::cipher::generic_array::GenericArray;

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -381,8 +381,7 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
     let batch = match ZcashSignBatch::try_from(bytes.to_vec()) {
         Ok(batch) => batch,
         Err(e) => {
-            return TransactionParseResult::from(RustCError::InvalidData(format!("{e:?}")))
-                .c_ptr()
+            return TransactionParseResult::from(RustCError::InvalidData(format!("{e:?}"))).c_ptr()
         }
     };
     let ufvk_text = unsafe { recover_c_char(ufvk) };
@@ -439,8 +438,7 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
                 Ok(seed_fingerprint) => {
                     if &seed_fingerprint != expected_seed_fingerprint {
                         seed.zeroize();
-                        return UREncodeResult::from(RustCError::MasterFingerprintMismatch)
-                            .c_ptr();
+                        return UREncodeResult::from(RustCError::MasterFingerprintMismatch).c_ptr();
                     }
 
                     let mut results = Vec::new();
@@ -479,8 +477,7 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
                         );
                         match TryInto::<Vec<u8>>::try_into(result) {
                             Ok(bytes) => {
-                                let registry_type =
-                                    ZcashSignResult::get_registry_type().get_type();
+                                let registry_type = ZcashSignResult::get_registry_type().get_type();
                                 if allow_multipart {
                                     UREncodeResult::encode(
                                         bytes,

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn check_zcash_tx_cypherpunk(
     let ufvk_text = unsafe { recover_c_char(ufvk) };
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
-    match app_zcash::preflight_pczt_cypherpunk(
+    match app_zcash::check_pczt_cypherpunk(
         &MainNetwork,
         &pczt.get_data(),
         &ufvk_text,
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn check_zcash_tx_multi_coins(
     let xpub_text = unsafe { recover_c_char(xpub) };
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
-    match app_zcash::preflight_pczt_multi_coins(
+    match app_zcash::check_pczt_multi_coins(
         &MainNetwork,
         &pczt.get_data(),
         &xpub_text,

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn check_zcash_batch_tx_cypherpunk(
 
     let mut checked_messages = Vec::with_capacity(batch.get_messages().len());
     for message in batch.get_messages() {
-        match app_zcash::preflight_batch_pczt_cypherpunk(
+        match app_zcash::check_batch_pczt_cypherpunk(
             &MainNetwork,
             message.get_payload(),
             &ufvk_text,

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -91,7 +91,9 @@ pub unsafe extern "C" fn check_zcash_tx_cypherpunk(
     seed_fingerprint: PtrBytes,
     account_index: u32,
     disabled: bool,
+    checked_pczt: Ptr<Ptr<ZcashCheckedPczt>>,
 ) -> *mut TransactionCheckResult {
+    *checked_pczt = core::ptr::null_mut();
     if disabled {
         return TransactionCheckResult::from(RustCError::UnsupportedTransaction(
             "Zcash requires at least 256-bit entropy (use 33-word Shamir shares)".to_string(),
@@ -102,14 +104,17 @@ pub unsafe extern "C" fn check_zcash_tx_cypherpunk(
     let ufvk_text = unsafe { recover_c_char(ufvk) };
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
-    match app_zcash::check_pczt_cypherpunk(
+    match app_zcash::preflight_pczt_cypherpunk(
         &MainNetwork,
         &pczt.get_data(),
         &ufvk_text,
         seed_fingerprint,
         account_index,
     ) {
-        Ok(_) => TransactionCheckResult::new().c_ptr(),
+        Ok(normalized) => {
+            *checked_pczt = ZcashCheckedPczt::new(normalized).c_ptr();
+            TransactionCheckResult::new().c_ptr()
+        }
         Err(e) => TransactionCheckResult::from(e).c_ptr(),
     }
 }
@@ -122,7 +127,9 @@ pub unsafe extern "C" fn check_zcash_tx_multi_coins(
     seed_fingerprint: PtrBytes,
     account_index: u32,
     disabled: bool,
+    checked_pczt: Ptr<Ptr<ZcashCheckedPczt>>,
 ) -> *mut TransactionCheckResult {
+    *checked_pczt = core::ptr::null_mut();
     if disabled {
         return TransactionCheckResult::from(RustCError::UnsupportedTransaction(
             "Zcash requires at least 256-bit entropy (use 33-word Shamir shares)".to_string(),
@@ -133,14 +140,17 @@ pub unsafe extern "C" fn check_zcash_tx_multi_coins(
     let xpub_text = unsafe { recover_c_char(xpub) };
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
-    match app_zcash::check_pczt_multi_coins(
+    match app_zcash::preflight_pczt_multi_coins(
         &MainNetwork,
         &pczt.get_data(),
         &xpub_text,
         seed_fingerprint,
         account_index,
     ) {
-        Ok(_) => TransactionCheckResult::new().c_ptr(),
+        Ok(normalized) => {
+            *checked_pczt = ZcashCheckedPczt::new(normalized).c_ptr();
+            TransactionCheckResult::new().c_ptr()
+        }
         Err(e) => TransactionCheckResult::from(e).c_ptr(),
     }
 }
@@ -148,20 +158,25 @@ pub unsafe extern "C" fn check_zcash_tx_multi_coins(
 #[cfg(feature = "cypherpunk")]
 #[no_mangle]
 pub unsafe extern "C" fn parse_zcash_tx_cypherpunk(
-    tx: PtrUR,
+    checked_pczt: Ptr<ZcashCheckedPczt>,
     ufvk: PtrString,
     seed_fingerprint: PtrBytes,
 ) -> Ptr<TransactionParseResult<DisplayPczt>> {
-    let pczt = extract_ptr_with_type!(tx, ZcashPczt);
+    if checked_pczt.is_null() {
+        return TransactionParseResult::from(RustCError::InvalidData(
+            "no checked PCZT available".to_string(),
+        ))
+        .c_ptr();
+    }
+    let checked = extract_ptr_with_type!(checked_pczt, ZcashCheckedPczt);
+    let bytes = match checked.verified_bytes() {
+        Ok(bytes) => bytes,
+        Err(e) => return TransactionParseResult::from(e).c_ptr(),
+    };
     let ufvk_text = unsafe { recover_c_char(ufvk) };
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
-    match app_zcash::parse_pczt_cypherpunk(
-        &MainNetwork,
-        &pczt.get_data(),
-        &ufvk_text,
-        seed_fingerprint,
-    ) {
+    match app_zcash::parse_pczt_cypherpunk(&MainNetwork, bytes, &ufvk_text, seed_fingerprint) {
         Ok(pczt) => TransactionParseResult::success(DisplayPczt::from(&pczt).c_ptr()).c_ptr(),
         Err(e) => TransactionParseResult::from(e).c_ptr(),
     }
@@ -170,13 +185,23 @@ pub unsafe extern "C" fn parse_zcash_tx_cypherpunk(
 #[cfg(feature = "multi-coins")]
 #[no_mangle]
 pub unsafe extern "C" fn parse_zcash_tx_multi_coins(
-    tx: PtrUR,
+    checked_pczt: Ptr<ZcashCheckedPczt>,
     seed_fingerprint: PtrBytes,
 ) -> Ptr<TransactionParseResult<DisplayPczt>> {
-    let pczt = extract_ptr_with_type!(tx, ZcashPczt);
+    if checked_pczt.is_null() {
+        return TransactionParseResult::from(RustCError::InvalidData(
+            "no checked PCZT available".to_string(),
+        ))
+        .c_ptr();
+    }
+    let checked = extract_ptr_with_type!(checked_pczt, ZcashCheckedPczt);
+    let bytes = match checked.verified_bytes() {
+        Ok(bytes) => bytes,
+        Err(e) => return TransactionParseResult::from(e).c_ptr(),
+    };
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
-    match app_zcash::parse_pczt_multi_coins(&MainNetwork, &pczt.get_data(), seed_fingerprint) {
+    match app_zcash::parse_pczt_multi_coins(&MainNetwork, bytes, seed_fingerprint) {
         Ok(pczt) => TransactionParseResult::success(DisplayPczt::from(&pczt).c_ptr()).c_ptr(),
         Err(e) => TransactionParseResult::from(e).c_ptr(),
     }
@@ -277,22 +302,6 @@ fn check_zcash_batch_message_cypherpunk(
     app_zcash::ensure_pczt_has_signable_shielded_action(
         &MainNetwork,
         message.get_payload(),
-        seed_fingerprint,
-        account_index,
-    )
-}
-
-#[cfg(feature = "cypherpunk")]
-fn check_zcash_pczt_message_cypherpunk(
-    payload: &[u8],
-    ufvk_text: &str,
-    seed_fingerprint: &[u8; 32],
-    account_index: u32,
-) -> app_zcash::errors::Result<()> {
-    app_zcash::check_pczt_cypherpunk(
-        &MainNetwork,
-        payload,
-        ufvk_text,
         seed_fingerprint,
         account_index,
     )
@@ -537,39 +546,48 @@ pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk_unlimited(
 
 #[no_mangle]
 pub unsafe extern "C" fn sign_zcash_tx(
-    tx: PtrUR,
+    checked_pczt: Ptr<ZcashCheckedPczt>,
     seed: PtrBytes,
     seed_len: u32,
 ) -> *mut UREncodeResult {
-    sign_zcash_tx_dynamic(tx, seed, seed_len, FRAGMENT_MAX_LENGTH_DEFAULT)
+    sign_zcash_tx_dynamic(checked_pczt, seed, seed_len, FRAGMENT_MAX_LENGTH_DEFAULT)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sign_zcash_tx_unlimited(
-    tx: PtrUR,
+    checked_pczt: Ptr<ZcashCheckedPczt>,
     seed: PtrBytes,
     seed_len: u32,
 ) -> *mut UREncodeResult {
-    sign_zcash_tx_dynamic(tx, seed, seed_len, FRAGMENT_UNLIMITED_LENGTH)
+    sign_zcash_tx_dynamic(checked_pczt, seed, seed_len, FRAGMENT_UNLIMITED_LENGTH)
 }
 
 unsafe fn sign_zcash_tx_dynamic(
-    tx: PtrUR,
+    checked_pczt: Ptr<ZcashCheckedPczt>,
     seed: PtrBytes,
     seed_len: u32,
     max_fragment_length: usize,
 ) -> *mut UREncodeResult {
-    let pczt = extract_ptr_with_type!(tx, ZcashPczt);
+    if checked_pczt.is_null() {
+        return UREncodeResult::from(RustCError::InvalidData(
+            "no checked PCZT available for signing".to_string(),
+        ))
+        .c_ptr();
+    }
+    let checked = extract_ptr_with_type!(checked_pczt, ZcashCheckedPczt);
     let mut seed = extract_array_mut!(seed, u8, seed_len as usize);
-    let result = match app_zcash::sign_pczt(&pczt.get_data(), seed) {
-        Ok(pczt) => match ZcashPczt::new(pczt).try_into() {
+    let result = match checked.verified_bytes() {
+        Ok(bytes) => match app_zcash::sign_pczt(bytes, seed) {
+            Ok(pczt) => match ZcashPczt::new(pczt).try_into() {
+                Err(e) => UREncodeResult::from(e).c_ptr(),
+                Ok(v) => UREncodeResult::encode(
+                    v,
+                    ZcashPczt::get_registry_type().get_type(),
+                    max_fragment_length,
+                )
+                .c_ptr(),
+            },
             Err(e) => UREncodeResult::from(e).c_ptr(),
-            Ok(v) => UREncodeResult::encode(
-                v,
-                ZcashPczt::get_registry_type().get_type(),
-                max_fragment_length,
-            )
-            .c_ptr(),
         },
         Err(e) => UREncodeResult::from(e).c_ptr(),
     };
@@ -579,7 +597,7 @@ unsafe fn sign_zcash_tx_dynamic(
 
 #[cfg(feature = "cypherpunk")]
 unsafe fn sign_zcash_tx_cypherpunk_dynamic(
-    tx: PtrUR,
+    checked_pczt: Ptr<ZcashCheckedPczt>,
     ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
@@ -588,66 +606,54 @@ unsafe fn sign_zcash_tx_cypherpunk_dynamic(
     seed_len: u32,
     max_fragment_length: usize,
 ) -> *mut UREncodeResult {
+    // ufvk is consumed by preflight now; the parameter is dropped together with
+    // the batch signature in the final cleanup task.
+    let _ = ufvk;
     if disabled {
         return UREncodeResult::from(RustCError::UnsupportedTransaction(
             "Zcash requires at least 256-bit entropy (use 33-word Shamir shares)".to_string(),
         ))
         .c_ptr();
     }
-
-    let pczt = extract_ptr_with_type!(tx, ZcashPczt);
-    let ufvk_text = unsafe { recover_c_char(ufvk) };
+    if checked_pczt.is_null() {
+        return UREncodeResult::from(RustCError::InvalidData(
+            "no checked PCZT available for signing".to_string(),
+        ))
+        .c_ptr();
+    }
+    let checked = extract_ptr_with_type!(checked_pczt, ZcashCheckedPczt);
     let expected_seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let expected_seed_fingerprint: &[u8; 32] = expected_seed_fingerprint.try_into().unwrap();
     let mut seed = extract_array_mut!(seed, u8, seed_len as usize);
-    let pczt_data = pczt.get_data();
 
-    let result = match check_zcash_pczt_message_cypherpunk(
-        &pczt_data,
-        &ufvk_text,
-        expected_seed_fingerprint,
-        account_index,
-    ) {
-        Ok(()) => {
-            let seed_fingerprint = calculate_seed_fingerprint(seed);
-            match seed_fingerprint {
-                Ok(seed_fingerprint) => {
-                    if &seed_fingerprint != expected_seed_fingerprint {
-                        seed.zeroize();
-                        return UREncodeResult::from(RustCError::MasterFingerprintMismatch).c_ptr();
-                    }
-
-                    match app_zcash::sign_pczt(&pczt_data, seed) {
-                        Ok(signed_pczt) => {
-                            if let Err(e) =
-                                app_zcash::ensure_owned_supported_shielded_actions_are_signed(
-                                    &MainNetwork,
-                                    &pczt_data,
-                                    &signed_pczt,
-                                    &seed_fingerprint,
-                                    account_index,
-                                )
-                            {
-                                seed.zeroize();
-                                return UREncodeResult::from(e).c_ptr();
-                            }
-
-                            match ZcashPczt::new(signed_pczt).try_into() {
-                                Err(e) => UREncodeResult::from(e).c_ptr(),
-                                Ok(v) => UREncodeResult::encode(
-                                    v,
-                                    ZcashPczt::get_registry_type().get_type(),
-                                    max_fragment_length,
-                                )
-                                .c_ptr(),
-                            }
-                        }
-                        Err(e) => UREncodeResult::from(e).c_ptr(),
-                    }
+    let result = match checked.verified_bytes() {
+        Ok(pczt_bytes) => match calculate_seed_fingerprint(seed) {
+            Ok(seed_fingerprint) => {
+                if &seed_fingerprint != expected_seed_fingerprint {
+                    seed.zeroize();
+                    return UREncodeResult::from(RustCError::MasterFingerprintMismatch).c_ptr();
                 }
-                Err(e) => UREncodeResult::from(e).c_ptr(),
+                match app_zcash::sign_checked_pczt(
+                    &MainNetwork,
+                    pczt_bytes,
+                    seed,
+                    &seed_fingerprint,
+                    account_index,
+                ) {
+                    Ok(signed_pczt) => match ZcashPczt::new(signed_pczt).try_into() {
+                        Err(e) => UREncodeResult::from(e).c_ptr(),
+                        Ok(v) => UREncodeResult::encode(
+                            v,
+                            ZcashPczt::get_registry_type().get_type(),
+                            max_fragment_length,
+                        )
+                        .c_ptr(),
+                    },
+                    Err(e) => UREncodeResult::from(e).c_ptr(),
+                }
             }
-        }
+            Err(e) => UREncodeResult::from(e).c_ptr(),
+        },
         Err(e) => UREncodeResult::from(e).c_ptr(),
     };
     seed.zeroize();
@@ -657,7 +663,7 @@ unsafe fn sign_zcash_tx_cypherpunk_dynamic(
 #[cfg(feature = "cypherpunk")]
 #[no_mangle]
 pub unsafe extern "C" fn sign_zcash_tx_cypherpunk(
-    tx: PtrUR,
+    checked_pczt: Ptr<ZcashCheckedPczt>,
     ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
@@ -666,7 +672,7 @@ pub unsafe extern "C" fn sign_zcash_tx_cypherpunk(
     seed_len: u32,
 ) -> *mut UREncodeResult {
     sign_zcash_tx_cypherpunk_dynamic(
-        tx,
+        checked_pczt,
         ufvk,
         seed_fingerprint,
         account_index,
@@ -680,7 +686,7 @@ pub unsafe extern "C" fn sign_zcash_tx_cypherpunk(
 #[cfg(feature = "cypherpunk")]
 #[no_mangle]
 pub unsafe extern "C" fn sign_zcash_tx_cypherpunk_unlimited(
-    tx: PtrUR,
+    checked_pczt: Ptr<ZcashCheckedPczt>,
     ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
@@ -689,7 +695,7 @@ pub unsafe extern "C" fn sign_zcash_tx_cypherpunk_unlimited(
     seed_len: u32,
 ) -> *mut UREncodeResult {
     sign_zcash_tx_cypherpunk_dynamic(
-        tx,
+        checked_pczt,
         ufvk,
         seed_fingerprint,
         account_index,

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn parse_zcash_tx_cypherpunk(
         .c_ptr();
     }
     let checked = extract_ptr_with_type!(checked_pczt, ZcashCheckedPczt);
-    let bytes = match checked.verified_bytes() {
+    let bytes = match checked.checked_bytes() {
         Ok(bytes) => bytes,
         Err(e) => return TransactionParseResult::from(e).c_ptr(),
     };
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn parse_zcash_tx_multi_coins(
         .c_ptr();
     }
     let checked = extract_ptr_with_type!(checked_pczt, ZcashCheckedPczt);
-    let bytes = match checked.verified_bytes() {
+    let bytes = match checked.checked_bytes() {
         Ok(bytes) => bytes,
         Err(e) => return TransactionParseResult::from(e).c_ptr(),
     };
@@ -374,7 +374,7 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
         .c_ptr();
     }
     let checked = extract_ptr_with_type!(checked_batch, ZcashCheckedPczt);
-    let bytes = match checked.verified_bytes() {
+    let bytes = match checked.checked_bytes() {
         Ok(bytes) => bytes,
         Err(e) => return TransactionParseResult::from(e).c_ptr(),
     };
@@ -432,7 +432,7 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
     let expected_seed_fingerprint: &[u8; 32] = expected_seed_fingerprint.try_into().unwrap();
     let mut seed = extract_array_mut!(seed, u8, seed_len as usize);
 
-    let result = match checked.verified_bytes() {
+    let result = match checked.checked_bytes() {
         Ok(bytes) => match ZcashSignBatch::try_from(bytes.to_vec()) {
             Ok(batch) => match calculate_seed_fingerprint(seed) {
                 Ok(seed_fingerprint) => {
@@ -580,7 +580,7 @@ unsafe fn sign_zcash_tx_dynamic(
     }
     let checked = extract_ptr_with_type!(checked_pczt, ZcashCheckedPczt);
     let mut seed = extract_array_mut!(seed, u8, seed_len as usize);
-    let result = match checked.verified_bytes() {
+    let result = match checked.checked_bytes() {
         Ok(bytes) => match app_zcash::sign_pczt(bytes, seed) {
             Ok(pczt) => match ZcashPczt::new(pczt).try_into() {
                 Err(e) => UREncodeResult::from(e).c_ptr(),
@@ -626,7 +626,7 @@ unsafe fn sign_zcash_tx_cypherpunk_dynamic(
     let expected_seed_fingerprint: &[u8; 32] = expected_seed_fingerprint.try_into().unwrap();
     let mut seed = extract_array_mut!(seed, u8, seed_len as usize);
 
-    let result = match checked.verified_bytes() {
+    let result = match checked.checked_bytes() {
         Ok(pczt_bytes) => match calculate_seed_fingerprint(seed) {
             Ok(seed_fingerprint) => {
                 if &seed_fingerprint != expected_seed_fingerprint {

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -408,7 +408,6 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
 #[cfg(feature = "cypherpunk")]
 unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
     checked_batch: Ptr<ZcashCheckedPczt>,
-    ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
     disabled: bool,
@@ -417,8 +416,6 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
     max_fragment_length: usize,
     allow_multipart: bool,
 ) -> *mut UREncodeResult {
-    // ufvk is consumed by preflight now; dropped in the final cleanup task.
-    let _ = ufvk;
     if disabled {
         return UREncodeResult::from(RustCError::UnsupportedTransaction(
             "Zcash requires at least 256-bit entropy (use 33-word Shamir shares)".to_string(),
@@ -514,7 +511,6 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
 #[no_mangle]
 pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk(
     checked_batch: Ptr<ZcashCheckedPczt>,
-    ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
     disabled: bool,
@@ -523,7 +519,6 @@ pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk(
 ) -> *mut UREncodeResult {
     sign_zcash_batch_tx_cypherpunk_dynamic(
         checked_batch,
-        ufvk,
         seed_fingerprint,
         account_index,
         disabled,
@@ -538,7 +533,6 @@ pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk(
 #[no_mangle]
 pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk_unlimited(
     checked_batch: Ptr<ZcashCheckedPczt>,
-    ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
     disabled: bool,
@@ -547,7 +541,6 @@ pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk_unlimited(
 ) -> *mut UREncodeResult {
     sign_zcash_batch_tx_cypherpunk_dynamic(
         checked_batch,
-        ufvk,
         seed_fingerprint,
         account_index,
         disabled,
@@ -612,7 +605,6 @@ unsafe fn sign_zcash_tx_dynamic(
 #[cfg(feature = "cypherpunk")]
 unsafe fn sign_zcash_tx_cypherpunk_dynamic(
     checked_pczt: Ptr<ZcashCheckedPczt>,
-    ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
     disabled: bool,
@@ -620,9 +612,6 @@ unsafe fn sign_zcash_tx_cypherpunk_dynamic(
     seed_len: u32,
     max_fragment_length: usize,
 ) -> *mut UREncodeResult {
-    // ufvk is consumed by preflight now; the parameter is dropped together with
-    // the batch signature in the final cleanup task.
-    let _ = ufvk;
     if disabled {
         return UREncodeResult::from(RustCError::UnsupportedTransaction(
             "Zcash requires at least 256-bit entropy (use 33-word Shamir shares)".to_string(),
@@ -678,7 +667,6 @@ unsafe fn sign_zcash_tx_cypherpunk_dynamic(
 #[no_mangle]
 pub unsafe extern "C" fn sign_zcash_tx_cypherpunk(
     checked_pczt: Ptr<ZcashCheckedPczt>,
-    ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
     disabled: bool,
@@ -687,7 +675,6 @@ pub unsafe extern "C" fn sign_zcash_tx_cypherpunk(
 ) -> *mut UREncodeResult {
     sign_zcash_tx_cypherpunk_dynamic(
         checked_pczt,
-        ufvk,
         seed_fingerprint,
         account_index,
         disabled,
@@ -701,7 +688,6 @@ pub unsafe extern "C" fn sign_zcash_tx_cypherpunk(
 #[no_mangle]
 pub unsafe extern "C" fn sign_zcash_tx_cypherpunk_unlimited(
     checked_pczt: Ptr<ZcashCheckedPczt>,
-    ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
     disabled: bool,
@@ -710,7 +696,6 @@ pub unsafe extern "C" fn sign_zcash_tx_cypherpunk_unlimited(
 ) -> *mut UREncodeResult {
     sign_zcash_tx_cypherpunk_dynamic(
         checked_pczt,
-        ufvk,
         seed_fingerprint,
         account_index,
         disabled,

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -286,28 +286,6 @@ fn validate_zcash_batch(batch: &ZcashSignBatch) -> Result<(), RustCError> {
 }
 
 #[cfg(feature = "cypherpunk")]
-fn check_zcash_batch_message_cypherpunk(
-    message: &ZcashSignMessage,
-    ufvk_text: &str,
-    seed_fingerprint: &[u8; 32],
-    account_index: u32,
-) -> app_zcash::errors::Result<()> {
-    app_zcash::check_pczt_cypherpunk(
-        &MainNetwork,
-        message.get_payload(),
-        ufvk_text,
-        seed_fingerprint,
-        account_index,
-    )?;
-    app_zcash::ensure_pczt_has_signable_shielded_action(
-        &MainNetwork,
-        message.get_payload(),
-        seed_fingerprint,
-        account_index,
-    )
-}
-
-#[cfg(feature = "cypherpunk")]
 #[no_mangle]
 pub unsafe extern "C" fn check_zcash_batch_tx_cypherpunk(
     tx: PtrUR,
@@ -315,7 +293,9 @@ pub unsafe extern "C" fn check_zcash_batch_tx_cypherpunk(
     seed_fingerprint: PtrBytes,
     account_index: u32,
     disabled: bool,
+    checked_batch: Ptr<Ptr<ZcashCheckedPczt>>,
 ) -> *mut TransactionCheckResult {
+    *checked_batch = core::ptr::null_mut();
     if disabled {
         return TransactionCheckResult::from(RustCError::UnsupportedTransaction(
             "Zcash requires at least 256-bit entropy (use 33-word Shamir shares)".to_string(),
@@ -331,27 +311,54 @@ pub unsafe extern "C" fn check_zcash_batch_tx_cypherpunk(
         return TransactionCheckResult::from(e).c_ptr();
     }
 
+    let mut checked_messages = Vec::with_capacity(batch.get_messages().len());
     for message in batch.get_messages() {
-        if let Err(e) = check_zcash_batch_message_cypherpunk(
-            message,
+        match app_zcash::preflight_batch_pczt_cypherpunk(
+            &MainNetwork,
+            message.get_payload(),
             &ufvk_text,
             seed_fingerprint,
             account_index,
         ) {
-            return TransactionCheckResult::from(e).c_ptr();
+            Ok(normalized) => {
+                let digest = sha256(&normalized).to_vec();
+                checked_messages.push(ZcashSignMessage::new(
+                    message.get_id().clone(),
+                    message.get_kind(),
+                    normalized,
+                    Some(digest),
+                ));
+            }
+            Err(e) => return TransactionCheckResult::from(e).c_ptr(),
         }
     }
 
-    TransactionCheckResult::new().c_ptr()
+    // Rebuild the envelope around the normalized payloads (with re-stamped
+    // per-message digests) so parse/sign consume exactly what was checked.
+    let normalized_batch = ZcashSignBatch::new(
+        batch.get_version(),
+        batch.get_request_id().clone(),
+        batch.get_network(),
+        checked_messages,
+        Some(true),
+    );
+    match TryInto::<Vec<u8>>::try_into(normalized_batch) {
+        Ok(bytes) => {
+            *checked_batch = ZcashCheckedPczt::new(bytes).c_ptr();
+            TransactionCheckResult::new().c_ptr()
+        }
+        // The encode error is a ur-registry error type; TransactionCheckResult
+        // has no From impl for it, so map explicitly.
+        Err(e) => TransactionCheckResult::from(RustCError::InvalidData(format!("{e:?}"))).c_ptr(),
+    }
 }
 
 #[cfg(feature = "cypherpunk")]
 #[no_mangle]
 pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
-    tx: PtrUR,
+    checked_batch: Ptr<ZcashCheckedPczt>,
     ufvk: PtrString,
     seed_fingerprint: PtrBytes,
-    account_index: u32,
     disabled: bool,
 ) -> Ptr<TransactionParseResult<DisplayZcashBatch>> {
     if disabled {
@@ -360,25 +367,30 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
         ))
         .c_ptr();
     }
-    let batch = extract_ptr_with_type!(tx, ZcashSignBatch);
+    if checked_batch.is_null() {
+        return TransactionParseResult::from(RustCError::InvalidData(
+            "no checked Zcash batch available".to_string(),
+        ))
+        .c_ptr();
+    }
+    let checked = extract_ptr_with_type!(checked_batch, ZcashCheckedPczt);
+    let bytes = match checked.verified_bytes() {
+        Ok(bytes) => bytes,
+        Err(e) => return TransactionParseResult::from(e).c_ptr(),
+    };
+    let batch = match ZcashSignBatch::try_from(bytes.to_vec()) {
+        Ok(batch) => batch,
+        Err(e) => {
+            return TransactionParseResult::from(RustCError::InvalidData(format!("{e:?}")))
+                .c_ptr()
+        }
+    };
     let ufvk_text = unsafe { recover_c_char(ufvk) };
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
 
-    if let Err(e) = validate_zcash_batch(batch) {
-        return TransactionParseResult::from(e).c_ptr();
-    }
-
     let mut display_items = Vec::new();
     for message in batch.get_messages() {
-        if let Err(e) = check_zcash_batch_message_cypherpunk(
-            message,
-            &ufvk_text,
-            seed_fingerprint,
-            account_index,
-        ) {
-            return TransactionParseResult::from(e).c_ptr();
-        }
         match app_zcash::parse_pczt_cypherpunk(
             &MainNetwork,
             message.get_payload(),
@@ -395,7 +407,7 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
 
 #[cfg(feature = "cypherpunk")]
 unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
-    tx: PtrUR,
+    checked_batch: Ptr<ZcashCheckedPczt>,
     ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
@@ -405,55 +417,46 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
     max_fragment_length: usize,
     allow_multipart: bool,
 ) -> *mut UREncodeResult {
+    // ufvk is consumed by preflight now; dropped in the final cleanup task.
+    let _ = ufvk;
     if disabled {
         return UREncodeResult::from(RustCError::UnsupportedTransaction(
             "Zcash requires at least 256-bit entropy (use 33-word Shamir shares)".to_string(),
         ))
         .c_ptr();
     }
-    let batch = extract_ptr_with_type!(tx, ZcashSignBatch);
-    let ufvk_text = unsafe { recover_c_char(ufvk) };
+    if checked_batch.is_null() {
+        return UREncodeResult::from(RustCError::InvalidData(
+            "no checked Zcash batch available for signing".to_string(),
+        ))
+        .c_ptr();
+    }
+    let checked = extract_ptr_with_type!(checked_batch, ZcashCheckedPczt);
     let expected_seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let expected_seed_fingerprint: &[u8; 32] = expected_seed_fingerprint.try_into().unwrap();
     let mut seed = extract_array_mut!(seed, u8, seed_len as usize);
 
-    let result = match validate_zcash_batch(batch) {
-        Ok(()) => {
-            let seed_fingerprint = calculate_seed_fingerprint(seed);
-            match seed_fingerprint {
+    let result = match checked.verified_bytes() {
+        Ok(bytes) => match ZcashSignBatch::try_from(bytes.to_vec()) {
+            Ok(batch) => match calculate_seed_fingerprint(seed) {
                 Ok(seed_fingerprint) => {
                     if &seed_fingerprint != expected_seed_fingerprint {
                         seed.zeroize();
-                        return UREncodeResult::from(RustCError::MasterFingerprintMismatch).c_ptr();
+                        return UREncodeResult::from(RustCError::MasterFingerprintMismatch)
+                            .c_ptr();
                     }
 
                     let mut results = Vec::new();
+                    let mut error = None;
                     for message in batch.get_messages() {
-                        if let Err(e) = check_zcash_batch_message_cypherpunk(
-                            message,
-                            &ufvk_text,
+                        match app_zcash::sign_checked_batch_pczt(
+                            &MainNetwork,
+                            message.get_payload(),
+                            seed,
                             &seed_fingerprint,
                             account_index,
                         ) {
-                            seed.zeroize();
-                            return UREncodeResult::from(e).c_ptr();
-                        }
-
-                        match app_zcash::sign_pczt(message.get_payload(), seed) {
                             Ok(payload) => {
-                                if let Err(e) =
-                                    app_zcash::ensure_signable_shielded_actions_are_signed(
-                                        &MainNetwork,
-                                        message.get_payload(),
-                                        &payload,
-                                        &seed_fingerprint,
-                                        account_index,
-                                    )
-                                {
-                                    seed.zeroize();
-                                    return UREncodeResult::from(e).c_ptr();
-                                }
-
                                 let payload_digest = sha256(&payload).to_vec();
                                 results.push(ZcashSignMessageResult::signed(
                                     message.get_id().clone(),
@@ -463,33 +466,44 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
                                 ));
                             }
                             Err(e) => {
-                                seed.zeroize();
-                                return UREncodeResult::from(e).c_ptr();
+                                error = Some(UREncodeResult::from(e).c_ptr());
+                                break;
                             }
                         }
                     }
 
-                    let result = ZcashSignResult::new(
-                        ZCASH_SIGN_BATCH_VERSION,
-                        batch.get_request_id().clone(),
-                        results,
-                    );
-                    match TryInto::<Vec<u8>>::try_into(result) {
-                        Ok(bytes) => {
-                            let registry_type = ZcashSignResult::get_registry_type().get_type();
-                            let encode_result = if allow_multipart {
-                                UREncodeResult::encode(bytes, registry_type, max_fragment_length)
-                            } else {
-                                UREncodeResult::encode_full_response(bytes, registry_type)
-                            };
-                            encode_result.c_ptr()
+                    if let Some(error) = error {
+                        error
+                    } else {
+                        let result = ZcashSignResult::new(
+                            ZCASH_SIGN_BATCH_VERSION,
+                            batch.get_request_id().clone(),
+                            results,
+                        );
+                        match TryInto::<Vec<u8>>::try_into(result) {
+                            Ok(bytes) => {
+                                let registry_type =
+                                    ZcashSignResult::get_registry_type().get_type();
+                                if allow_multipart {
+                                    UREncodeResult::encode(
+                                        bytes,
+                                        registry_type,
+                                        max_fragment_length,
+                                    )
+                                    .c_ptr()
+                                } else {
+                                    UREncodeResult::encode_full_response(bytes, registry_type)
+                                        .c_ptr()
+                                }
+                            }
+                            Err(e) => UREncodeResult::from(e).c_ptr(),
                         }
-                        Err(e) => UREncodeResult::from(e).c_ptr(),
                     }
                 }
                 Err(e) => UREncodeResult::from(e).c_ptr(),
-            }
-        }
+            },
+            Err(e) => UREncodeResult::from(RustCError::InvalidData(format!("{e:?}"))).c_ptr(),
+        },
         Err(e) => UREncodeResult::from(e).c_ptr(),
     };
     seed.zeroize();
@@ -499,7 +513,7 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
 #[cfg(feature = "cypherpunk")]
 #[no_mangle]
 pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk(
-    tx: PtrUR,
+    checked_batch: Ptr<ZcashCheckedPczt>,
     ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
@@ -508,7 +522,7 @@ pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk(
     seed_len: u32,
 ) -> *mut UREncodeResult {
     sign_zcash_batch_tx_cypherpunk_dynamic(
-        tx,
+        checked_batch,
         ufvk,
         seed_fingerprint,
         account_index,
@@ -523,7 +537,7 @@ pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk(
 #[cfg(feature = "cypherpunk")]
 #[no_mangle]
 pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk_unlimited(
-    tx: PtrUR,
+    checked_batch: Ptr<ZcashCheckedPczt>,
     ufvk: PtrString,
     seed_fingerprint: PtrBytes,
     account_index: u32,
@@ -532,7 +546,7 @@ pub unsafe extern "C" fn sign_zcash_batch_tx_cypherpunk_unlimited(
     seed_len: u32,
 ) -> *mut UREncodeResult {
     sign_zcash_batch_tx_cypherpunk_dynamic(
-        tx,
+        checked_batch,
         ufvk,
         seed_fingerprint,
         account_index,

--- a/rust/rust_c/src/zcash/structs.rs
+++ b/rust/rust_c/src/zcash/structs.rs
@@ -1,16 +1,18 @@
-use core::ptr::null_mut;
+use core::{ptr::null_mut, slice};
 
 use crate::common::{
+    errors::RustCError,
     ffi::VecFFI,
     free::Free,
     types::{Ptr, PtrString},
     utils::convert_c_char,
 };
 use crate::{free_str_ptr, free_vec, impl_c_ptr, impl_c_ptrs};
-use alloc::vec::Vec;
+use alloc::{string::ToString, vec::Vec};
 use app_zcash::pczt::structs::{
     ParsedFrom, ParsedOrchard, ParsedPczt, ParsedTo, ParsedTransparent,
 };
+use cryptoxide::hashing::sha256;
 use cstr_core;
 
 #[repr(C)]
@@ -214,3 +216,80 @@ impl_c_ptrs!(
     DisplayTo,
     DisplayOrchard
 );
+
+/// Preflight-verified, normalized transaction bytes retained by C between the
+/// check, display, and sign stages (`checked_PCZT` on the C side).
+///
+/// `data` is opaque to C: the normalized PCZT encoding in the single-transaction
+/// flow, or the normalized `ZcashSignBatch` CBOR in the batch flow. `digest` is
+/// the SHA-256 of those bytes, stamped at preflight; `verified_bytes` recomputes
+/// and compares it so parse/sign only operate on bytes produced by a successful
+/// preflight. Construct exclusively from preflight results.
+#[repr(C)]
+pub struct ZcashCheckedPczt {
+    pub data: Ptr<VecFFI<u8>>,
+    pub digest: [u8; 32],
+}
+
+impl ZcashCheckedPczt {
+    /// Wraps preflight-verified bytes and stamps their digest.
+    pub fn new(data: Vec<u8>) -> Self {
+        let digest = sha256(&data);
+        Self {
+            data: VecFFI::from(data).c_ptr(),
+            digest,
+        }
+    }
+
+    /// Borrows the checked bytes after re-verifying the digest stamped at
+    /// preflight, guarding against C handing back a different or corrupted
+    /// buffer than the one that was checked and displayed.
+    pub unsafe fn verified_bytes(&self) -> Result<&[u8], RustCError> {
+        if self.data.is_null() {
+            return Err(RustCError::InvalidData(
+                "checked PCZT has no data".to_string(),
+            ));
+        }
+        let vec = &*self.data;
+        let bytes = slice::from_raw_parts(vec.data, vec.size);
+        if sha256(bytes) != self.digest {
+            return Err(RustCError::InvalidData(
+                "checked PCZT digest mismatch".to_string(),
+            ));
+        }
+        Ok(bytes)
+    }
+}
+
+impl_c_ptr!(ZcashCheckedPczt);
+
+impl Free for ZcashCheckedPczt {
+    unsafe fn free(&self) {
+        if !self.data.is_null() {
+            let vec_ffi = alloc::boxed::Box::from_raw(self.data);
+            drop(Vec::from_raw_parts(vec_ffi.data, vec_ffi.size, vec_ffi.cap));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_checked_pczt_digest_round_trip() {
+        let checked = ZcashCheckedPczt::new(b"normalized-bytes".to_vec());
+        let bytes = unsafe { checked.verified_bytes() }.unwrap();
+        assert_eq!(bytes, b"normalized-bytes");
+        unsafe { checked.free() };
+    }
+
+    #[test]
+    fn test_checked_pczt_digest_mismatch_is_rejected() {
+        let mut checked = ZcashCheckedPczt::new(b"normalized-bytes".to_vec());
+        checked.digest[0] ^= 0xff;
+        assert!(unsafe { checked.verified_bytes() }.is_err());
+        unsafe { checked.free() };
+    }
+}

--- a/rust/rust_c/src/zcash/structs.rs
+++ b/rust/rust_c/src/zcash/structs.rs
@@ -12,7 +12,6 @@ use alloc::{string::ToString, vec::Vec};
 use app_zcash::pczt::structs::{
     ParsedFrom, ParsedOrchard, ParsedPczt, ParsedTo, ParsedTransparent,
 };
-use cryptoxide::hashing::sha256;
 use cstr_core;
 
 #[repr(C)]
@@ -221,43 +220,30 @@ impl_c_ptrs!(
 /// the check, display, and sign stages (`checked_PCZT` on the C side).
 ///
 /// `data` is opaque to C: the normalized PCZT encoding in the single-transaction
-/// flow, or the normalized `ZcashSignBatch` CBOR in the batch flow. `digest` is
-/// the SHA-256 of those bytes, stamped during check; `verified_bytes` recomputes
-/// and compares it so parse/sign only operate on bytes produced by a successful
-/// check. Construct exclusively from check results.
+/// flow, or the normalized `ZcashSignBatch` CBOR in the batch flow. Construct
+/// exclusively from check results.
 #[repr(C)]
 pub struct ZcashCheckedPczt {
     pub data: Ptr<VecFFI<u8>>,
-    pub digest: [u8; 32],
 }
 
 impl ZcashCheckedPczt {
-    /// Wraps bytes verified during check and stamps their digest.
+    /// Wraps bytes verified during check.
     pub fn new(data: Vec<u8>) -> Self {
-        let digest = sha256(&data);
         Self {
             data: VecFFI::from(data).c_ptr(),
-            digest,
         }
     }
 
-    /// Borrows the checked bytes after rechecking the digest stamped during
-    /// check, guarding against C handing back a different or corrupted
-    /// buffer than the one that was checked and displayed.
-    pub unsafe fn verified_bytes(&self) -> Result<&[u8], RustCError> {
+    /// Borrows the bytes produced by a successful check.
+    pub unsafe fn checked_bytes(&self) -> Result<&[u8], RustCError> {
         if self.data.is_null() {
             return Err(RustCError::InvalidData(
                 "checked PCZT has no data".to_string(),
             ));
         }
         let vec = &*self.data;
-        let bytes = slice::from_raw_parts(vec.data, vec.size);
-        if sha256(bytes) != self.digest {
-            return Err(RustCError::InvalidData(
-                "checked PCZT digest mismatch".to_string(),
-            ));
-        }
-        Ok(bytes)
+        Ok(slice::from_raw_parts(vec.data, vec.size))
     }
 }
 
@@ -278,18 +264,10 @@ mod tests {
     use alloc::vec::Vec;
 
     #[test]
-    fn test_checked_pczt_digest_round_trip() {
+    fn test_checked_pczt_bytes_round_trip() {
         let checked = ZcashCheckedPczt::new(b"normalized-bytes".to_vec());
-        let bytes = unsafe { checked.verified_bytes() }.unwrap();
+        let bytes = unsafe { checked.checked_bytes() }.unwrap();
         assert_eq!(bytes, b"normalized-bytes");
-        unsafe { checked.free() };
-    }
-
-    #[test]
-    fn test_checked_pczt_digest_mismatch_is_rejected() {
-        let mut checked = ZcashCheckedPczt::new(b"normalized-bytes".to_vec());
-        checked.digest[0] ^= 0xff;
-        assert!(unsafe { checked.verified_bytes() }.is_err());
         unsafe { checked.free() };
     }
 }

--- a/rust/rust_c/src/zcash/structs.rs
+++ b/rust/rust_c/src/zcash/structs.rs
@@ -217,14 +217,14 @@ impl_c_ptrs!(
     DisplayOrchard
 );
 
-/// Preflight-verified, normalized transaction bytes retained by C between the
-/// check, display, and sign stages (`checked_PCZT` on the C side).
+/// Normalized transaction bytes verified during check and retained by C between
+/// the check, display, and sign stages (`checked_PCZT` on the C side).
 ///
 /// `data` is opaque to C: the normalized PCZT encoding in the single-transaction
 /// flow, or the normalized `ZcashSignBatch` CBOR in the batch flow. `digest` is
-/// the SHA-256 of those bytes, stamped at preflight; `verified_bytes` recomputes
+/// the SHA-256 of those bytes, stamped during check; `verified_bytes` recomputes
 /// and compares it so parse/sign only operate on bytes produced by a successful
-/// preflight. Construct exclusively from preflight results.
+/// check. Construct exclusively from check results.
 #[repr(C)]
 pub struct ZcashCheckedPczt {
     pub data: Ptr<VecFFI<u8>>,
@@ -232,7 +232,7 @@ pub struct ZcashCheckedPczt {
 }
 
 impl ZcashCheckedPczt {
-    /// Wraps preflight-verified bytes and stamps their digest.
+    /// Wraps bytes verified during check and stamps their digest.
     pub fn new(data: Vec<u8>) -> Self {
         let digest = sha256(&data);
         Self {
@@ -241,8 +241,8 @@ impl ZcashCheckedPczt {
         }
     }
 
-    /// Borrows the checked bytes after re-verifying the digest stamped at
-    /// preflight, guarding against C handing back a different or corrupted
+    /// Borrows the checked bytes after rechecking the digest stamped during
+    /// check, guarding against C handing back a different or corrupted
     /// buffer than the one that was checked and displayed.
     pub unsafe fn verified_bytes(&self) -> Result<&[u8], RustCError> {
         if self.data.is_null() {

--- a/rust/zcash_vendor/Cargo.toml
+++ b/rust/zcash_vendor/Cargo.toml
@@ -41,20 +41,20 @@ chacha20poly1305 = { version = "0.10.1", default-features = false, features = [
 ] }
 postcard = { version = "1.0.3", features = ["alloc"] }
 getset = { version = "0.1.3" }
-orchard = { version = "0.15.0-pre.1", default-features = false, optional = true }
+orchard = { version = "0.15.0-pre.2", default-features = false, optional = true }
 pczt = { version = "0.7", default-features = false }
 serde = { workspace = true }
 serde_with = { version = "3.11.0", features = [
     "alloc",
     "macros",
 ], default-features = false }
-transparent = { package = "zcash_transparent", version = "0.8", default-features = false, features = [
+transparent = { package = "zcash_transparent", version = "0.9.0-pre.0", default-features = false, features = [
     "transparent-inputs",
 ] }
-zcash_address = { version = "0.12", default-features = false }
+zcash_address = { version = "0.13.0-pre.0", default-features = false }
 zcash_encoding = { version = "0.4", default-features = false }
-zcash_keys = { version = "0.14", default-features = false }
-zcash_protocol = { version = "0.9", default-features = false }
+zcash_keys = { version = "0.15.0-pre.0", default-features = false }
+zcash_protocol = { version = "0.10.0-pre.0", default-features = false }
 zip32 = { version = "0.2", default-features = false }
 rust_tools = { workspace = true }
 #zcash end
@@ -65,7 +65,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [dev-dependencies]
-transparent = { package = "zcash_transparent", version = "0.8", default-features = false, features = [
+transparent = { package = "zcash_transparent", version = "0.9.0-pre.0", default-features = false, features = [
     "transparent-inputs",
     "test-dependencies",
 ] }

--- a/rust/zcash_vendor/src/pczt_ext.rs
+++ b/rust/zcash_vendor/src/pczt_ext.rs
@@ -188,6 +188,31 @@ fn hash_transparent_tx_id(t_digests: Option<TransparentDigests>) -> Hash {
     h.finalize()
 }
 
+/// Orchard/Ironwood note ciphertext length; the ZIP-244 action digests slice it as
+/// 52 (compact) | 512 (memo) | 16 (non-compact).
+const ORCHARD_ENC_CIPHERTEXT_SIZE: usize = 580;
+
+/// The action's value-commitment bytes for the sighash. `cv_net` is `Option` in the v2
+/// PCZT wire model; the checked-PCZT preflight resolves it and `check::verify_cv_net`
+/// rejects any still-missing value before signing, so it is always present here. The zero
+/// fallback only keeps this infallible digest panic-free — a malformed PCZT then yields a
+/// non-matching sighash (an invalid signature), never a silent-but-valid one.
+fn action_cv_net(action: &pczt::orchard::Action) -> &[u8; 32] {
+    static ZERO: [u8; 32] = [0; 32];
+    action.cv_net().as_ref().unwrap_or(&ZERO)
+}
+
+/// The output's encrypted note ciphertext for the sighash. `resolve_fields` restores the
+/// full ciphertext from a memo-plaintext-only (`EncCiphertext::MemoPlaintext`) output; see
+/// [`action_cv_net`] for why the zero fallback is unreachable in the signing path.
+fn action_enc_ciphertext(output: &pczt::orchard::Output) -> &[u8] {
+    static ZERO: [u8; ORCHARD_ENC_CIPHERTEXT_SIZE] = [0; ORCHARD_ENC_CIPHERTEXT_SIZE];
+    match output.enc_ciphertext() {
+        pczt::orchard::EncCiphertext::Encrypted(c) if c.len() == ORCHARD_ENC_CIPHERTEXT_SIZE => c,
+        _ => &ZERO,
+    }
+}
+
 fn digest_orchard(pczt: &Pczt) -> Hash {
     let mut h = hasher(ZCASH_ORCHARD_HASH_PERSONALIZATION);
 
@@ -199,13 +224,13 @@ fn digest_orchard(pczt: &Pczt) -> Hash {
         ch.update(action.spend().nullifier());
         ch.update(action.output().cmx());
         ch.update(action.output().ephemeral_key());
-        ch.update(&action.output().enc_ciphertext()[..52]);
+        ch.update(&action_enc_ciphertext(action.output())[..52]);
 
-        mh.update(&action.output().enc_ciphertext()[52..564]);
+        mh.update(&action_enc_ciphertext(action.output())[52..564]);
 
-        nh.update(action.cv_net());
+        nh.update(action_cv_net(action));
         nh.update(action.spend().rk());
-        nh.update(&action.output().enc_ciphertext()[564..]);
+        nh.update(&action_enc_ciphertext(action.output())[564..]);
         nh.update(action.output().out_ciphertext());
     }
 
@@ -221,7 +246,9 @@ fn digest_orchard(pczt: &Pczt) -> Hash {
     };
     h.update(&value_balance.to_le_bytes());
 
-    h.update(pczt.orchard().anchor());
+    // v5 commits the anchor (v6 omits it). Present for well-formed v5 bundles; the empty
+    // fallback keeps this infallible — see `action_cv_net`.
+    h.update(pczt.orchard().anchor().as_ref().unwrap_or(&[0u8; 32]));
 
     h.finalize()
 }
@@ -354,13 +381,13 @@ fn digest_orchard_shaped_v6(
         ch.update(action.spend().nullifier());
         ch.update(action.output().cmx());
         ch.update(action.output().ephemeral_key());
-        ch.update(&action.output().enc_ciphertext()[..52]);
+        ch.update(&action_enc_ciphertext(action.output())[..52]);
 
-        mh.update(&action.output().enc_ciphertext()[52..564]);
+        mh.update(&action_enc_ciphertext(action.output())[52..564]);
 
-        nh.update(action.cv_net());
+        nh.update(action_cv_net(action));
         nh.update(action.spend().rk());
-        nh.update(&action.output().enc_ciphertext()[564..]);
+        nh.update(&action_enc_ciphertext(action.output())[564..]);
         nh.update(action.output().out_ciphertext());
     }
 
@@ -604,7 +631,7 @@ where
 pub fn sign_orchard<T>(llsigner: Signer, signer: &T) -> Result<Signer, T::Error>
 where
     T: PcztSigner,
-    T::Error: From<pczt::orchard::BundleParseError>,
+    T::Error: From<pczt::roles::low_level_signer::OrchardParseError>,
     T::Error: From<orchard::pczt::ParseError>,
     T::Error: From<transparent::pczt::ParseError>,
 {
@@ -657,7 +684,7 @@ where
 pub fn sign_ironwood<T>(llsigner: Signer, signer: &T) -> Result<Signer, T::Error>
 where
     T: PcztSigner,
-    T::Error: From<pczt::orchard::BundleParseError>,
+    T::Error: From<pczt::roles::low_level_signer::OrchardParseError>,
     T::Error: From<orchard::pczt::ParseError>,
     T::Error: From<transparent::pczt::ParseError>,
 {

--- a/src/ui/gui_chain/multi/gui_zcash.c
+++ b/src/ui/gui_chain/multi/gui_zcash.c
@@ -15,6 +15,15 @@ static URParseResult *g_urResult = NULL;
 static URParseMultiResult *g_urMultiResult = NULL;
 static void *g_parseResult = NULL;
 static DisplayPczt *g_zcashData;
+static ZcashCheckedPczt *g_checkedPczt = NULL;
+
+static void FreeCheckedPczt(void)
+{
+    if (g_checkedPczt != NULL) {
+        free_zcash_checked_pczt(g_checkedPczt);
+        g_checkedPczt = NULL;
+    }
+}
 
 #define CHECK_FREE_PARSE_RESULT(result)                                                             \
     if (result != NULL)                                                                             \
@@ -33,19 +42,21 @@ void GuiSetZcashUrData(URParseResult *urResult, URParseMultiResult *urMultiResul
 void *GuiGetZcashGUIData(void)
 {
     CHECK_FREE_PARSE_RESULT(g_parseResult);
-    void *data = g_isMulti ? g_urMultiResult->data : g_urResult->data;
+    if (g_checkedPczt == NULL) {
+        return NULL;
+    }
     uint8_t sfp[32];
     GetZcashSFP(GetCurrentAccountIndex(), sfp);
 
     PtrT_TransactionParseResult_DisplayPczt parseResult = NULL;
     do {
 #ifdef WEB3_VERSION
-        parseResult = parse_zcash_tx_multi_coins(data, sfp);
+        parseResult = parse_zcash_tx_multi_coins(g_checkedPczt, sfp);
 #endif
 #ifdef CYPHERPUNK_VERSION
         char ufvk[ZCASH_UFVK_MAX_LEN] = {'\0'};
         GetZcashUFVK(GetCurrentAccountIndex(), ufvk);
-        parseResult = parse_zcash_tx_cypherpunk(data, ufvk, sfp);
+        parseResult = parse_zcash_tx_cypherpunk(g_checkedPczt, ufvk, sfp);
 #endif
         CHECK_CHAIN_BREAK(parseResult);
         g_zcashData = parseResult->data;
@@ -327,14 +338,15 @@ PtrT_TransactionCheckResult GuiGetZcashCheckResult(void)
     MnemonicType mnemonicType = GetMnemonicType();
     printf("mnemonicType: %d\n", mnemonicType);
 
+    FreeCheckedPczt();
 #ifdef WEB3_VERSION
     char *xpub = GetCurrentAccountPublicKey(XPUB_TYPE_ZEC_TRANSPARENT_LEGACY);
-    return check_zcash_tx_multi_coins(data, xpub, sfp, zcash_account_index, mnemonicType == MNEMONIC_TYPE_SLIP39);
+    return check_zcash_tx_multi_coins(data, xpub, sfp, zcash_account_index, mnemonicType == MNEMONIC_TYPE_SLIP39, &g_checkedPczt);
 #endif
 #ifdef CYPHERPUNK_VERSION
     char ufvk[ZCASH_UFVK_MAX_LEN + 1] = {0};
     GetZcashUFVK(GetCurrentAccountIndex(), ufvk);
-    return check_zcash_tx_cypherpunk(data, ufvk, sfp, zcash_account_index, !IsZcashSupportedForCurrentMnemonic());
+    return check_zcash_tx_cypherpunk(data, ufvk, sfp, zcash_account_index, !IsZcashSupportedForCurrentMnemonic(), &g_checkedPczt);
 #endif
 }
 
@@ -391,28 +403,26 @@ static UREncodeResult *SignZcashCypherpunkInternal(void *data, bool unlimited)
     return GuiSignZcashCypherpunkWithSeed(
                data,
                unlimited,
-               sign_zcash_tx_cypherpunk,
-               sign_zcash_tx_cypherpunk_unlimited);
+               (ZcashCypherpunkSignFunc)sign_zcash_tx_cypherpunk,
+               (ZcashCypherpunkSignFunc)sign_zcash_tx_cypherpunk_unlimited);
 }
 #endif
 
 UREncodeResult *GuiGetZcashSignQrCodeData(void)
 {
-    void *data = g_isMulti ? g_urMultiResult->data : g_urResult->data;
 #ifdef CYPHERPUNK_VERSION
-    return SignZcashCypherpunkInternal(data, false);
+    return SignZcashCypherpunkInternal(g_checkedPczt, false);
 #else
-    return SignInternal(sign_zcash_tx, data);
+    return SignInternal((SignFn)sign_zcash_tx, g_checkedPczt);
 #endif
 }
 
 UREncodeResult *GuiGetZcashSignUrDataUnlimited(void)
 {
-    void *data = g_isMulti ? g_urMultiResult->data : g_urResult->data;
 #ifdef CYPHERPUNK_VERSION
-    return SignZcashCypherpunkInternal(data, true);
+    return SignZcashCypherpunkInternal(g_checkedPczt, true);
 #else
-    return SignInternal(sign_zcash_tx_unlimited, data);
+    return SignInternal((SignFn)sign_zcash_tx_unlimited, g_checkedPczt);
 #endif
 }
 
@@ -421,4 +431,5 @@ void FreeZcashMemory(void)
     CHECK_FREE_UR_RESULT(g_urResult, false);
     CHECK_FREE_UR_RESULT(g_urMultiResult, true);
     CHECK_FREE_PARSE_RESULT(g_parseResult);
+    FreeCheckedPczt();
 }

--- a/src/ui/gui_chain/multi/gui_zcash.c
+++ b/src/ui/gui_chain/multi/gui_zcash.c
@@ -362,14 +362,13 @@ UREncodeResult *GuiSignZcashCypherpunkWithSeed(void *data,
     uint8_t seed[SEED_LEN] = {0};
     uint8_t sfp[32] = {0};
     uint32_t zcashAccountIndex = 0;
-    char ufvk[ZCASH_UFVK_MAX_LEN + 1] = {0};
     bool disabled = !IsZcashSupportedForCurrentMnemonic();
     int ret = 0;
 
     do {
         ZcashCypherpunkSignFunc selectedSignFunc = unlimited ? unlimitedSignFunc : signFunc;
         if (disabled) {
-            encodeResult = selectedSignFunc(data, ufvk, sfp, zcashAccountIndex, true, seed, 0);
+            encodeResult = selectedSignFunc(data, sfp, zcashAccountIndex, true, seed, 0);
             CHECK_CHAIN_BREAK(encodeResult);
             break;
         }
@@ -382,13 +381,9 @@ UREncodeResult *GuiSignZcashCypherpunkWithSeed(void *data,
         if (ret != 0) {
             break;
         }
-        ret = GetZcashUFVK(GetCurrentAccountIndex(), ufvk);
-        if (ret != 0) {
-            break;
-        }
 
         int len = GetMnemonicType() == MNEMONIC_TYPE_BIP39 ? sizeof(seed) : GetCurrentAccountEntropyLen();
-        encodeResult = selectedSignFunc(data, ufvk, sfp, zcashAccountIndex, false, seed, len);
+        encodeResult = selectedSignFunc(data, sfp, zcashAccountIndex, false, seed, len);
         CHECK_CHAIN_BREAK(encodeResult);
     } while (0);
 

--- a/src/ui/gui_chain/multi/gui_zcash.h
+++ b/src/ui/gui_chain/multi/gui_zcash.h
@@ -10,7 +10,6 @@ void GuiZcashOverview(lv_obj_t *parent, void *totalData);
 PtrT_TransactionCheckResult GuiGetZcashCheckResult(void);
 #ifdef CYPHERPUNK_VERSION
 typedef UREncodeResult *(*ZcashCypherpunkSignFunc)(void *data,
-        PtrString ufvk,
         PtrBytes seedFingerprint,
         uint32_t accountIndex,
         bool disabled,

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
@@ -32,6 +32,7 @@ static uint32_t g_txCount = 0;
 static TransactionParseResult_DisplayZcashBatch *g_parseResult = NULL;
 static DisplayZcashBatch *g_displayZcashBatch = NULL;
 static DisplayPczt *g_currentTransaction = NULL;
+static ZcashCheckedPczt *g_checkedBatch = NULL;
 
 static PageWidget_t *g_pageWidget = NULL;
 static lv_obj_t *g_cont = NULL;
@@ -54,12 +55,22 @@ static bool IsZcashBatchUsbMode(void);
 static void RejectZcashBatchUsbRequest(void);
 static void RespondZcashBatchUsbParseError(const char *errorMessage);
 
+static void FreeCheckedBatch(void)
+{
+    if (g_checkedBatch != NULL) {
+        free_zcash_checked_pczt(g_checkedBatch);
+        g_checkedBatch = NULL;
+    }
+}
+
 static void ClearPageData(void)
 {
     g_currentTxIndex = 0;
     g_txCount = 0;
     g_currentTransaction = NULL;
     g_displayZcashBatch = NULL;
+
+    FreeCheckedBatch();
 
     if (g_parseResult != NULL) {
         free_TransactionParseResult_DisplayZcashBatch(g_parseResult);
@@ -82,14 +93,12 @@ void GuiSetZcashBatchUrData(URParseResult *urResult, URParseMultiResult *urMulti
 
 UREncodeResult *GuiGetZcashBatchSignQrCodeData(void)
 {
-    void *data = g_isMulti ? g_urMultiResult->data : g_urResult->data;
-    return SignZcashBatchInternal(data, false);
+    return SignZcashBatchInternal(g_checkedBatch, false);
 }
 
 UREncodeResult *GuiGetZcashBatchSignUrDataUnlimited(void)
 {
-    void *data = g_isMulti ? g_urMultiResult->data : g_urResult->data;
-    return SignZcashBatchInternal(data, true);
+    return SignZcashBatchInternal(g_checkedBatch, true);
 }
 
 static bool IsZcashBatchUsbMode(void)
@@ -124,8 +133,8 @@ static UREncodeResult *SignZcashBatchInternal(void *data, bool unlimited)
     return GuiSignZcashCypherpunkWithSeed(
                data,
                unlimited,
-               sign_zcash_batch_tx_cypherpunk,
-               sign_zcash_batch_tx_cypherpunk_unlimited);
+               (ZcashCypherpunkSignFunc)sign_zcash_batch_tx_cypherpunk,
+               (ZcashCypherpunkSignFunc)sign_zcash_batch_tx_cypherpunk_unlimited);
 }
 
 #ifdef CYPHERPUNK_VERSION
@@ -137,9 +146,11 @@ PtrT_TransactionCheckResult GuiGetZcashBatchCheckResult(void)
     uint8_t accountNum = 0;
     char ufvk[ZCASH_UFVK_MAX_LEN + 1] = {0};
 
+    FreeCheckedBatch();
+
     GetExistAccountNum(&accountNum);
     if (accountNum <= 0) {
-        return check_zcash_batch_tx_cypherpunk(data, ufvk, sfp, zcashAccountIndex, true);
+        return check_zcash_batch_tx_cypherpunk(data, ufvk, sfp, zcashAccountIndex, true, &g_checkedBatch);
     }
 
     GetZcashSFP(GetCurrentAccountIndex(), sfp);
@@ -149,7 +160,8 @@ PtrT_TransactionCheckResult GuiGetZcashBatchCheckResult(void)
                ufvk,
                sfp,
                zcashAccountIndex,
-               !IsZcashSupportedForCurrentMnemonic());
+               !IsZcashSupportedForCurrentMnemonic(),
+               &g_checkedBatch);
 }
 #endif
 
@@ -363,18 +375,15 @@ void GuiZcashBatchWidgetsRefresh(void)
 
 static void *GuiParseZcashBatchData(void)
 {
-    void *data = g_isMulti ? g_urMultiResult->data : g_urResult->data;
     uint8_t sfp[32];
-    uint32_t zcashAccountIndex = 0;
     GetZcashSFP(GetCurrentAccountIndex(), sfp);
 
     char ufvk[ZCASH_UFVK_MAX_LEN + 1] = {0};
     GetZcashUFVK(GetCurrentAccountIndex(), ufvk);
     g_parseResult = parse_zcash_batch_tx_cypherpunk(
-        data,
+        g_checkedBatch,
         ufvk,
         sfp,
-        zcashAccountIndex,
         !IsZcashSupportedForCurrentMnemonic());
 
     return g_parseResult;

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
@@ -33,6 +33,10 @@ static TransactionParseResult_DisplayZcashBatch *g_parseResult = NULL;
 static DisplayZcashBatch *g_displayZcashBatch = NULL;
 static DisplayPczt *g_currentTransaction = NULL;
 static ZcashCheckedPczt *g_checkedBatch = NULL;
+// Holds a batch preflight failure message when the QR display path runs the
+// check itself (see GuiParseZcashBatchData), so the parse-fail handler can
+// surface it instead of a generic "invalid QR" window.
+static char g_batchPreflightError[128] = {0};
 
 static PageWidget_t *g_pageWidget = NULL;
 static lv_obj_t *g_cont = NULL;
@@ -375,6 +379,29 @@ void GuiZcashBatchWidgetsRefresh(void)
 
 static void *GuiParseZcashBatchData(void)
 {
+    g_batchPreflightError[0] = '\0';
+
+    // The QR scan path opens this view directly (gui_scan_widgets.c), bypassing
+    // the model check step that the USB path runs, so the preflight that
+    // populates g_checkedBatch has not run yet. g_checkedBatch is the normalized,
+    // checked bytes that this parse and later signing consume, so run the
+    // preflight here when it is missing. On failure, stash the real message for
+    // the parse-fail handler; only after it passes can parse succeed.
+    if (g_checkedBatch == NULL) {
+        PtrT_TransactionCheckResult checkResult = GuiGetZcashBatchCheckResult();
+        if (checkResult == NULL || checkResult->error_code != 0) {
+            if (checkResult != NULL) {
+                if (checkResult->error_message != NULL) {
+                    snprintf_s(g_batchPreflightError, sizeof(g_batchPreflightError), "%s",
+                               checkResult->error_message);
+                }
+                free_TransactionCheckResult(checkResult);
+            }
+            return NULL;
+        }
+        free_TransactionCheckResult(checkResult);
+    }
+
     uint8_t sfp[32];
     GetZcashSFP(GetCurrentAccountIndex(), sfp);
 
@@ -400,13 +427,18 @@ void GuiZcashBatchWidgetsTransactionParseSuccess(void)
 void GuiZcashBatchWidgetsTransactionParseFail(void)
 {
     printf("GuiZcashBatchWidgetsTransactionParseFail\n");
-    if (g_parseResult != NULL) {
-        printf("error: %s\n", g_parseResult->error_message);
+    // A failed preflight leaves g_parseResult NULL but records its message in
+    // g_batchPreflightError; prefer whichever carries the real reason.
+    const char *errorMessage = (g_parseResult != NULL)
+                               ? g_parseResult->error_message
+                               : (g_batchPreflightError[0] != '\0' ? g_batchPreflightError : NULL);
+    if (errorMessage != NULL) {
+        printf("error: %s\n", errorMessage);
         if (IsZcashBatchUsbMode()) {
-            RespondZcashBatchUsbParseError(g_parseResult->error_message);
+            RespondZcashBatchUsbParseError(errorMessage);
             return;
         }
-        g_parseErrorHintBox = GuiCreateZcashBatchParseErrorWindow(g_parseResult->error_message);
+        g_parseErrorHintBox = GuiCreateZcashBatchParseErrorWindow(errorMessage);
         return;
     }
     if (IsZcashBatchUsbMode()) {

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
@@ -33,10 +33,10 @@ static TransactionParseResult_DisplayZcashBatch *g_parseResult = NULL;
 static DisplayZcashBatch *g_displayZcashBatch = NULL;
 static DisplayPczt *g_currentTransaction = NULL;
 static ZcashCheckedPczt *g_checkedBatch = NULL;
-// Holds a batch preflight failure message when the QR display path runs the
+// Holds a batch check failure message when the QR display path runs the
 // check itself (see GuiParseZcashBatchData), so the parse-fail handler can
 // surface it instead of a generic "invalid QR" window.
-static char g_batchPreflightError[128] = {0};
+static char g_batchCheckError[128] = {0};
 
 static PageWidget_t *g_pageWidget = NULL;
 static lv_obj_t *g_cont = NULL;
@@ -379,20 +379,20 @@ void GuiZcashBatchWidgetsRefresh(void)
 
 static void *GuiParseZcashBatchData(void)
 {
-    g_batchPreflightError[0] = '\0';
+    g_batchCheckError[0] = '\0';
 
     // The QR scan path opens this view directly (gui_scan_widgets.c), bypassing
-    // the model check step that the USB path runs, so the preflight that
+    // the model check step that the USB path runs, so the check that
     // populates g_checkedBatch has not run yet. g_checkedBatch is the normalized,
     // checked bytes that this parse and later signing consume, so run the
-    // preflight here when it is missing. On failure, stash the real message for
+    // check here when it is missing. On failure, stash the real message for
     // the parse-fail handler; only after it passes can parse succeed.
     if (g_checkedBatch == NULL) {
         PtrT_TransactionCheckResult checkResult = GuiGetZcashBatchCheckResult();
         if (checkResult == NULL || checkResult->error_code != 0) {
             if (checkResult != NULL) {
                 if (checkResult->error_message != NULL) {
-                    snprintf_s(g_batchPreflightError, sizeof(g_batchPreflightError), "%s",
+                    snprintf_s(g_batchCheckError, sizeof(g_batchCheckError), "%s",
                                checkResult->error_message);
                 }
                 free_TransactionCheckResult(checkResult);
@@ -427,11 +427,11 @@ void GuiZcashBatchWidgetsTransactionParseSuccess(void)
 void GuiZcashBatchWidgetsTransactionParseFail(void)
 {
     printf("GuiZcashBatchWidgetsTransactionParseFail\n");
-    // A failed preflight leaves g_parseResult NULL but records its message in
-    // g_batchPreflightError; prefer whichever carries the real reason.
+    // A failed check leaves g_parseResult NULL but records its message in
+    // g_batchCheckError; prefer whichever carries the real reason.
     const char *errorMessage = (g_parseResult != NULL)
                                ? g_parseResult->error_message
-                               : (g_batchPreflightError[0] != '\0' ? g_batchPreflightError : NULL);
+                               : (g_batchCheckError[0] != '\0' ? g_batchCheckError : NULL);
     if (errorMessage != NULL) {
         printf("error: %s\n", errorMessage);
         if (IsZcashBatchUsbMode()) {


### PR DESCRIPTION
## Summary

Makes the Zcash check step the single policy preflight for both single and batch PCZTs. It resolves compact fields, applies account and signing-policy checks, and returns normalized checked bytes that the UI retains for display and signing.

This removes repeated policy checks and the UFVK dependency from signing, keeps post-sign verification in memory, and updates the pinned PCZT/Orchard stack needed for field resolution. The QR batch path now runs preflight before rendering.

## Validation

- `app_zcash` and `rust_c` tests for cypherpunk and multi-coins
- Rust coverage and formatting gates
- Cypherpunk and WEB3 simulator builds