### PR TITLE
Zcash: single-pass batch review and output-recoverability enforcement

### DIFF
--- a/.github/workflows/rust-zcash-checks.yml
+++ b/.github/workflows/rust-zcash-checks.yml
@@ -2,6 +2,10 @@ on:
   pull_request:
     paths:
       - rust/apps/zcash/**
+      - rust/zcash_vendor/**
+      - rust/rust_c/src/zcash/**
+      - rust/rust_c/src/common/ur.rs
+      - rust/rust_c/src/common/ur_ext.rs
 
 name: Zcash Checks
 
@@ -28,3 +32,25 @@ jobs:
 
       - name: Run rust/apps/zcash
         run: cd rust/apps/zcash && cargo +$RUST_TOOLCHAIN llvm-cov  --fail-under-regions 69 --fail-under-functions 71 --fail-under-lines 76 --ignore-filename-regex 'keystore/*|utils/*|zcash_vendor/*'
+
+  # The rust_c Zcash FFI tests (batch validation, reviewed-batch fingerprint)
+  # only build under the simulator feature set (the device feature set has no
+  # host panic handler), and the simulator's screen-capture dependency needs
+  # macOS on CI.
+  RustCZcashTest:
+    name: rust_c Zcash FFI tests
+    runs-on: macos-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Read Rust toolchain
+        run: echo "RUST_TOOLCHAIN=$(cat rust-toolchain)" >> $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Run rust_c zcash tests
+        run: cd rust && cargo +$RUST_TOOLCHAIN test -p rust_c --no-default-features --features simulator-cypherpunk --lib -- zcash common::ur

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -2,4 +2,3 @@
 ## This path is hardcoded into the Makefiles, so make sure a contributor’s
 ## config hasn’t overridden it.
 target-dir = "target"
-rustflags = ["--cfg", "zcash_unstable=\"nu6.3\""]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives",
  "zcash_vendor",
+ "zeroize",
 ]
 
 [[package]]

--- a/rust/apps/zcash/Cargo.toml
+++ b/rust/apps/zcash/Cargo.toml
@@ -38,7 +38,6 @@ orchard = { version = "0.15.0-pre.2", default-features = false }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(coverage_nightly)',
-    'cfg(zcash_unstable, values("nu6.3"))',
 ] }
 
 [features]

--- a/rust/apps/zcash/Cargo.toml
+++ b/rust/apps/zcash/Cargo.toml
@@ -23,6 +23,7 @@ serde_with = { version = "3.11.0", features = [
     "alloc",
     "macros",
 ], default-features = false }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 keystore = { path = "../../keystore" }

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -1042,6 +1042,37 @@ mod tests {
     }
 
     #[test]
+    fn test_check_rejects_foreign_restricted_orchard_output() {
+        let sample = pczt::test_support::sample_orchard_foreign_change_pczt();
+        let expected =
+            "funded Orchard output paired with a zero-value spend does not belong to the selected account";
+
+        for result in [
+            check_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                0,
+            )
+            .map(|_| ()),
+            check_and_parse_batch_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                0,
+            )
+            .map(|_| ()),
+        ] {
+            match result {
+                Err(ZcashError::InvalidPczt(message)) if message == expected => {}
+                other => panic!("check must reject foreign restricted output, got: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn test_get_address() {
         let address = get_address(&MainNetwork, "uview1s2e0495jzhdarezq4h4xsunfk4jrq7gzg22tjjmkzpd28wgse4ejm6k7yfg8weanaghmwsvc69clwxz9f9z2hwaz4gegmna0plqrf05zkeue0nevnxzm557rwdkjzl4pl4hp4q9ywyszyjca8jl54730aymaprt8t0kxj8ays4fs682kf7prj9p24dnlcgqtnd2vnskkm7u8cwz8n0ce7yrwx967cyp6dhkc2wqprt84q0jmwzwnufyxe3j0758a9zgk9ssrrnywzkwfhu6ap6cgx3jkxs3un53n75s3");
         assert_eq!(address.unwrap(), "u1tqdskj32l9udfp0rysmca6gpz73fdqc2rmeenyhh0nfrq4vgak284ehkxefw5cf9495rdur0tparuntevp6nnetzjkyzv08m524e4swwk94asas7hm2ad5w5c64zz00hmr7nux0yhaz");
@@ -1598,6 +1629,83 @@ mod tests {
             )
             .unwrap_err(),
             ZcashError::PcztNoMyInputs
+        );
+    }
+
+    #[test]
+    fn test_check_rejects_undecryptable_ironwood_output() {
+        use zcash_vendor::pczt::Pczt;
+
+        /// Flips a byte inside the first verbatim occurrence of `needle`.
+        fn corrupt_first_occurrence(haystack: &mut [u8], needle: &[u8]) -> bool {
+            if needle.is_empty() || needle.len() > haystack.len() {
+                return false;
+            }
+            for start in 0..=haystack.len() - needle.len() {
+                if &haystack[start..start + needle.len()] == needle {
+                    haystack[start + needle.len() / 2] ^= 0xff;
+                    return true;
+                }
+            }
+            false
+        }
+
+        let sample = pczt::test_support::sample_migration_pczt();
+
+        // Extract the non-zero Ironwood output's ciphertext bytes.
+        let enc_ciphertext = {
+            let pczt = Pczt::parse(&sample.bytes).expect("sample PCZT should parse");
+            pczt.ironwood()
+                .actions()
+                .iter()
+                .find(|action| matches!(action.output().value(), Some(value) if *value != 0))
+                .expect("migration child must contain a non-zero Ironwood output")
+                .output()
+                .enc_ciphertext()
+                .clone()
+                .into_encrypted()
+                .expect("the sample's Ironwood output carries a full enc_ciphertext")
+        };
+
+        // Corrupt only the ciphertext: cmx, cv_net, the value balance, and the
+        // plaintext recipient are all untouched, so every other check still
+        // passes and only decryption/recoverability fails.
+        let mut corrupted = sample.bytes.clone();
+        assert!(
+            corrupt_first_occurrence(&mut corrupted, &enc_ciphertext),
+            "sample must embed the Ironwood output enc_ciphertext verbatim"
+        );
+        assert!(
+            Pczt::parse(&corrupted).is_ok(),
+            "corruption must keep the PCZT structurally well-formed"
+        );
+
+        let check_err = check_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &corrupted,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect_err("check must reject a PCZT with an undecryptable output");
+        assert!(
+            matches!(&check_err, ZcashError::InvalidPczt(message) if message.contains("undecryptable")),
+            "expected an undecryptable-output rejection, got {check_err:?}"
+        );
+
+        // Both review paths enforce the same output-recoverability contract.
+        assert!(
+            matches!(
+                check_and_parse_batch_pczt_cypherpunk(
+                    &pczt::test_support::Nu6_3Network,
+                    &corrupted,
+                    &sample.ufvk_text,
+                    &sample.seed_fingerprint,
+                    0,
+                ),
+                Err(ZcashError::InvalidPczt(message)) if message.contains("undecryptable")
+            ),
+            "single-pass batch review must also reject the undecryptable output"
         );
     }
 

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -216,7 +216,6 @@ fn transparent_account_pubkey_from_xpub(
 
 #[cfg(feature = "multi_coins")]
 fn reject_legacy_check_unsupported_pczt(pczt: &Pczt) -> Result<()> {
-    #[cfg(zcash_unstable = "nu6.3")]
     {
         // The legacy multi-coins check path only verifies transparent data. Reject any
         // shielded (Sapling/Orchard/Ironwood) or V6 PCZT so check, parse, and sign
@@ -386,7 +385,6 @@ mod legacy_tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_check_rejects_v6_pczt() {
         let pczt = Creator::new(
@@ -431,7 +429,6 @@ fn map_shielded_verifier_error(
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SignableShieldedPool {
     Orchard,
-    #[cfg(zcash_unstable = "nu6.3")]
     Ironwood,
 }
 
@@ -440,7 +437,6 @@ impl SignableShieldedPool {
     fn label(self) -> &'static str {
         match self {
             SignableShieldedPool::Orchard => "Orchard",
-            #[cfg(zcash_unstable = "nu6.3")]
             SignableShieldedPool::Ironwood => "Ironwood",
         }
     }
@@ -448,7 +444,6 @@ impl SignableShieldedPool {
     fn shielded_pool(self) -> pczt::ShieldedPool {
         match self {
             SignableShieldedPool::Orchard => pczt::ShieldedPool::Orchard,
-            #[cfg(zcash_unstable = "nu6.3")]
             SignableShieldedPool::Ironwood => pczt::ShieldedPool::Ironwood,
         }
     }
@@ -575,7 +570,6 @@ fn signable_shielded_actions<P: consensus::Parameters>(
         reject_unsupported_batch_pczt(&pczt)?;
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let should_process_ironwood = pczt::pczt_should_process_ironwood(&pczt);
     let mut actions = Vec::new();
     let verifier = Verifier::new(pczt)
@@ -592,7 +586,6 @@ fn signable_shielded_actions<P: consensus::Parameters>(
         })
         .map_err(map_shielded_verifier_error)?;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let verifier = if should_process_ironwood {
         verifier
             .with_ironwood::<ZcashError, _>(|bundle| {
@@ -622,7 +615,6 @@ fn ensure_shielded_actions_are_signed(
 ) -> Result<Pczt> {
     use zcash_vendor::pczt::roles::verifier::Verifier;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let should_process_ironwood = pczt::pczt_should_process_ironwood(&signed_pczt);
     let verifier = Verifier::new(signed_pczt)
         .with_orchard::<ZcashError, _>(|bundle| {
@@ -630,7 +622,6 @@ fn ensure_shielded_actions_are_signed(
         })
         .map_err(map_shielded_verifier_error)?;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let verifier = if should_process_ironwood {
         verifier
             .with_ironwood::<ZcashError, _>(|bundle| {
@@ -794,7 +785,6 @@ mod tests {
         derivation_path: Vec<u32>,
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     fn v5_pczt_with_ironwood_actions() -> Vec<u8> {
         let sample = pczt::test_support::sample_ironwood_pczt();
         let bytes = sample.bytes;
@@ -992,7 +982,6 @@ mod tests {
         assert_eq!(address.unwrap(), "u1tqdskj32l9udfp0rysmca6gpz73fdqc2rmeenyhh0nfrq4vgak284ehkxefw5cf9495rdur0tparuntevp6nnetzjkyzv08m524e4swwk94asas7hm2ad5w5c64zz00hmr7nux0yhaz");
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_pczt_ironwood_to_ironwood() {
         let sample = pczt::test_support::sample_ironwood_pczt();
@@ -1030,7 +1019,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_parse_pczt_orchard_decodes_spend_and_change() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
@@ -1073,7 +1061,6 @@ mod tests {
         .unwrap();
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_parse_and_check_ignore_unsupported_ironwood_spend_zip32_path() {
         let sample = pczt::test_support::sample_ironwood_pczt();
@@ -1117,7 +1104,6 @@ mod tests {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_parse_and_check_ignore_dummy_ironwood_spend_zip32_metadata() {
         let sample = pczt::test_support::sample_ironwood_pczt();
@@ -1156,7 +1142,6 @@ mod tests {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_parse_check_and_sign_reject_v5_pczt_with_ironwood_actions() {
         let sample = pczt::test_support::sample_ironwood_pczt();
@@ -1216,7 +1201,6 @@ mod tests {
         assert!(matches!(result.unwrap_err(), ZcashError::InvalidPczt(_)));
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_check_pczt_normalizes_and_is_idempotent() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
@@ -1288,7 +1272,6 @@ mod tests {
     const BATCH_UNSUPPORTED_SAPLING_ERROR: &str =
         "Zcash batch PCZT must not contain Sapling spends or outputs";
 
-    #[cfg(zcash_unstable = "nu6.3")]
     fn pczt_with_sapling_output() -> pczt::test_support::SamplePczt {
         let mut sample = pczt::test_support::sample_orchard_change_pczt();
         let (mut prefix, rest) =
@@ -1335,7 +1318,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_checked_batch_pczt_signs_ironwood_spend() {
         let sample = pczt::test_support::sample_ironwood_pczt();
@@ -1363,7 +1345,6 @@ mod tests {
             .any(|action| action.spend().spend_auth_sig().is_some()));
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_checked_pczt_signs_owned_orchard_actions() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
@@ -1395,7 +1376,6 @@ mod tests {
         assert_eq!(signed_actions, 2);
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_checked_pczt_rejects_foreign_seed() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
@@ -1420,7 +1400,6 @@ mod tests {
         assert!(matches!(result, Err(ZcashError::PcztNoMyInputs)));
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_checked_batch_pczt_signs_and_rejects_sapling() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
@@ -1462,7 +1441,6 @@ mod tests {
         ));
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_check_batch_pczt_accepts_orchard_and_ironwood_spends() {
         for sample in [
@@ -1494,7 +1472,6 @@ mod tests {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_check_resolves_compact_pczt_and_signs() {
         use zcash_vendor::pczt::roles::redactor::Redactor;
@@ -1571,7 +1548,6 @@ mod tests {
             .any(|action| action.spend().spend_auth_sig().is_some()));
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_check_batch_pczt_rejects_sapling_outputs() {
         let sample = pczt_with_sapling_output();

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -259,6 +259,71 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
     pczt::parse::parse_pczt_cypherpunk(params, seed_fingerprint, &ufvk, &pczt)
 }
 
+/// Validates a batch PCZT for the selected account and returns its display data.
+#[cfg(feature = "cypherpunk")]
+pub fn check_and_parse_batch_pczt_cypherpunk<P: consensus::Parameters>(
+    params: &P,
+    pczt_bytes: &[u8],
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<ParsedPczt> {
+    let mut pczt = pczt::parse_pczt(pczt_bytes)?;
+    // Resolve compact field representations up front so the single-pass check
+    // sees complete actions, matching `preflight_batch_pczt_cypherpunk`.
+    pczt.resolve_fields().map_err(|e| {
+        ZcashError::InvalidPczt(alloc::format!("resolve compact PCZT fields: {e:?}"))
+    })?;
+    let account_index = zip32::AccountId::try_from(account_index)
+        .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
+    let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
+        .map_err(|e| ZcashError::InvalidDataError(e.to_string()))?;
+    let xpub = ufvk.transparent().ok_or(ZcashError::InvalidDataError(
+        "transparent xpub is not present".to_string(),
+    ))?;
+
+    // Validate shielded actions while collecting their display rows.
+    let (checked_shielded, pczt) = pczt::check::check_and_parse_pczt_shielded(
+        params,
+        seed_fingerprint,
+        account_index,
+        &ufvk,
+        pczt,
+    )?;
+
+    // Check the remaining transparent bundle against the same account.
+    pczt::check::check_pczt_transparent(
+        params,
+        seed_fingerprint,
+        account_index,
+        xpub,
+        &pczt,
+        false,
+    )?;
+
+    // Reuse the PCZT returned by signability validation for display assembly.
+    let (signable_actions, pczt) = signable_shielded_actions(
+        params,
+        pczt,
+        seed_fingerprint,
+        account_index,
+        ShieldedActionPolicy::Batch,
+    )?;
+
+    if signable_actions.is_empty() {
+        Err(ZcashError::PcztNoMyInputs)
+    } else {
+        // Assemble the display from the shielded rows collected above.
+        pczt::parse::parse_pczt_cypherpunk_with_checked_shielded(
+            params,
+            seed_fingerprint,
+            &pczt,
+            checked_shielded.orchard,
+            checked_shielded.ironwood,
+        )
+    }
+}
+
 #[cfg(test)]
 mod additional_tests {
     use super::*;
@@ -1470,6 +1535,70 @@ mod tests {
                 ZcashError::PcztNoMyInputs
             );
         }
+    }
+
+    #[test]
+    fn test_batch_check_and_parse_accepts_ironwood_spend() {
+        let sample = pczt::test_support::sample_ironwood_pczt();
+
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("Ironwood batch PCZT should parse");
+        assert!(parsed.get_orchard().is_some() || parsed.get_ironwood().is_some());
+
+        assert_eq!(
+            check_and_parse_batch_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                1,
+            )
+            .unwrap_err(),
+            ZcashError::PcztNoMyInputs
+        );
+    }
+
+    #[test]
+    fn test_batch_check_and_parse_accepts_orchard_to_ironwood_migration() {
+        let sample = pczt::test_support::sample_migration_pczt();
+
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("migration batch PCZT should parse");
+        assert!(!parsed
+            .get_orchard()
+            .expect("migration must show Orchard inputs")
+            .get_from()
+            .is_empty());
+        assert!(!parsed
+            .get_ironwood()
+            .expect("migration must show Ironwood outputs")
+            .get_to()
+            .is_empty());
+        assert_eq!(parsed.get_fee_value(), "0.0002 ZEC");
+
+        assert_eq!(
+            check_and_parse_batch_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                1,
+            )
+            .unwrap_err(),
+            ZcashError::PcztNoMyInputs
+        );
     }
 
     #[test]

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -45,7 +45,6 @@ pub fn check_pczt_orchard<P: consensus::Parameters>(
     pczt: &Pczt,
 ) -> Result<(), ZcashError> {
     super::validate_supported_pczt(pczt)?;
-    #[cfg(zcash_unstable = "nu6.3")]
     let should_process_ironwood = super::pczt_should_process_ironwood(pczt);
     let verifier = Verifier::new(pczt.clone())
         .with_orchard(|bundle| {
@@ -61,7 +60,6 @@ pub fn check_pczt_orchard<P: consensus::Parameters>(
             Ok(())
         })
         .map_err(map_orchard_verifier_error)?;
-    #[cfg(zcash_unstable = "nu6.3")]
     if should_process_ironwood {
         verifier
             .with_ironwood(|bundle| {

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -24,6 +24,8 @@ use zcash_vendor::{
 use zcash_vendor::zcash_protocol::consensus::NetworkConstants;
 
 #[cfg(feature = "cypherpunk")]
+use super::structs::ParsedOrchard;
+#[cfg(feature = "cypherpunk")]
 use super::ShieldedPool;
 
 #[cfg(feature = "cypherpunk")]
@@ -77,6 +79,75 @@ pub fn check_pczt_orchard<P: consensus::Parameters>(
             .map_err(map_orchard_verifier_error)?;
     }
     Ok(())
+}
+
+/// Orchard and Ironwood display rows collected during shielded validation.
+/// A pool is `None` when it contains no displayable actions.
+#[cfg(feature = "cypherpunk")]
+pub(crate) struct CheckedShieldedParse {
+    pub(crate) orchard: Option<ParsedOrchard>,
+    pub(crate) ironwood: Option<ParsedOrchard>,
+}
+
+/// Validates the supported shielded bundles and collects their display rows.
+/// Returns the collected Orchard and Ironwood rows together with the PCZT.
+#[cfg(feature = "cypherpunk")]
+pub(crate) fn check_and_parse_pczt_shielded<P: consensus::Parameters>(
+    params: &P,
+    seed_fingerprint: &[u8; 32],
+    account_index: zip32::AccountId,
+    ufvk: &UnifiedFullViewingKey,
+    pczt: Pczt,
+) -> Result<(CheckedShieldedParse, Pczt), ZcashError> {
+    super::validate_supported_pczt(&pczt)?;
+    let mut parsed_orchard = None;
+    let mut parsed_ironwood = None;
+    let should_process_ironwood = super::pczt_should_process_ironwood(&pczt);
+
+    // Validate Orchard while collecting the rows shown during review.
+    let verifier = Verifier::new(pczt)
+        .with_orchard(|bundle| {
+            parsed_orchard = check_and_parse_shielded_bundle(
+                params,
+                seed_fingerprint,
+                account_index,
+                ufvk,
+                bundle,
+                ShieldedPool::Orchard,
+            )
+            .map_err(pczt::roles::verifier::OrchardError::Custom)?;
+            Ok(())
+        })
+        .map_err(map_orchard_verifier_error)?;
+
+    // Continue through Ironwood when this transaction version enables it.
+    let verifier = if should_process_ironwood {
+        verifier
+            .with_ironwood(|bundle| {
+                parsed_ironwood = check_and_parse_shielded_bundle(
+                    params,
+                    seed_fingerprint,
+                    account_index,
+                    ufvk,
+                    bundle,
+                    ShieldedPool::Ironwood,
+                )
+                .map_err(pczt::roles::verifier::OrchardError::Custom)?;
+                Ok(())
+            })
+            .map_err(map_orchard_verifier_error)?
+    } else {
+        verifier
+    };
+
+    // Return the verifier-owned PCZT for the remaining checks.
+    Ok((
+        CheckedShieldedParse {
+            orchard: parsed_orchard,
+            ironwood: parsed_ironwood,
+        },
+        verifier.finish(),
+    ))
 }
 
 pub fn check_pczt_transparent<P: consensus::Parameters>(
@@ -312,6 +383,85 @@ fn check_shielded_bundle<P: consensus::Parameters>(
 
     match calculated_value_balance {
         Ok(value_balance) if &value_balance == bundle.value_sum() => Ok(()),
+        _ => Err(ZcashError::InvalidPczt(format!(
+            "invalid {pool_label} bundle value balance"
+        ))),
+    }
+}
+
+/// Validates a shielded bundle while collecting its non-dummy display rows.
+/// Returns `None` when the bundle contains no displayable actions.
+#[cfg(feature = "cypherpunk")]
+fn check_and_parse_shielded_bundle<P: consensus::Parameters>(
+    params: &P,
+    seed_fingerprint: &[u8; 32],
+    account_index: zip32::AccountId,
+    ufvk: &UnifiedFullViewingKey,
+    bundle: &orchard::pczt::Bundle,
+    pool: ShieldedPool,
+) -> Result<Option<ParsedOrchard>, ZcashError> {
+    let pool_label = pool.label();
+    let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
+        "orchard fvk is not present".to_string(),
+    ))?;
+
+    let mut parsed_orchard = ParsedOrchard::new(vec![], vec![]);
+    // Validate and decode each action in the canonical order.
+    bundle.actions().iter().try_for_each(|action| {
+        action.verify_cv_net().map_err(|e| {
+            ZcashError::InvalidPczt(format!("invalid cv_net in {pool_label} action: {e:?}"))
+        })?;
+
+        check_action_spend(
+            params,
+            seed_fingerprint,
+            account_index,
+            fvk,
+            action.spend(),
+            pool,
+        )?;
+        action
+            .output()
+            .verify_note_commitment(action.spend())
+            .map_err(|e| {
+                ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}"))
+            })?;
+
+        // Add only real spends to the review.
+        if let Some(value) = action.spend().value() {
+            if value.inner() != 0 {
+                let parsed_from =
+                    super::parse::parse_orchard_spend(seed_fingerprint, action.spend())?;
+                parsed_orchard.add_from(parsed_from);
+            }
+        }
+
+        // Decode real outputs once and add them to the review.
+        let parsed_to = super::parse::parse_orchard_output(params, ufvk, action, pool)?;
+        if !parsed_to.get_is_dummy() {
+            parsed_orchard.add_to(parsed_to);
+        }
+
+        Ok::<_, ZcashError>(())
+    })?;
+
+    // Recompute the bundle balance from the values just reviewed.
+    let calculated_value_balance = bundle
+        .actions()
+        .iter()
+        .map(|action| {
+            action.spend().value().expect("present") - action.output().value().expect("present")
+        })
+        .sum::<Result<ValueSum, _>>();
+
+    match calculated_value_balance {
+        Ok(value_balance) if &value_balance == bundle.value_sum() => {
+            if parsed_orchard.get_from().is_empty() && parsed_orchard.get_to().is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(parsed_orchard))
+            }
+        }
         _ => Err(ZcashError::InvalidPczt(format!(
             "invalid {pool_label} bundle value balance"
         ))),

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -6,7 +6,7 @@ use crate::errors::ZcashError;
 
 #[cfg(feature = "cypherpunk")]
 use zcash_vendor::{
-    orchard::{self, keys::FullViewingKey, value::ValueSum, Address},
+    orchard::{self, keys::FullViewingKey, value::ValueSum},
     zcash_keys::keys::UnifiedFullViewingKey,
 };
 
@@ -367,7 +367,15 @@ fn check_shielded_bundle<P: consensus::Parameters>(
 ) -> Result<(), ZcashError> {
     let pool_label = pool.label();
     bundle.actions().iter().try_for_each(|action| {
-        check_action(params, seed_fingerprint, account_index, ufvk, action, pool)?;
+        check_action(
+            params,
+            seed_fingerprint,
+            account_index,
+            ufvk,
+            action,
+            bundle.flags(),
+            pool,
+        )?;
         Ok::<_, ZcashError>(())
     })?;
 
@@ -436,8 +444,9 @@ fn check_and_parse_shielded_bundle<P: consensus::Parameters>(
             }
         }
 
-        // Decode real outputs once and add them to the review.
+        // Require every real output to be recoverable for review.
         let parsed_to = super::parse::parse_orchard_output(params, ufvk, action, pool)?;
+        check_restricted_zero_value_output(ufvk, action, bundle.flags(), pool)?;
         if !parsed_to.get_is_dummy() {
             parsed_orchard.add_to(parsed_to);
         }
@@ -476,6 +485,7 @@ fn check_action<P: consensus::Parameters>(
     account_index: zip32::AccountId,
     ufvk: &UnifiedFullViewingKey,
     action: &orchard::pczt::Action,
+    flags: &orchard::bundle::Flags,
     pool: ShieldedPool,
 ) -> Result<(), ZcashError> {
     let pool_label = pool.label();
@@ -496,7 +506,7 @@ fn check_action<P: consensus::Parameters>(
         action.spend(),
         pool,
     )?;
-    check_action_output(params, ufvk, action, pool)?;
+    check_action_output(params, ufvk, action, flags, pool)?;
     Ok(())
 }
 
@@ -546,20 +556,11 @@ fn check_action_spend<P: consensus::Parameters>(
 }
 
 #[cfg(feature = "cypherpunk")]
-fn is_wallet_orchard_address(fvk: &FullViewingKey, address: &Address) -> bool {
-    let external_ivk = fvk.to_ivk(zcash_vendor::zip32::Scope::External);
-    let internal_ivk = fvk.to_ivk(zcash_vendor::zip32::Scope::Internal);
-
-    external_ivk.diversifier_index(address).is_some()
-        || internal_ivk.diversifier_index(address).is_some()
-}
-
-#[cfg(feature = "cypherpunk")]
-// check output cmx and internal-ovk output ownership constraints
 fn check_action_output<P: consensus::Parameters>(
     params: &P,
     ufvk: &UnifiedFullViewingKey,
     action: &orchard::pczt::Action,
+    flags: &orchard::bundle::Flags,
     pool: ShieldedPool,
 ) -> Result<(), ZcashError> {
     let pool_label = pool.label();
@@ -568,40 +569,39 @@ fn check_action_output<P: consensus::Parameters>(
         .verify_note_commitment(action.spend())
         .map_err(|e| ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}")))?;
 
-    let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
-        "orchard fvk is not present".to_string(),
-    ))?;
-    let external_ovk = fvk.to_ovk(zcash_vendor::zip32::Scope::External).clone();
-    let internal_ovk = fvk.to_ovk(zcash_vendor::zip32::Scope::Internal).clone();
-    let transparent_internal_ovk = ufvk
-        .transparent()
-        .map(|k| orchard::keys::OutgoingViewingKey::from(k.internal_ovk().as_bytes()));
+    // Decode and validate the recipient, rejecting non-zero outputs the device cannot review.
+    super::parse::parse_orchard_output(params, ufvk, action, pool)?;
+    check_restricted_zero_value_output(ufvk, action, flags, pool)?;
 
-    let mut keys = vec![(Some(external_ovk), false), (Some(internal_ovk), true)];
-    if let Some(ovk) = transparent_internal_ovk {
-        keys.push((Some(ovk), true));
+    Ok(())
+}
+
+#[cfg(feature = "cypherpunk")]
+fn check_restricted_zero_value_output(
+    ufvk: &UnifiedFullViewingKey,
+    action: &orchard::pczt::Action,
+    flags: &orchard::bundle::Flags,
+    pool: ShieldedPool,
+) -> Result<(), ZcashError> {
+    // A restricted action binds its spend and output to the same expanded receiver.
+    // A funded output paired with a zero-valued spend must therefore be ours.
+    let is_zero_spend = matches!(action.spend().value(), Some(value) if value.inner() == 0);
+    let is_funded_output = matches!(action.output().value(), Some(value) if value.inner() != 0);
+    if flags.cross_address_enabled() || !is_zero_spend || !is_funded_output {
+        return Ok(());
     }
 
-    for (vk, is_internal_ovk) in keys {
-        if let Some((_, address, _)) =
-            super::parse::decode_output_enc_ciphertext(action, vk.as_ref())?
-        {
-            if let Some(user_address) = action.output().user_address() {
-                super::parse::validate_orchard_user_address(params, user_address, &address)?;
-            }
-            if is_internal_ovk && !is_wallet_orchard_address(fvk, &address) {
-                return Err(ZcashError::InvalidPczt(format!(
-                    "{pool_label} output was recoverable with an internal OVK but does not belong to this wallet"
-                )));
-            }
-            break;
-        }
-    }
-
-    if let (Some(user_address), Some(recipient)) =
-        (action.output().user_address(), action.output().recipient())
-    {
-        super::parse::validate_orchard_user_address(params, user_address, recipient)?;
+    let recipient = action.output().recipient().ok_or_else(|| {
+        ZcashError::InvalidPczt(format!(
+            "missing recipient for funded {} output",
+            pool.label()
+        ))
+    })?;
+    if !super::parse::is_wallet_orchard_address(ufvk, &recipient)? {
+        return Err(ZcashError::InvalidPczt(format!(
+            "funded {} output paired with a zero-value spend does not belong to the selected account",
+            pool.label()
+        )));
     }
 
     Ok(())

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -20,7 +20,6 @@ pub(crate) fn parse_pczt(bytes: &[u8]) -> Result<Pczt, ZcashError> {
 pub(crate) fn validate_supported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     validate_sapling_bundle_consistency(pczt)?;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     {
         if pczt_has_ironwood_actions(pczt) && !pczt_is_v6(pczt) {
             return Err(ZcashError::InvalidPczt(
@@ -46,18 +45,15 @@ pub(crate) fn validate_supported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     Ok(())
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 pub(crate) fn pczt_has_ironwood_actions(pczt: &Pczt) -> bool {
     !pczt.ironwood().actions().is_empty()
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 pub(crate) fn pczt_is_v6(pczt: &Pczt) -> bool {
     *pczt.global().tx_version() == constants::V6_TX_VERSION
         && *pczt.global().version_group_id() == constants::V6_VERSION_GROUP_ID
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 pub(crate) fn pczt_should_process_ironwood(pczt: &Pczt) -> bool {
     pczt_is_v6(pczt) || pczt_has_ironwood_actions(pczt)
 }
@@ -116,7 +112,6 @@ pub(crate) fn check_transparent_derivation<
 #[derive(Clone, Copy)]
 pub(crate) enum ShieldedPool {
     Orchard,
-    #[cfg(zcash_unstable = "nu6.3")]
     Ironwood,
 }
 
@@ -125,7 +120,6 @@ impl ShieldedPool {
     pub(crate) fn label(self) -> &'static str {
         match self {
             ShieldedPool::Orchard => "Orchard",
-            #[cfg(zcash_unstable = "nu6.3")]
             ShieldedPool::Ironwood => "Ironwood",
         }
     }
@@ -178,10 +172,7 @@ pub(crate) fn matching_seed_supported_orchard_account(
 /// Returns whether a PCZT carries anything the transparent-only legacy path
 /// cannot handle: a v6+ transaction, or any shielded (Sapling/Orchard/Ironwood)
 /// content. These must be checked, parsed, and signed by the cypherpunk build.
-#[cfg(all(
-    zcash_unstable = "nu6.3",
-    any(feature = "multi_coins", not(feature = "cypherpunk"))
-))]
+#[cfg(any(feature = "multi_coins", not(feature = "cypherpunk")))]
 pub(crate) fn pczt_requires_cypherpunk_support(pczt: &zcash_vendor::pczt::Pczt) -> bool {
     *pczt.global().tx_version() >= 6
         || !pczt.sapling().spends().is_empty()
@@ -195,20 +186,16 @@ pub(crate) mod test_support {
     use alloc::{string::String, vec, vec::Vec};
 
     use ::pczt::roles::{creator::Creator, updater::Updater};
-    #[cfg(zcash_unstable = "nu6.3")]
     use incrementalmerkletree::Retention;
     use keystore::algorithms::zcash::{calculate_seed_fingerprint, derive_ufvk};
     use rand_core::OsRng;
-    #[cfg(zcash_unstable = "nu6.3")]
     use shardtree::{store::memory::MemoryShardStore, ShardTree};
-    #[cfg(zcash_unstable = "nu6.3")]
     use zcash_note_encryption::try_note_decryption;
     use zcash_primitives::transaction::{
         builder::{BuildConfig, Builder, PcztParts, PcztResult},
         fees::zip317,
         TxVersion,
     };
-    #[cfg(zcash_unstable = "nu6.3")]
     use zcash_vendor::zcash_protocol::consensus::{BlockHeight, NetworkType, NetworkUpgrade};
     use zcash_vendor::{
         orchard,
@@ -229,11 +216,9 @@ pub(crate) mod test_support {
         pub(crate) seed_fingerprint: [u8; 32],
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[derive(Clone, Copy, Debug)]
     pub(crate) struct Nu6_3Network;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     impl Parameters for Nu6_3Network {
         fn network_type(&self) -> NetworkType {
             NetworkType::Main
@@ -247,7 +232,6 @@ pub(crate) mod test_support {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn unsupported_orchard_spend_paths() -> Vec<Vec<u32>> {
         vec![
             vec![
@@ -264,7 +248,6 @@ pub(crate) mod test_support {
         ]
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn orchard_spend_path_for_account(account_index: u32) -> Vec<u32> {
         vec![
             zip32::ChildIndex::hardened(32).index(),
@@ -273,7 +256,6 @@ pub(crate) mod test_support {
         ]
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn ironwood_pczt_with_spend_derivation(
         bytes: &[u8],
         seed_fingerprint: [u8; 32],
@@ -298,7 +280,6 @@ pub(crate) mod test_support {
             .unwrap()
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn ironwood_pczt_with_dummy_spend_derivation(
         bytes: &[u8],
         seed_fingerprint: [u8; 32],
@@ -335,7 +316,6 @@ pub(crate) mod test_support {
             .unwrap()
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn sample_ironwood_pczt() -> SamplePczt {
         let params = Nu6_3Network;
         let seed = [7u8; 32];
@@ -446,7 +426,6 @@ pub(crate) mod test_support {
     // Orchard spend -> Ironwood output: a cross-pool migration, the message type
     // the real batch uses (and the one never exercised on-device). Mirrors
     // sample_ironwood_pczt but the *spent* note is an Orchard note.
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn sample_migration_pczt() -> SamplePczt {
         let params = Nu6_3Network;
         let seed = [7u8; 32];
@@ -556,7 +535,6 @@ pub(crate) mod test_support {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn sample_orchard_change_pczt() -> SamplePczt {
         let params = MainNetwork;
         let seed = [7u8; 32];

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -536,15 +536,33 @@ pub(crate) mod test_support {
     }
 
     pub(crate) fn sample_orchard_change_pczt() -> SamplePczt {
+        sample_orchard_change_pczt_for_account(0)
+    }
+
+    pub(crate) fn sample_orchard_foreign_change_pczt() -> SamplePczt {
+        sample_orchard_change_pczt_for_account(1)
+    }
+
+    fn sample_orchard_change_pczt_for_account(output_account: u32) -> SamplePczt {
         let params = MainNetwork;
         let seed = [7u8; 32];
         let ufvk_text = derive_ufvk(&params, &seed, "m/32'/133'/0'").unwrap();
         let ufvk = UnifiedFullViewingKey::decode(&params, &ufvk_text).unwrap();
         let orchard_fvk = ufvk.orchard().unwrap().clone();
         let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+
+        let output_ufvk_text = derive_ufvk(
+            &params,
+            &seed,
+            &alloc::format!("m/32'/133'/{output_account}'"),
+        )
+        .unwrap();
+        let output_ufvk = UnifiedFullViewingKey::decode(&params, &output_ufvk_text).unwrap();
+        let output_fvk = output_ufvk.orchard().unwrap().clone();
         let recipient_scope = orchard::keys::Scope::External;
-        let recipient = orchard_fvk.address_at(0u32, recipient_scope);
-        let orchard_ovk = orchard_fvk.to_ovk(recipient_scope);
+        let spend_recipient = orchard_fvk.address_at(0u32, recipient_scope);
+        let output_recipient = output_fvk.address_at(0u32, recipient_scope);
+        let orchard_ovk = output_fvk.to_ovk(recipient_scope);
 
         let value = orchard::value::NoteValue::from_raw(1_000_000);
         let note = {
@@ -556,7 +574,12 @@ pub(crate) mod test_support {
             )
             .expect("spends-disabled flags are valid for a coinbase bundle");
             orchard_builder
-                .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+                .add_output(
+                    None,
+                    spend_recipient,
+                    value,
+                    Memo::Empty.encode().into_bytes(),
+                )
                 .unwrap();
             let (bundle, meta) = orchard_builder.build::<i64>(&mut OsRng).unwrap().unwrap();
             let action = bundle
@@ -598,9 +621,9 @@ pub(crate) mod test_support {
             .unwrap();
         builder
             .add_change_output(
-                orchard_fvk,
+                output_fvk,
                 Some(orchard_ovk),
-                recipient,
+                output_recipient,
                 orchard::value::NoteValue::from_raw(990_000),
                 Memo::Empty.encode().into_bytes(),
             )
@@ -621,21 +644,28 @@ pub(crate) mod test_support {
         .unwrap();
         let pczt = Updater::new(pczt)
             .update_orchard_with(|mut bundle| {
-                let signing_action_indices = bundle
+                let signing_action_accounts = bundle
                     .bundle()
                     .actions()
                     .iter()
                     .enumerate()
                     .filter_map(|(index, action)| {
-                        action.spend().dummy_sk().is_none().then_some(index)
+                        action.spend().dummy_sk().is_none().then(|| {
+                            let account = if action.spend().value().unwrap().inner() == 0 {
+                                output_account
+                            } else {
+                                0
+                            };
+                            (index, account)
+                        })
                     })
                     .collect::<Vec<_>>();
-                assert_eq!(signing_action_indices.len(), 2);
+                assert_eq!(signing_action_accounts.len(), 2);
 
-                for action_index in signing_action_indices {
+                for (action_index, account) in signing_action_accounts {
                     let derivation = orchard::pczt::Zip32Derivation::parse(
                         seed_fingerprint,
-                        orchard_spend_path_for_account(0),
+                        orchard_spend_path_for_account(account),
                     )
                     .unwrap();
                     bundle.update_action_with(action_index, |mut action| {

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -250,12 +250,51 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
         })
         .map_err(map_transparent_verifier_error)?;
 
+    assemble_parsed_pczt(pczt, parsed_transparent, parsed_orchard, parsed_ironwood)
+}
+
+/// Parses the transparent bundle and combines it with the supplied shielded
+/// display rows.
+#[cfg(feature = "cypherpunk")]
+pub(crate) fn parse_pczt_cypherpunk_with_checked_shielded<P: consensus::Parameters>(
+    params: &P,
+    seed_fingerprint: &[u8; 32],
+    pczt: &Pczt,
+    parsed_orchard: Option<ParsedOrchard>,
+    parsed_ironwood: Option<ParsedOrchard>,
+) -> Result<ParsedPczt, ZcashError> {
+    super::validate_supported_pczt(pczt)?;
+    let mut parsed_transparent = None;
+
+    // Parse the remaining transparent rows.
+    Verifier::new(pczt.clone())
+        .with_transparent(|bundle| {
+            parsed_transparent = parse_transparent(params, seed_fingerprint, bundle)
+                .map_err(pczt::roles::verifier::TransparentError::Custom)?;
+            Ok(())
+        })
+        .map_err(map_transparent_verifier_error)?;
+
+    // Combine all checked rows and calculate the display totals.
+    assemble_parsed_pczt(pczt, parsed_transparent, parsed_orchard, parsed_ironwood)
+}
+
+/// Assembles the per-pool parse results into the final [`ParsedPczt`],
+/// computing the transfer, change, and fee totals.
+#[cfg(feature = "cypherpunk")]
+fn assemble_parsed_pczt(
+    pczt: &Pczt,
+    parsed_transparent: Option<ParsedTransparent>,
+    parsed_orchard: Option<ParsedOrchard>,
+    parsed_ironwood: Option<ParsedOrchard>,
+) -> Result<ParsedPczt, ZcashError> {
     let mut total_input_value = 0;
     let mut total_output_value = 0;
     let mut total_change_value = 0;
     //total_input_value = total_output_value + fee_value
     //total_output_value = total_transfer_value + total_change_value
 
+    // Fold each decoded pool into the display totals.
     if let Some(orchard) = &parsed_orchard {
         total_change_value += orchard
             .get_to()
@@ -323,6 +362,7 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
         total_input_value = total_input_value.saturating_add(sapling_value_sum as u64)
     };
 
+    // Derive the transfer and fee values shown during confirmation.
     let total_transfer_value = format_zec_value((total_output_value - total_change_value) as f64);
     let fee_value = format_zec_value((total_input_value - total_output_value) as f64);
 
@@ -583,7 +623,7 @@ fn parse_orchard<P: consensus::Parameters>(
 }
 
 #[cfg(feature = "cypherpunk")]
-fn parse_orchard_spend(
+pub(crate) fn parse_orchard_spend(
     seed_fingerprint: &[u8; 32],
     spend: &orchard::pczt::Spend,
 ) -> Result<ParsedFrom, ZcashError> {
@@ -651,8 +691,11 @@ pub(crate) fn validate_orchard_user_address<P: consensus::Parameters>(
     Ok(())
 }
 
+/// Decodes one action's output into its [`ParsedTo`] display row, trying the
+/// wallet OVKs and then direct decryption. Every non-zero output must be
+/// recoverable.
 #[cfg(feature = "cypherpunk")]
-fn parse_orchard_output<P: consensus::Parameters>(
+pub(crate) fn parse_orchard_output<P: consensus::Parameters>(
     params: &P,
     ufvk: &UnifiedFullViewingKey,
     action: &orchard::pczt::Action,

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -98,52 +98,49 @@ fn format_zec_value(value: f64) -> String {
 /// - `Ok(None)` if the output cannot be decrypted.
 /// - `Err(_)` if `ovk` is `None` and the PCZT is missing fields needed to directly
 ///   decrypt the output.
+///
+/// `pool` selects the note-encryption domain used for recovery.
 #[cfg(feature = "cypherpunk")]
-pub fn decode_output_enc_ciphertext(
+pub(crate) fn decode_output_enc_ciphertext(
     action: &orchard::pczt::Action,
     ovk: Option<&OutgoingViewingKey>,
+    pool: ShieldedPool,
 ) -> Result<Option<(Note, Address, [u8; 512])>, ZcashError> {
-    // orchard 0.15.0-pre.1 splits note encryption by version: Ironwood actions carry V3
-    // note plaintexts and must be trial-decrypted with `IronwoodDomain`, while Orchard
-    // actions use the V2 `OrchardDomain`. Select the domain from the action's note version
-    // so both pools decrypt correctly.
-    let is_ironwood = matches!(*action.output().note_version(), orchard::NoteVersion::V3);
-
     if let Some(ovk) = ovk {
         let out_ciphertext = &action.output().encrypted_note().out_ciphertext;
-        Ok(if is_ironwood {
-            try_output_recovery_with_ovk(
-                &IronwoodDomain::for_pczt_action(action),
-                ovk,
-                action,
-                action.cv_net(),
-                out_ciphertext,
-            )
-        } else {
-            try_output_recovery_with_ovk(
+        Ok(match pool {
+            ShieldedPool::Orchard => try_output_recovery_with_ovk(
                 &OrchardDomain::for_pczt_action(action),
                 ovk,
                 action,
                 action.cv_net(),
                 out_ciphertext,
-            )
+            ),
+            ShieldedPool::Ironwood => try_output_recovery_with_ovk(
+                &IronwoodDomain::for_pczt_action(action),
+                ovk,
+                action,
+                action.cv_net(),
+                out_ciphertext,
+            ),
         })
     } else {
         // If we reached here, none of our OVKs matched; recover directly as the fallback.
+        let pool_label = pool.label();
 
         let recipient = action.output().recipient().ok_or_else(|| {
-            ZcashError::InvalidPczt("Missing recipient field for Orchard action".into())
+            ZcashError::InvalidPczt(format!("Missing recipient field for {pool_label} action"))
         })?;
         let value = action.output().value().ok_or_else(|| {
-            ZcashError::InvalidPczt("Missing value field for Orchard action".into())
+            ZcashError::InvalidPczt(format!("Missing value field for {pool_label} action"))
         })?;
         let rho = orchard::note::Rho::from_bytes(&action.spend().nullifier().to_bytes())
             .into_option()
             .ok_or_else(|| {
-                ZcashError::InvalidPczt("Missing rho field for Orchard action".into())
+                ZcashError::InvalidPczt(format!("Missing rho field for {pool_label} action"))
             })?;
         let rseed = action.output().rseed().ok_or_else(|| {
-            ZcashError::InvalidPczt("Missing rseed field for Orchard action".into())
+            ZcashError::InvalidPczt(format!("Missing rseed field for {pool_label} action"))
         })?;
 
         let note = orchard::Note::from_parts(
@@ -151,29 +148,36 @@ pub fn decode_output_enc_ciphertext(
             value,
             rho,
             rseed,
-            *action.output().note_version(),
+            (*action.output().note_version()).into(),
         )
         .into_option()
-        .ok_or_else(|| ZcashError::InvalidPczt("Orchard action contains invalid note".into()))?;
+        .ok_or_else(|| {
+            ZcashError::InvalidPczt(format!("{pool_label} action contains invalid note"))
+        })?;
 
-        Ok(if is_ironwood {
-            let pk_d = IronwoodDomain::get_pk_d(&note);
-            let esk = IronwoodDomain::derive_esk(&note).expect("Orchard notes are post-ZIP 212");
-            try_output_recovery_with_pkd_esk(
-                &IronwoodDomain::for_pczt_action(action),
-                pk_d,
-                esk,
-                action,
-            )
-        } else {
-            let pk_d = OrchardDomain::get_pk_d(&note);
-            let esk = OrchardDomain::derive_esk(&note).expect("Orchard notes are post-ZIP 212");
-            try_output_recovery_with_pkd_esk(
-                &OrchardDomain::for_pczt_action(action),
-                pk_d,
-                esk,
-                action,
-            )
+        Ok(match pool {
+            ShieldedPool::Orchard => {
+                let pk_d = OrchardDomain::get_pk_d(&note);
+                let esk = OrchardDomain::derive_esk(&note)
+                    .expect("Orchard-shaped notes are post-ZIP 212");
+                try_output_recovery_with_pkd_esk(
+                    &OrchardDomain::for_pczt_action(action),
+                    pk_d,
+                    esk,
+                    action,
+                )
+            }
+            ShieldedPool::Ironwood => {
+                let pk_d = IronwoodDomain::get_pk_d(&note);
+                let esk = IronwoodDomain::derive_esk(&note)
+                    .expect("Orchard-shaped notes are post-ZIP 212");
+                try_output_recovery_with_pkd_esk(
+                    &IronwoodDomain::for_pczt_action(action),
+                    pk_d,
+                    esk,
+                    action,
+                )
+            }
         })
     }
 }
@@ -644,7 +648,7 @@ pub(crate) fn parse_orchard_spend(
 }
 
 #[cfg(feature = "cypherpunk")]
-fn is_wallet_orchard_address(
+pub(crate) fn is_wallet_orchard_address(
     ufvk: &UnifiedFullViewingKey,
     address: &Address,
 ) -> Result<bool, ZcashError> {
@@ -721,10 +725,10 @@ pub(crate) fn parse_orchard_output<P: consensus::Parameters>(
         .inner();
 
     let decode_output = |vk: Option<OutgoingViewingKey>, is_internal_ovk: bool| {
-        match decode_output_enc_ciphertext(action, vk.as_ref())? {
+        match decode_output_enc_ciphertext(action, vk.as_ref(), pool)? {
             Some((note, address, memo)) => {
                 let zec_value = format_zec_value(note.value().inner() as f64);
-                let memo = decode_memo(memo);
+                let memo = decode_memo(memo)?;
 
                 // Check output recipient with decoded address here to save CPU
                 // if the address is not match, return error
@@ -878,7 +882,7 @@ mod legacy_tests {
 }
 
 #[cfg(feature = "cypherpunk")]
-fn decode_memo(memo_bytes: [u8; 512]) -> Option<String> {
+fn decode_memo(memo_bytes: [u8; 512]) -> Result<Option<String>, ZcashError> {
     let first = memo_bytes[0];
 
     //decode as utf8.
@@ -897,21 +901,24 @@ fn decode_memo(memo_bytes: [u8; 512]) -> Option<String> {
         }
         result.reverse();
 
-        return Some(String::from_utf8(result).unwrap());
+        // ZIP 302 requires text-tagged memos to contain valid UTF-8.
+        return String::from_utf8(result)
+            .map(Some)
+            .map_err(|_| ZcashError::InvalidPczt("text memo is not valid UTF-8".to_string()));
     }
 
     if first == 0xF6 {
         let temp_memo = memo_bytes.to_vec();
         let result = temp_memo[1..].iter().find(|&&v| v != 0);
         match result {
-            Some(_v) => return Some(hex::encode(memo_bytes)),
+            Some(_v) => return Ok(Some(hex::encode(memo_bytes))),
             None => {
-                return None;
+                return Ok(None);
             }
         }
     }
 
-    Some(hex::encode(memo_bytes))
+    Ok(Some(hex::encode(memo_bytes)))
 }
 
 #[cfg(feature = "cypherpunk")]
@@ -926,6 +933,18 @@ mod tests {
     };
 
     extern crate std;
+
+    #[test]
+    fn test_decode_memo_rejects_invalid_utf8() {
+        let mut memo = [0u8; 512];
+        memo[0] = 0xC3; // start of a 2-byte UTF-8 sequence...
+        memo[1] = 0x28; // ...followed by an invalid continuation byte
+
+        assert!(matches!(
+            decode_memo(memo),
+            Err(ZcashError::InvalidPczt(msg)) if msg == "text memo is not valid UTF-8"
+        ));
+    }
 
     fn p2sh_output_with_matching_seed_fingerprint(
         seed_fingerprint: [u8; 32],
@@ -968,12 +987,12 @@ mod tests {
         {
             let mut memo = [0u8; 512];
             memo[0] = 0xF6;
-            let result = decode_memo(memo);
+            let result = decode_memo(memo).unwrap();
             assert_eq!(result, None);
         }
         {
             let memo = hex::decode("74657374206b657973746f6e65206d656d6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap().try_into().unwrap();
-            let result = decode_memo(memo);
+            let result = decode_memo(memo).unwrap();
             assert!(result.is_some());
             assert_eq!(result.unwrap(), "test keystone memo");
         }
@@ -1046,7 +1065,7 @@ mod tests {
             let mut memo = [0u8; 512];
             memo[0] = 0xF6;
             memo[1] = 0x01;
-            let result = decode_memo(memo);
+            let result = decode_memo(memo).unwrap();
             assert!(result.is_some());
             let hex_str = result.unwrap();
             assert!(hex_str.starts_with("f6"));
@@ -1054,7 +1073,7 @@ mod tests {
         {
             let mut memo = [0u8; 512];
             memo[0] = 0xF5;
-            let result = decode_memo(memo);
+            let result = decode_memo(memo).unwrap();
             assert!(result.is_some());
         }
     }
@@ -1105,7 +1124,7 @@ mod tests {
     #[test]
     fn test_decode_memo_empty() {
         let memo = [0u8; 512];
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         let decoded = result.unwrap();
         assert!(decoded.is_empty());
@@ -1114,7 +1133,7 @@ mod tests {
     #[test]
     fn test_decode_memo_full_text() {
         let memo = [b'A'; 512];
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         let decoded = result.unwrap();
         assert_eq!(decoded.len(), 512);
@@ -1125,7 +1144,7 @@ mod tests {
         let mut memo = [0u8; 512];
         let text = b"Hello World";
         memo[..text.len()].copy_from_slice(text);
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "Hello World");
     }
@@ -1135,7 +1154,7 @@ mod tests {
         let mut memo = [0u8; 512];
         let text = "测试中文".as_bytes();
         memo[..text.len()].copy_from_slice(text);
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "测试中文");
     }
@@ -1147,14 +1166,14 @@ mod tests {
         memo[0] = b'A';
         memo[1] = b'B';
         memo[2] = b'C';
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "ABC");
 
         // Test with 0xF5 (should use hex encoding)
         let mut memo = [0u8; 512];
         memo[0] = 0xF5;
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         let hex_str = result.unwrap();
         assert!(hex_str.starts_with("f5"));
@@ -1165,7 +1184,7 @@ mod tests {
         // Test 0xF6 marker with all zeros after it (should return None)
         let mut memo = [0u8; 512];
         memo[0] = 0xF6;
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert_eq!(result, None);
     }
 
@@ -1176,7 +1195,7 @@ mod tests {
         memo[0] = 0xF6;
         memo[1] = 0xFF;
         memo[2] = 0xAB;
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         let hex_str = result.unwrap();
         assert!(hex_str.starts_with("f6ff"));
@@ -1187,7 +1206,7 @@ mod tests {
         let mut memo = [0u8; 512];
         let text = b"Test!@#$%^&*()_+-=[]{}|;:',.<>?/`~";
         memo[..text.len()].copy_from_slice(text);
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "Test!@#$%^&*()_+-=[]{}|;:',.<>?/`~");
     }
@@ -1225,7 +1244,7 @@ mod tests {
         let mut memo = [0u8; 512];
         let text = b"Line1\nLine2\tTabbed";
         memo[..text.len()].copy_from_slice(text);
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "Line1\nLine2\tTabbed");
     }
@@ -1237,7 +1256,7 @@ mod tests {
         for i in 32..=126 {
             memo[i - 32] = i as u8;
         }
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         let decoded = result.unwrap();
         // Should decode all printable ASCII
@@ -1261,7 +1280,7 @@ mod tests {
         let mut memo = [0u8; 512];
         let text = b"Test123!@# ZEC Payment";
         memo[..text.len()].copy_from_slice(text);
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "Test123!@# ZEC Payment");
     }

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -208,9 +208,7 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
 ) -> Result<ParsedPczt, ZcashError> {
     super::validate_supported_pczt(pczt)?;
     let mut parsed_orchard = None;
-    #[cfg(zcash_unstable = "nu6.3")]
     let mut parsed_ironwood = None;
-    #[cfg(zcash_unstable = "nu6.3")]
     let should_process_ironwood = super::pczt_should_process_ironwood(pczt);
     let mut parsed_transparent = None;
 
@@ -227,7 +225,6 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
             Ok(())
         })
         .map_err(map_orchard_verifier_error)?;
-    #[cfg(zcash_unstable = "nu6.3")]
     let verifier = if should_process_ironwood {
         verifier
             .with_ironwood(|bundle| {
@@ -274,7 +271,6 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
             .iter()
             .fold(0, |acc, to| acc + to.get_amount());
     }
-    #[cfg(zcash_unstable = "nu6.3")]
     if let Some(ironwood) = &parsed_ironwood {
         total_change_value += ironwood
             .get_to()
@@ -331,11 +327,6 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
     let fee_value = format_zec_value((total_input_value - total_output_value) as f64);
 
     let has_sapling = !pczt.sapling().spends().is_empty() || !pczt.sapling().outputs().is_empty();
-
-    #[cfg(zcash_unstable = "nu6.3")]
-    let parsed_ironwood = parsed_ironwood;
-    #[cfg(not(zcash_unstable = "nu6.3"))]
-    let parsed_ironwood = None;
 
     Ok(ParsedPczt::new(
         parsed_transparent,
@@ -424,7 +415,6 @@ pub fn parse_pczt_multi_coins<P: consensus::Parameters>(
 
 #[cfg(feature = "multi_coins")]
 fn reject_legacy_parse_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
-    #[cfg(zcash_unstable = "nu6.3")]
     {
         // The legacy multi-coins parser only displays transparent data. Reject any
         // shielded (Sapling/Orchard/Ironwood) or V6 PCZT instead of showing an
@@ -822,7 +812,6 @@ mod legacy_tests {
         zcash_protocol::consensus::{BranchId, MainNetwork, NetworkConstants},
     };
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_parse_rejects_v6_pczt() {
         let pczt = Creator::new(

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -90,7 +90,6 @@ pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
 
 #[cfg(not(feature = "cypherpunk"))]
 fn reject_legacy_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
-    #[cfg(zcash_unstable = "nu6.3")]
     {
         // The legacy helper below carries the pre-NU6.3 transparent sighash implementation.
         // It must not be used for shielded (Sapling/Orchard/Ironwood) or V6 PCZTs.
@@ -265,7 +264,6 @@ pub fn sign_and_redact_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
     let seed_fingerprint =
         calculate_seed_fingerprint(seed).map_err(|e| ZcashError::SigningError(e.to_string()))?;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let process_ironwood = super::pczt_should_process_ironwood(&pczt);
 
     // The orchard signer handles both the transparent inputs and the Orchard bundle
@@ -279,9 +277,7 @@ pub fn sign_and_redact_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
     let signer = pczt_ext::sign_transparent(signer, &orchard_signer)?;
     let signer = pczt_ext::sign_orchard(signer, &orchard_signer)?;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let ironwood_signer = SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Ironwood);
-    #[cfg(zcash_unstable = "nu6.3")]
     let signer = if process_ironwood {
         pczt_ext::sign_ironwood(signer, &ironwood_signer)?
     } else {
@@ -289,7 +285,6 @@ pub fn sign_and_redact_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
     };
 
     let mut signed = orchard_signer.signed.get();
-    #[cfg(zcash_unstable = "nu6.3")]
     {
         signed += ironwood_signer.signed.get();
     }
@@ -318,7 +313,6 @@ fn stamp_and_redact(pczt: Pczt) -> Pczt {
     // signing response does not need. This keeps the QR round trip small while
     // preserving signatures and global proprietary fields for the wallet.
     let redactor = Redactor::new(stamped_pczt).redact_orchard_with(redact_orchard_bundle);
-    #[cfg(zcash_unstable = "nu6.3")]
     let redactor = redactor.redact_ironwood_with(redact_orchard_bundle);
 
     redactor
@@ -446,12 +440,10 @@ mod tests {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     fn signable_sample_pczt() -> crate::pczt::test_support::SamplePczt {
         crate::pczt::test_support::sample_ironwood_pczt()
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_invalid_seed_fingerprint() {
         let sample = signable_sample_pczt();
@@ -467,7 +459,6 @@ mod tests {
     // bit-exact for an Orchard-only tx, a dual-pool Orchard->Ironwood migration, and an
     // Ironwood spend, so any upstream sighash change turns CI red instead of silently
     // producing wrong signatures on-device.
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_lean_sighash_control_orchard_only() {
         let sample = crate::pczt::test_support::sample_orchard_change_pczt();
@@ -483,7 +474,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_lean_sighash_migration_dualpool() {
         let sample = crate::pczt::test_support::sample_migration_pczt();
@@ -499,7 +489,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_lean_sighash_ironwood_spend() {
         // Exercises a populated Ironwood bundle with a real spend action.
@@ -518,7 +507,6 @@ mod tests {
 
     // End-to-end: an Orchard->Ironwood migration signs the Orchard spend and leaves the
     // output-only Ironwood bundle unsigned.
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_migration_signs_orchard_only() {
         let sample = crate::pczt::test_support::sample_migration_pczt();
@@ -543,7 +531,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_ironwood_spend() {
         let sample = crate::pczt::test_support::sample_ironwood_pczt();
@@ -609,7 +596,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_ironwood_spend_rejects_unsupported_zip32_path() {
         let sample = crate::pczt::test_support::sample_ironwood_pczt();
@@ -627,7 +613,6 @@ mod tests {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_ironwood_spend_ignores_dummy_zip32_metadata() {
         let sample = crate::pczt::test_support::sample_ironwood_pczt();
@@ -650,7 +635,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_orchard_change_output_spend() {
         let sample = crate::pczt::test_support::sample_orchard_change_pczt();
@@ -671,7 +655,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     fn pczt_with_min_version(min_version: &[u8]) -> Pczt {
         let sample = signable_sample_pczt();
         let base = Pczt::parse(&sample.bytes).unwrap();
@@ -683,12 +666,10 @@ mod tests {
             .finish()
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     fn test_seed() -> Vec<u8> {
         [7u8; 32].to_vec()
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn firmware_equal_version_stamps_response() {
         let pczt = pczt_with_min_version(&KEYSTONE_FW_VERSION.encode());
@@ -710,7 +691,6 @@ mod tests {
         assert_eq!(request_min, &KEYSTONE_FW_VERSION.encode().to_vec());
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn firmware_older_min_version_still_stamps_response() {
         let pczt = pczt_with_min_version(&[1, 0, 0]);
@@ -725,7 +705,6 @@ mod tests {
         assert_eq!(stamp, &KEYSTONE_FW_VERSION.encode().to_vec());
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn malformed_min_version_round_trips_and_stamps() {
         let pczt = pczt_with_min_version(&[1, 2]);
@@ -757,7 +736,6 @@ mod legacy_tests {
         zcash_protocol::consensus::{BranchId, MainNetwork, NetworkConstants},
     };
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_signing_rejects_v6_pczt() {
         let pczt = Creator::new(

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -31,7 +31,15 @@ use zcash_vendor::{
 };
 
 #[cfg(feature = "cypherpunk")]
-use {blake2b_simd::Hash, core::cell::Cell, core::cell::RefCell, rand_core::OsRng};
+use {
+    blake2b_simd::Hash,
+    core::{
+        cell::{Cell, RefCell},
+        mem::MaybeUninit,
+    },
+    rand_core::OsRng,
+    zeroize::Zeroize,
+};
 
 use crate::{errors::ZcashError, version::KEYSTONE_FW_VERSION};
 
@@ -102,6 +110,85 @@ fn reject_legacy_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     Ok(())
 }
 
+/// One cached spend authorizing key slot, scrubbed on replacement and drop.
+///
+/// `SpendAuthorizingKey` bottoms out in reddsa's `Copy` `SigningKey`, which
+/// holds the secret ask scalar and has no `Zeroize` or `Drop` of its own, so a
+/// plainly-dropped cache would leave the scalar bytes behind in memory.
+#[cfg(feature = "cypherpunk")]
+struct AskCacheSlot {
+    account: Option<zcash_vendor::zip32::AccountId>,
+    // `MaybeUninit` makes every post-scrub bit pattern valid without depending
+    // on private Orchard/reddsa layout invariants. The slot invariant is that
+    // this field is initialized exactly when `account` is `Some`.
+    ask: MaybeUninit<orchard::keys::SpendAuthorizingKey>,
+}
+
+// `MaybeUninit` deliberately suppresses the wrapped value's destructor. Fail
+// the build if a dependency bump gives either secret type drop glue; any change
+// to an indirect or owning representation requires a fresh zeroization audit
+// rather than silently retaining this type-specific strategy.
+#[cfg(feature = "cypherpunk")]
+const _: () = assert!(!core::mem::needs_drop::<orchard::keys::SpendAuthorizingKey>());
+#[cfg(feature = "cypherpunk")]
+const _: () = assert!(!core::mem::needs_drop::<orchard::keys::SpendingKey>());
+
+#[cfg(feature = "cypherpunk")]
+impl AskCacheSlot {
+    fn empty() -> Self {
+        Self {
+            account: None,
+            ask: MaybeUninit::uninit(),
+        }
+    }
+
+    fn get(
+        &self,
+        account: zcash_vendor::zip32::AccountId,
+    ) -> Option<&orchard::keys::SpendAuthorizingKey> {
+        if self.account == Some(account) {
+            // SAFETY: `account` is only set to `Some` after `ask` is written.
+            Some(unsafe { self.ask.assume_init_ref() })
+        } else {
+            None
+        }
+    }
+
+    fn replace(
+        &mut self,
+        account: zcash_vendor::zip32::AccountId,
+        ask: orchard::keys::SpendAuthorizingKey,
+    ) -> &orchard::keys::SpendAuthorizingKey {
+        self.account = None;
+        self.ask.zeroize();
+        self.ask.write(ask);
+        self.account = Some(account);
+
+        // SAFETY: the value was written immediately above, before `account`
+        // was set to `Some`.
+        unsafe { self.ask.assume_init_ref() }
+    }
+}
+
+#[cfg(feature = "cypherpunk")]
+impl Drop for AskCacheSlot {
+    fn drop(&mut self) {
+        self.account = None;
+        self.ask.zeroize();
+    }
+}
+
+/// One scrubbed spend authorizing key slot shared by the pool signing passes.
+#[cfg(feature = "cypherpunk")]
+struct SpendAuthCache(RefCell<AskCacheSlot>);
+
+#[cfg(feature = "cypherpunk")]
+impl SpendAuthCache {
+    fn new() -> Self {
+        Self(RefCell::new(AskCacheSlot::empty()))
+    }
+}
+
 /// Lean signer for the cypherpunk path. Drives the shallow `low_level_signer` and
 /// derives keys / signs each action in place, instead of materializing a full
 /// `RoleSigner` (which reconstructs the whole transaction to compute the sighash and
@@ -113,16 +200,13 @@ struct SeedSigner<'a> {
     seed: &'a [u8],
     seed_fingerprint: [u8; 32],
     pool: ShieldedPool,
-    /// Per-account spend authorizing key cache. The seed fingerprint and the account
-    /// key depend only on (seed, account), not on the action, so a bundle with many
-    /// actions for one account derives once. Interior mutability because the
-    /// `PcztSigner` trait signs through `&self`.
-    ask_cache: RefCell<
-        Vec<(
-            zcash_vendor::zip32::AccountId,
-            orchard::keys::SpendAuthorizingKey,
-        )>,
-    >,
+    /// Single-slot cache for the spend authorizing key. The key depends only on
+    /// (seed, account), not on the action or pool, so consecutive actions for one
+    /// account derive once and the Orchard and Ironwood passes can share it. A
+    /// change of account replaces and scrubs the old key. Interior mutability is
+    /// needed because `PcztSigner` signs through `&self`; the slot lives inline
+    /// in the signing call and never touches the heap.
+    ask_cache: &'a SpendAuthCache,
     /// Number of authorizations produced, so `sign_pczt` can distinguish "nothing of
     /// ours to sign" (`PcztNoMyInputs`) from a successful signing.
     signed: Cell<usize>,
@@ -130,40 +214,63 @@ struct SeedSigner<'a> {
 
 #[cfg(feature = "cypherpunk")]
 impl<'a> SeedSigner<'a> {
-    fn new(seed: &'a [u8], seed_fingerprint: [u8; 32], pool: ShieldedPool) -> Self {
+    fn new(
+        seed: &'a [u8],
+        seed_fingerprint: [u8; 32],
+        pool: ShieldedPool,
+        ask_cache: &'a SpendAuthCache,
+    ) -> Self {
         Self {
             seed,
             seed_fingerprint,
             pool,
-            ask_cache: RefCell::new(Vec::new()),
+            ask_cache,
             signed: Cell::new(0),
         }
     }
 
-    fn spend_authorizing_key(
+    /// Derives the spend authorizing key for `account_index` from the seed,
+    /// scrubbing the intermediate spending key before returning.
+    fn derive_spend_authorizing_key(
         &self,
         account_index: zcash_vendor::zip32::AccountId,
     ) -> Result<orchard::keys::SpendAuthorizingKey, ZcashError> {
-        if let Some((_, ask)) = self
-            .ask_cache
-            .borrow()
-            .iter()
-            .find(|(cached, _)| *cached == account_index)
-        {
-            return Ok(ask.clone());
-        }
-        let osk = orchard::keys::SpendingKey::from_zip32_seed(self.seed, 133, account_index)
-            .map_err(|e| {
-                ZcashError::SigningError(format!(
-                    "failed to derive {} spending key: {e:?}",
-                    self.pool.label()
-                ))
-            })?;
-        let ask = orchard::keys::SpendAuthorizingKey::from(&osk);
-        self.ask_cache
-            .borrow_mut()
-            .push((account_index, ask.clone()));
+        let mut osk = MaybeUninit::new(
+            orchard::keys::SpendingKey::from_zip32_seed(self.seed, 133, account_index).map_err(
+                |e| {
+                    ZcashError::SigningError(format!(
+                        "failed to derive {} spending key: {e:?}",
+                        self.pool.label()
+                    ))
+                },
+            )?,
+        );
+        // SAFETY: `osk` was initialized immediately above and is only scrubbed
+        // after this borrow ends.
+        let ask = orchard::keys::SpendAuthorizingKey::from(unsafe { osk.assume_init_ref() });
+        osk.zeroize();
         Ok(ask)
+    }
+
+    /// Looks up (or derives and caches) the spend authorizing key for
+    /// `account_index` and runs `f` against it in place, so no unscrubbed
+    /// copies of the key are handed out. On an account change, the slot scrubs
+    /// the old key in place before storing the replacement.
+    fn with_spend_authorizing_key<R>(
+        &self,
+        account_index: zcash_vendor::zip32::AccountId,
+        f: impl FnOnce(&orchard::keys::SpendAuthorizingKey) -> Result<R, ZcashError>,
+    ) -> Result<R, ZcashError> {
+        // Mutably borrowed across `f`, which is fine: `f` only signs and never
+        // re-enters the cache.
+        let mut cache = self.ask_cache.0.borrow_mut();
+        if cache.get(account_index).is_none() {
+            let ask = self.derive_spend_authorizing_key(account_index)?;
+            cache.replace(account_index, ask);
+        }
+        f(cache
+            .get(account_index)
+            .expect("cache contains the requested account"))
     }
 }
 
@@ -229,16 +336,17 @@ impl PcztSigner for SeedSigner<'_> {
             return Ok(());
         };
 
-        let ask = self.spend_authorizing_key(account_index)?;
-        action
-            .sign(
-                hash.as_bytes().try_into().expect("sighash is 32 bytes"),
-                &ask,
-                OsRng,
-            )
-            .map_err(|e| {
-                ZcashError::SigningError(format!("failed to sign {pool_label} action: {e:?}"))
-            })?;
+        self.with_spend_authorizing_key(account_index, |ask| {
+            action
+                .sign(
+                    hash.as_bytes().try_into().expect("sighash is 32 bytes"),
+                    ask,
+                    OsRng,
+                )
+                .map_err(|e| {
+                    ZcashError::SigningError(format!("failed to sign {pool_label} action: {e:?}"))
+                })
+        })?;
         self.signed.set(self.signed.get() + 1);
         Ok(())
     }
@@ -266,32 +374,33 @@ pub fn sign_and_redact_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
 
     let process_ironwood = super::pczt_should_process_ironwood(&pczt);
 
-    // The orchard signer handles both the transparent inputs and the Orchard bundle
-    // (the pool only changes error labels for shielded actions). Ironwood gets its own.
-    let orchard_signer = SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Orchard);
+    // Keep one scrubbed key slot and one lean signer for both pool passes.
+    let ask_cache = SpendAuthCache::new();
+    let mut seed_signer =
+        SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Orchard, &ask_cache);
 
-    // Propagate the signer error directly (it is already a ZcashError): the strict
-    // validation in SeedSigner::sign_orchard returns ZcashError::InvalidPczt for bad
-    // ZIP 32 paths, which callers/tests distinguish from generic SigningError.
+    // The Orchard pass also handles transparent inputs; the pool only changes
+    // error labels and ZIP 32 matching for shielded actions. Propagate signer
+    // errors directly so strict path validation remains `InvalidPczt`.
     let signer = low_level_signer::Signer::new(pczt);
-    let signer = pczt_ext::sign_transparent(signer, &orchard_signer)?;
-    let signer = pczt_ext::sign_orchard(signer, &orchard_signer)?;
+    let signer = pczt_ext::sign_transparent(signer, &seed_signer)?;
+    let signer = pczt_ext::sign_orchard(signer, &seed_signer)?;
 
-    let ironwood_signer = SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Ironwood);
     let signer = if process_ironwood {
-        pczt_ext::sign_ironwood(signer, &ironwood_signer)?
+        seed_signer.pool = ShieldedPool::Ironwood;
+        pczt_ext::sign_ironwood(signer, &seed_signer)?
     } else {
         signer
     };
 
-    let mut signed = orchard_signer.signed.get();
-    {
-        signed += ironwood_signer.signed.get();
-    }
-    if signed == 0 {
+    if seed_signer.signed.get() == 0 {
         return Err(ZcashError::PcztNoMyInputs);
     }
 
+    // The low-level signer does not borrow the cache, so scrub the cached key
+    // before finishing and redacting the response.
+    drop(seed_signer);
+    drop(ask_cache);
     Ok(stamp_and_redact(signer.finish()))
 }
 
@@ -438,6 +547,88 @@ mod tests {
             Err(ZcashError::InvalidPczt(message)) if message == expected => {}
             other => panic!("unexpected InvalidPczt result: {other:?}"),
         }
+    }
+
+    use zcash_vendor::{
+        pasta_curves::{group::ff::Field, Fq},
+        zip32,
+    };
+
+    /// Extracts the ask scalar bytes via public API only: randomizing by zero
+    /// returns `rsk = ask + 0 = ask`.
+    fn ask_scalar_bytes(ask: &orchard::keys::SpendAuthorizingKey) -> [u8; 32] {
+        (&ask.randomize(&Fq::ZERO)).into()
+    }
+
+    #[test]
+    fn test_ask_cache_slot_zeroizes_on_drop() {
+        let seed = [7u8; 32];
+        let osk = orchard::keys::SpendingKey::from_zip32_seed(&seed, 133, zip32::AccountId::ZERO)
+            .unwrap();
+        let mut storage = MaybeUninit::<AskCacheSlot>::uninit();
+        let slot = storage.write(AskCacheSlot::empty());
+        slot.replace(
+            zip32::AccountId::ZERO,
+            orchard::keys::SpendAuthorizingKey::from(&osk),
+        );
+        assert_ne!(
+            ask_scalar_bytes(slot.get(zip32::AccountId::ZERO).unwrap()),
+            [0u8; 32],
+            "a real ask must not start out zero"
+        );
+
+        // The outer `MaybeUninit` keeps the backing storage alive after the
+        // slot itself is dropped.
+        unsafe { core::ptr::drop_in_place(storage.as_mut_ptr()) };
+
+        // SAFETY: `Drop` initialized every byte of the still-allocated
+        // `MaybeUninit<SpendAuthorizingKey>` storage to zero. `addr_of!`
+        // projects the dropped slot without reading it.
+        let bytes = unsafe {
+            let ask_storage = core::ptr::addr_of!((*storage.as_ptr()).ask);
+            core::slice::from_raw_parts(
+                ask_storage.cast::<u8>(),
+                core::mem::size_of::<MaybeUninit<orchard::keys::SpendAuthorizingKey>>(),
+            )
+        };
+        assert!(
+            bytes.iter().all(|b| *b == 0),
+            "cached ask storage must be fully scrubbed"
+        );
+    }
+
+    #[test]
+    fn test_ask_cache_shared_single_slot_consistent() {
+        let seed = [7u8; 32];
+        let fingerprint = calculate_seed_fingerprint(&seed).unwrap();
+        let cache = SpendAuthCache::new();
+        let mut signer = SeedSigner::new(&seed, fingerprint, ShieldedPool::Orchard, &cache);
+        let account = |i: u32| zip32::AccountId::try_from(i).unwrap();
+        let fresh = |i: u32| {
+            let osk = orchard::keys::SpendingKey::from_zip32_seed(&seed, 133, account(i)).unwrap();
+            ask_scalar_bytes(&orchard::keys::SpendAuthorizingKey::from(&osk))
+        };
+
+        // Empty-slot miss, hit, replace-on-miss, hit-after-replace, and
+        // cross-pool reuse all hand out exactly the key a fresh derivation
+        // produces. The same signer and slot are reused across pool passes.
+        for (pool, i) in [
+            (ShieldedPool::Orchard, 0u32),
+            (ShieldedPool::Orchard, 0),
+            (ShieldedPool::Ironwood, 1),
+            (ShieldedPool::Ironwood, 1),
+            (ShieldedPool::Orchard, 0),
+            (ShieldedPool::Ironwood, 2),
+        ] {
+            signer.pool = pool;
+            let bytes = signer
+                .with_spend_authorizing_key(account(i), |ask| Ok(ask_scalar_bytes(ask)))
+                .unwrap();
+            assert_eq!(bytes, fresh(i), "account {i} must match a fresh derivation");
+        }
+
+        // The slot holds exactly the most recently used account's key.
+        assert_eq!(cache.0.borrow().account, Some(account(2)));
     }
 
     fn signable_sample_pczt() -> crate::pczt::test_support::SamplePczt {

--- a/rust/keystore/src/algorithms/zcash/mod.rs
+++ b/rust/keystore/src/algorithms/zcash/mod.rs
@@ -2,7 +2,6 @@ use core::str::FromStr;
 
 use alloc::string::{String, ToString};
 use bitcoin::bip32::{ChildNumber, DerivationPath};
-use rand_core::{CryptoRng, RngCore};
 use zcash_vendor::{
     zcash_keys::keys::UnifiedSpendingKey,
     zcash_protocol::consensus,
@@ -10,12 +9,6 @@ use zcash_vendor::{
 };
 
 use crate::algorithms::utils::is_all_zero_or_ff;
-
-#[cfg(feature = "cypherpunk")]
-use zcash_vendor::orchard::{
-    self,
-    keys::{SpendAuthorizingKey, SpendingKey},
-};
 
 use crate::errors::{KeystoreError, Result};
 
@@ -68,39 +61,6 @@ pub fn calculate_seed_fingerprint(seed: &[u8]) -> Result<[u8; 32]> {
         "Invalid seed, cannot calculate ZIP-32 Seed Fingerprint".into(),
     ))?;
     Ok(sfp.to_bytes())
-}
-
-#[cfg(feature = "cypherpunk")]
-pub fn sign_message_orchard<R: RngCore + CryptoRng>(
-    action: &mut orchard::pczt::Action,
-    seed: &[u8],
-    sighash: [u8; 32],
-    path: &[zip32::ChildIndex],
-    rng: R,
-) -> Result<()> {
-    ensure_non_trivial_seed(seed)?;
-    let coin_type = 133;
-
-    if path.len() == 3
-        && path[0] == zip32::ChildIndex::hardened(32)
-        && path[1] == zip32::ChildIndex::hardened(coin_type)
-    {
-        let account_id = zip32::AccountId::try_from(path[2].index() - (1 << 31)).expect("valid");
-
-        let osk = SpendingKey::from_zip32_seed(seed, coin_type, account_id).unwrap();
-
-        let osak = SpendAuthorizingKey::from(&osk);
-
-        action
-            .sign(sighash, &osak, rng)
-            .map_err(|e| KeystoreError::ZcashOrchardSign(format!("{e:?}")))
-    } else {
-        // Keystone only generates UFVKs at the above path; ignore all other signature
-        // requests.
-        Err(KeystoreError::ZcashOrchardSign(format!(
-            "invalid orchard account path: {path:?}"
-        )))
-    }
 }
 
 #[cfg(feature = "cypherpunk")]

--- a/rust/zcash_vendor/Cargo.toml
+++ b/rust/zcash_vendor/Cargo.toml
@@ -61,7 +61,7 @@ rust_tools = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(zcash_unstable, values("nu6.3", "zfuture"))',
+    'cfg(zcash_unstable, values("zfuture"))',
 ] }
 
 [dev-dependencies]

--- a/rust/zcash_vendor/src/pczt_ext.rs
+++ b/rust/zcash_vendor/src/pczt_ext.rs
@@ -337,24 +337,17 @@ fn hash_orchard_txid_empty() -> Hash {
 // This is consensus-critical and must stay bit-exact with upstream. The
 // `shielded_sig_commitment == RoleSigner::shielded_sighash` oracle tests in
 // apps/zcash/src/pczt/sign.rs guard it (red CI on any upstream drift).
-#[cfg(zcash_unstable = "nu6.3")]
 const ZCASH_ORCHARD_V6_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrchardH_v6";
-#[cfg(zcash_unstable = "nu6.3")]
 const ZCASH_IRONWOOD_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIronwd_H_v6";
-#[cfg(zcash_unstable = "nu6.3")]
 const ZCASH_IRONWOOD_ACTIONS_COMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActCH_v6";
-#[cfg(zcash_unstable = "nu6.3")]
 const ZCASH_IRONWOOD_ACTIONS_MEMOS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActMH_v6";
-#[cfg(zcash_unstable = "nu6.3")]
 const ZCASH_IRONWOOD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActNH_v6";
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn is_v6(pczt: &Pczt) -> bool {
     *pczt.global().tx_version() == zcash_protocol::constants::V6_TX_VERSION
         && *pczt.global().version_group_id() == zcash_protocol::constants::V6_VERSION_GROUP_ID
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn has_ironwood(pczt: &Pczt) -> bool {
     !pczt.ironwood().actions().is_empty()
 }
@@ -363,7 +356,6 @@ fn has_ironwood(pczt: &Pczt) -> bool {
 /// upstream `orchard::bundle::commitments::hash_bundle_txid_data_with_domain` for the
 /// `ORCHARD_V6` / `IRONWOOD_V6` domains: the three ZIP-244 action sub-hashes, the flag
 /// byte, the value balance, and — unlike v5 — NO anchor (`effects_anchor = Omit`).
-#[cfg(zcash_unstable = "nu6.3")]
 fn digest_orchard_shaped_v6(
     bundle: &pczt::orchard::Bundle,
     bundle_personalization: &[u8; 16],
@@ -406,7 +398,6 @@ fn digest_orchard_shaped_v6(
     h.finalize()
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn digest_orchard_v6(pczt: &Pczt) -> Hash {
     digest_orchard_shaped_v6(
         pczt.orchard(),
@@ -417,7 +408,6 @@ fn digest_orchard_v6(pczt: &Pczt) -> Hash {
     )
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn digest_ironwood_v6(pczt: &Pczt) -> Hash {
     digest_orchard_shaped_v6(
         pczt.ironwood(),
@@ -428,17 +418,14 @@ fn digest_ironwood_v6(pczt: &Pczt) -> Hash {
     )
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn hash_orchard_v6_txid_empty() -> Hash {
     hasher(ZCASH_ORCHARD_V6_HASH_PERSONALIZATION).finalize()
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn hash_ironwood_v6_txid_empty() -> Hash {
     hasher(ZCASH_IRONWOOD_HASH_PERSONALIZATION).finalize()
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn shielded_sig_commitment_v6(
     pczt: &Pczt,
     lock_time: u32,
@@ -487,8 +474,11 @@ fn shielded_sig_commitment_v6(
 /// `pub` so the `app_zcash` consensus oracle tests can assert it stays bit-exact against
 /// the upstream RoleSigner sighash (any divergence turns CI red rather than producing
 /// wrong on-device signatures).
-pub fn shielded_sig_commitment(pczt: &Pczt, lock_time: u32, input_info: Option<SignableInput>) -> Hash {
-    #[cfg(zcash_unstable = "nu6.3")]
+pub fn shielded_sig_commitment(
+    pczt: &Pczt,
+    lock_time: u32,
+    input_info: Option<SignableInput>,
+) -> Hash {
     if is_v6(pczt) {
         return shielded_sig_commitment_v6(pczt, lock_time, input_info);
     }
@@ -680,7 +670,7 @@ where
 /// is the one parsed and mutated. Dummy/output-only actions (value 0 or absent) are
 /// skipped, so an Orchard→Ironwood migration (Ironwood output-only) produces no
 /// Ironwood signature here.
-#[cfg(all(feature = "orchard", zcash_unstable = "nu6.3"))]
+#[cfg(feature = "orchard")]
 pub fn sign_ironwood<T>(llsigner: Signer, signer: &T) -> Result<Signer, T::Error>
 where
     T: PcztSigner,

--- a/rust/zcash_vendor/src/pczt_ext.rs
+++ b/rust/zcash_vendor/src/pczt_ext.rs
@@ -192,6 +192,18 @@ fn hash_transparent_tx_id(t_digests: Option<TransparentDigests>) -> Hash {
 /// 52 (compact) | 512 (memo) | 16 (non-compact).
 const ORCHARD_ENC_CIPHERTEXT_SIZE: usize = 580;
 
+/// Byte layout of Sapling, Orchard, and Ironwood `enc_ciphertext` fields used by
+/// the transaction digests:
+/// the first [`ENC_CIPHERTEXT_COMPACT_LEN`] bytes are the compact note ciphertext (the
+/// `*CHash` digests), bytes up to [`ENC_CIPHERTEXT_MEMO_END`] are the encrypted memo (the
+/// `*MHash` digests), and the remainder is hashed with the non-compact fields. For
+/// Orchard/Ironwood, `action_enc_ciphertext` returns a buffer of exactly
+/// [`ORCHARD_ENC_CIPHERTEXT_SIZE`] bytes, so slicing at these boundaries never panics;
+/// `pub` so signing preconditions elsewhere can reference the same constants.
+pub const ENC_CIPHERTEXT_COMPACT_LEN: usize = 52;
+/// See [`ENC_CIPHERTEXT_COMPACT_LEN`]: 52 compact bytes + 512 memo bytes.
+pub const ENC_CIPHERTEXT_MEMO_END: usize = ENC_CIPHERTEXT_COMPACT_LEN + 512;
+
 /// The action's value-commitment bytes for the sighash. `cv_net` is `Option` in the v2
 /// PCZT wire model; the checked-PCZT preflight resolves it and `check::verify_cv_net`
 /// rejects any still-missing value before signing, so it is always present here. The zero
@@ -221,16 +233,18 @@ fn digest_orchard(pczt: &Pczt) -> Hash {
     let mut nh = hasher(ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION);
 
     for action in pczt.orchard().actions().iter() {
+        let enc_ciphertext = action_enc_ciphertext(action.output());
+
         ch.update(action.spend().nullifier());
         ch.update(action.output().cmx());
         ch.update(action.output().ephemeral_key());
-        ch.update(&action_enc_ciphertext(action.output())[..52]);
+        ch.update(&enc_ciphertext[..ENC_CIPHERTEXT_COMPACT_LEN]);
 
-        mh.update(&action_enc_ciphertext(action.output())[52..564]);
+        mh.update(&enc_ciphertext[ENC_CIPHERTEXT_COMPACT_LEN..ENC_CIPHERTEXT_MEMO_END]);
 
         nh.update(action_cv_net(action));
         nh.update(action.spend().rk());
-        nh.update(&action_enc_ciphertext(action.output())[564..]);
+        nh.update(&enc_ciphertext[ENC_CIPHERTEXT_MEMO_END..]);
         nh.update(action.output().out_ciphertext());
     }
 
@@ -284,12 +298,12 @@ fn hash_sapling_outputs(pczt: &Pczt) -> Hash {
         for s_out in pczt.sapling().outputs() {
             ch.update(s_out.cmu());
             ch.update(s_out.ephemeral_key());
-            ch.update(&s_out.enc_ciphertext()[..52]);
+            ch.update(&s_out.enc_ciphertext()[..ENC_CIPHERTEXT_COMPACT_LEN]);
 
-            mh.update(&s_out.enc_ciphertext()[52..564]);
+            mh.update(&s_out.enc_ciphertext()[ENC_CIPHERTEXT_COMPACT_LEN..ENC_CIPHERTEXT_MEMO_END]);
 
             nh.update(s_out.cv());
-            nh.update(&s_out.enc_ciphertext()[564..]);
+            nh.update(&s_out.enc_ciphertext()[ENC_CIPHERTEXT_MEMO_END..]);
             nh.update(s_out.out_ciphertext());
         }
 
@@ -370,16 +384,18 @@ fn digest_orchard_shaped_v6(
     let mut nh = hasher(noncompact_personalization);
 
     for action in bundle.actions().iter() {
+        let enc_ciphertext = action_enc_ciphertext(action.output());
+
         ch.update(action.spend().nullifier());
         ch.update(action.output().cmx());
         ch.update(action.output().ephemeral_key());
-        ch.update(&action_enc_ciphertext(action.output())[..52]);
+        ch.update(&enc_ciphertext[..ENC_CIPHERTEXT_COMPACT_LEN]);
 
-        mh.update(&action_enc_ciphertext(action.output())[52..564]);
+        mh.update(&enc_ciphertext[ENC_CIPHERTEXT_COMPACT_LEN..ENC_CIPHERTEXT_MEMO_END]);
 
         nh.update(action_cv_net(action));
         nh.update(action.spend().rk());
-        nh.update(&action_enc_ciphertext(action.output())[564..]);
+        nh.update(&enc_ciphertext[ENC_CIPHERTEXT_MEMO_END..]);
         nh.update(action.output().out_ciphertext());
     }
 
@@ -628,8 +644,9 @@ where
     llsigner.sign_orchard_with::<T::Error, _>(|pczt, signable, tx_modifiable| {
         let lock_time = determine_lock_time(pczt.global(), pczt.transparent().inputs())
             .ok_or(transparent::pczt::ParseError::InvalidRequiredHeightLocktime)?;
+        let shielded_hash = shielded_sig_commitment(pczt, lock_time, None);
         signable.actions_mut().iter_mut().try_for_each(|action| {
-            sign_orchard_action(pczt, lock_time, signer, action, tx_modifiable)
+            sign_orchard_action(signer, action, &shielded_hash, tx_modifiable)
         })
     })
 }
@@ -639,12 +656,13 @@ where
 /// derivation and signs wallet-controlled spends, including zero-value ones), so we
 /// must NOT pre-filter by value here — that would drop a wallet-controlled zero-value
 /// spend. `tx_modifiable` is cleared only when this call adds a new signature.
+/// The caller supplies the transaction-wide shielded sighash shared by every action in
+/// the bundle. Added signatures do not affect this hash.
 #[cfg(feature = "orchard")]
 fn sign_orchard_action<T>(
-    pczt: &Pczt,
-    lock_time: u32,
     signer: &T,
     action: &mut orchard::pczt::Action,
+    shielded_hash: &Hash,
     tx_modifiable: &mut u8,
 ) -> Result<(), T::Error>
 where
@@ -655,7 +673,7 @@ where
         return Ok(());
     }
     let had_sig = action.spend().spend_auth_sig().is_some();
-    signer.sign_orchard(action, shielded_sig_commitment(pczt, lock_time, None))?;
+    signer.sign_orchard(action, shielded_hash.clone())?;
     if !had_sig && action.spend().spend_auth_sig().is_some() {
         *tx_modifiable &= !(FLAG_TRANSPARENT_INPUTS_MODIFIABLE
             | FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE
@@ -681,8 +699,9 @@ where
     llsigner.sign_ironwood_with::<T::Error, _>(|pczt, signable, tx_modifiable| {
         let lock_time = determine_lock_time(pczt.global(), pczt.transparent().inputs())
             .ok_or(transparent::pczt::ParseError::InvalidRequiredHeightLocktime)?;
+        let shielded_hash = shielded_sig_commitment(pczt, lock_time, None);
         signable.actions_mut().iter_mut().try_for_each(|action| {
-            sign_orchard_action(pczt, lock_time, signer, action, tx_modifiable)
+            sign_orchard_action(signer, action, &shielded_hash, tx_modifiable)
         })
     })
 }


### PR DESCRIPTION
The batch review check and parse paths are combined into one pass. `check_and_parse_pczt_shielded` runs the verifier once while recording display rows, so each output is decrypted once. `decode_output_enc_ciphertext` is generalized over the Orchard or Ironwood note-encryption domain selected by the caller.

Output validation now delegates to the same `parse_orchard_output` routine used by display, so a check-only path cannot accept an output that no wallet key can recover. The undecryptable Ironwood-output regression is covered directly.

The signing path now keeps the cached spend authorization key in a single inline slot shared by the Orchard and Ironwood passes. The slot is scrubbed on replacement and drop, and the intermediate spending key is scrubbed after derivation, so spend authorization material is not retained in freed heap storage. Signing behavior is unchanged.
