### PR TITLE
Zcash: use PCZT batch messages and compact responses

### DIFF
--- a/.github/workflows/rust-zcash-checks.yml
+++ b/.github/workflows/rust-zcash-checks.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Run rust/apps/zcash
         run: cd rust/apps/zcash && cargo +$RUST_TOOLCHAIN llvm-cov  --fail-under-regions 69 --fail-under-functions 71 --fail-under-lines 76 --ignore-filename-regex 'keystore/*|utils/*|zcash_vendor/*'
 
-  # The rust_c Zcash FFI tests (batch validation, reviewed-batch fingerprint)
-  # only build under the simulator feature set (the device feature set has no
-  # host panic handler), and the simulator's screen-capture dependency needs
-  # macOS on CI.
+  # The rust_c Zcash FFI tests (batch validation, compact signatures-only
+  # response) only build under the simulator feature set (the device feature
+  # set has no host panic handler), and the simulator's screen-capture
+  # dependency needs macOS on CI.
   RustCZcashTest:
     name: rust_c Zcash FFI tests
     runs-on: macos-latest

--- a/.github/workflows/rust-zcash-checks.yml
+++ b/.github/workflows/rust-zcash-checks.yml
@@ -2,6 +2,10 @@ on:
   pull_request:
     paths:
       - rust/apps/zcash/**
+      - rust/zcash_vendor/**
+      - rust/rust_c/src/zcash/**
+      - rust/rust_c/src/common/ur.rs
+      - rust/rust_c/src/common/ur_ext.rs
 
 name: Zcash Checks
 
@@ -28,3 +32,25 @@ jobs:
 
       - name: Run rust/apps/zcash
         run: cd rust/apps/zcash && cargo +$RUST_TOOLCHAIN llvm-cov  --fail-under-regions 69 --fail-under-functions 71 --fail-under-lines 76 --ignore-filename-regex 'keystore/*|utils/*|zcash_vendor/*'
+
+  # The rust_c Zcash FFI tests (batch validation, reviewed-batch fingerprint)
+  # only build under the simulator feature set (the device feature set has no
+  # host panic handler), and the simulator's screen-capture dependency needs
+  # macOS on CI.
+  RustCZcashTest:
+    name: rust_c Zcash FFI tests
+    runs-on: macos-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Read Rust toolchain
+        run: echo "RUST_TOOLCHAIN=$(cat rust-toolchain)" >> $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Run rust_c zcash tests
+        run: cd rust && cargo +$RUST_TOOLCHAIN test -p rust_c --no-default-features --features simulator-cypherpunk --lib -- zcash common::ur

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### What's new
 
 1. Added support for Zcash batch PCZT signing
+2. The device no longer auto-locks while a long Zcash batch review is loading
 
 ### Bug Fixes
 

--- a/docs/protocols/ur_registrys/zcash.md
+++ b/docs/protocols/ur_registrys/zcash.md
@@ -55,71 +55,85 @@ zcash-pczt {
 
 ### Zcash Batch Signing
 
-`zcash-sign-batch` wraps multiple signing messages into one Keystone approval.
-Version 1 is supported by cypherpunk firmware and currently supports up to 35
-mainnet PCZT messages. It requires `atomic` to be `true`; if any message is
-invalid or cannot be signed, Keystone returns an error instead of a partial
-result. Batch PCZT entries must be fully Keystone-owned spends from supported
-shielded pools, currently Orchard or Ironwood. Transparent inputs and Sapling
-spends or outputs are rejected.
+`zcash-sign-batch` wraps multiple PCZTs into one Keystone approval.
+The outer UR registry envelope carries a request id for response correlation and
+an opaque `data` field containing the PCZT-owned batch request. The matching
+compact response uses `zcash-batch-sig-result`, echoes the request id, and
+carries the PCZT-owned response in its own opaque `data` field.
 
-The 35-message limit is the current batch memory budget for `pczt-v1`. A full
-35-message batch using the supported PCZT message shape was measured at about
-35% RAM on target hardware, so this version does not define separate byte caps
-for request ids, message ids, or payloads. Revisit the limit if new message
-kinds or substantially larger payload encodings are added.
+Batch version 1 is supported by cypherpunk firmware and currently accepts up to
+50 PCZTs. The encoded batch data and request id together, and the canonical PCZT
+payloads after decoding, must each fit within 512 KiB. The operation is atomic.
+If any PCZT is invalid or cannot be signed, Keystone returns an error instead of
+a partial result. PCZT entries with identical canonical encodings are rejected.
+Every spend must be fully Keystone-owned and use a supported shielded pool,
+currently Orchard or Ironwood. Transparent inputs and Sapling spends or outputs
+are rejected.
 
-Message kinds:
+#### Outer UR/CBOR envelopes
 
-```cddl
-pczt-v1 = 1
-```
-
-Networks:
-
-```cddl
-zcash-mainnet = 1
-```
-
-Result statuses:
-
-```cddl
-signed = 0
-```
-
-#### CDDL for Zcash Sign Batch
+Both registry types use definite-length CBOR maps with the same integer keys.
+Firmware requires `request-id` to be non-empty. Key `1` follows `zcash-pczt` by
+carrying opaque transaction data, and key `2` follows `zcash-sign-result` by
+carrying the request id.
 
 ```cddl
 zcash-sign-batch = {
-    1: uint,                 ; version. Must be 1.
-    2: bytes,                ; request id. Echoed by zcash-sign-result.
-    3: uint,                 ; network. Must be zcash-mainnet.
-    4: [1*35 zcash-sign-message],
-   ?11: bool,                ; atomic. Defaults to true. Must be true.
+    1: bytes, ; BatchSignRequest::serialize output
+    2: bytes, ; request-id
 }
 
-zcash-sign-message = {
-    1: bytes,                ; caller-defined message id. Must be unique.
-    2: uint,                 ; message kind. Must be pczt-v1.
-    3: bytes,                ; message payload. For pczt-v1 this is raw PCZT bytes. Must be unique in the batch.
-   ?6: bytes.32,             ; SHA-256 of payload.
+zcash-batch-sig-result = {
+    1: bytes, ; BatchSignResponse::serialize output
+    2: bytes, ; echoed request-id
 }
 ```
 
-#### CDDL for Zcash Sign Result
+#### PCZT batch request
 
-```cddl
-zcash-sign-result = {
-    1: uint,                 ; version. Matches request version.
-    2: bytes,                ; request id from zcash-sign-batch.
-    3: [1*35 zcash-sign-message-result],
-}
+The request `data` encoding is
+`"PCZB" || batch_version_le || pczt_version_le || postcard_body`. Its Postcard
+body contains the PCZTs in request order. Both version fields are four-byte
+little-endian integers. Current encoders emit batch version 1 and PCZT version
+2. The shared PCZT version applies to every headerless PCZT wire value in the
+body.
 
-zcash-sign-message-result = {
-    1: bytes,                ; message id from zcash-sign-message.
-    2: uint,                 ; status. signed = 0.
-    3: uint,                 ; message kind from zcash-sign-message.
-    4: bytes,                ; signed payload. For pczt-v1 this is signed PCZT bytes.
-    6: bytes.32,             ; SHA-256 of signed payload.
+```rust
+struct BatchSignRequestBody {
+    pczts: Vec<PcztV2Wire>,
 }
 ```
+
+The exact PCZT wire value is owned by the pinned
+[`pczt::roles::signer::batch`](https://github.com/zcash/librustzcash/blob/878db2074ae8ac2682d3e6c61c00f7018b6adc0c/pczt/src/roles/signer/batch.rs)
+implementation. There are no request or message ids in the inner payload. PCZT
+entries are correlated by position and must be unique within the request.
+
+#### PCZT batch signature response
+
+The response `data` encoding is `"PCZS" || batch_version_le || postcard_body`.
+Entry `i` contains the signatures produced for PCZT `i` in the request.
+
+```rust
+struct BatchSignResponseBody {
+    signatures: Vec<Vec<SpendAuthSignature>>,
+}
+
+struct SpendAuthSignature {
+    value_pool: ValuePool,
+    action_index: u32,
+    signature: [u8; 64],
+}
+
+enum ValuePool {
+    Orchard,
+    Ironwood,
+}
+```
+
+Postcard encodes integer fields inside each body as varints; `ValuePool` uses
+the enum indexes Orchard = 0 and Ironwood = 1. Response entry `i` contains the
+signatures for request PCZT `i`. Each signature selects an action by value pool
+and action index, so the client can apply it to the corresponding unsigned PCZT
+without transporting another full PCZT. The outer response echoes the request
+id so the application can correlate it with the outstanding batch.

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -2,4 +2,3 @@
 ## This path is hardcoded into the Makefiles, so make sure a contributor’s
 ## config hasn’t overridden it.
 target-dir = "target"
-rustflags = ["--cfg", "zcash_unstable=\"nu6.3\""]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives",
  "zcash_vendor",
+ "zeroize",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3881,6 +3881,7 @@ dependencies = [
  "keystore",
  "minicbor",
  "no_std_io2",
+ "postcard",
  "rand_core 0.6.4",
  "rsa",
  "rust_tools",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1678,7 +1678,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
+source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
+source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3041,8 +3041,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "orchard"
-version = "0.15.0-pre.2"
-source = "git+https://github.com/zcash/orchard?rev=475ef0ff77d45aebff93cb039d639250d82518a3#475ef0ff77d45aebff93cb039d639250d82518a3"
+version = "0.15.0"
+source = "git+https://github.com/zcash/orchard?rev=8995ee7e26f8b654a5457d05c95ee5b3132b3edd#8995ee7e26f8b654a5457d05c95ee5b3132b3edd"
 dependencies = [
  "aes",
  "bitvec",
@@ -3143,7 +3143,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.7.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
+source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4813,7 +4813,7 @@ dependencies = [
 [[package]]
 name = "ur-registry"
 version = "1.0.5"
-source = "git+https://github.com/KeystoneHQ/keystone-sdk-rust.git?rev=0884de4b2e927bc3f95a98dff62045e0d492e574#0884de4b2e927bc3f95a98dff62045e0d492e574"
+source = "git+https://github.com/valargroup/keystone-sdk-rust.git?rev=bf5b6e4b5c533e8934c4611837db2b6567ae837e#bf5b6e4b5c533e8934c4611837db2b6567ae837e"
 dependencies = [
  "bs58",
  "hex",
@@ -5410,13 +5410,13 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.13.0-pre.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f)",
+ "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c)",
  "zcash_encoding",
  "zcash_protocol",
 ]
@@ -5424,7 +5424,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
+source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
 dependencies = [
  "corez",
  "hex",
@@ -5433,8 +5433,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0-pre.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
+version = "0.15.0"
+source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
 dependencies = [
  "bech32 0.11.0",
  "bip32",
@@ -5472,8 +5472,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.29.0-pre.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5502,8 +5502,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0-pre.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
 dependencies = [
  "corez",
  "hex",
@@ -5541,8 +5541,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0-pre.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=94d6e7fd8c76abb1d909390e10254a22f587981f#94d6e7fd8c76abb1d909390e10254a22f587981f"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
 dependencies = [
  "bip32",
  "bs58",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -122,14 +122,15 @@ zeroize = { version = "1.8.2", default-features = false }
 # third party dependencies end
 
 [patch.crates-io]
-pczt = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
-zcash_address = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
-zcash_encoding = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
-zcash_keys = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
-zcash_primitives = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
-zcash_protocol = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
-zcash_transparent = { git = "https://github.com/valargroup/librustzcash", rev = "94d6e7fd8c76abb1d909390e10254a22f587981f" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
 # Keep `orchard` aligned with the pinned PCZT/librustzcash revision.
-orchard = { git = "https://github.com/zcash/orchard", rev = "475ef0ff77d45aebff93cb039d639250d82518a3" }
-# Use the upstream SDK rev with the Zcash batch registry types until they are published as a crate.
-ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust.git", rev = "0884de4b2e927bc3f95a98dff62045e0d492e574" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "8995ee7e26f8b654a5457d05c95ee5b3132b3edd" }
+# Use the SDK rev that wraps PCZT-owned Postcard messages as opaque UR data and
+# correlates each request and result through the outer registry envelope.
+ur-registry = { git = "https://github.com/valargroup/keystone-sdk-rust.git", rev = "bf5b6e4b5c533e8934c4611837db2b6567ae837e" }

--- a/rust/apps/zcash/Cargo.toml
+++ b/rust/apps/zcash/Cargo.toml
@@ -38,7 +38,6 @@ orchard = { version = "0.15.0-pre.2", default-features = false }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(coverage_nightly)',
-    'cfg(zcash_unstable, values("nu6.3"))',
 ] }
 
 [features]

--- a/rust/apps/zcash/Cargo.toml
+++ b/rust/apps/zcash/Cargo.toml
@@ -23,6 +23,7 @@ serde_with = { version = "3.11.0", features = [
     "alloc",
     "macros",
 ], default-features = false }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 keystore = { path = "../../keystore" }

--- a/rust/apps/zcash/Cargo.toml
+++ b/rust/apps/zcash/Cargo.toml
@@ -34,7 +34,7 @@ shardtree = "0.6.2"
 # Nameable only so the transparent-only `legacy_test_support` can spell the
 # `BuildConfig::orchard_pool_bundle_type` value; orchard is already built transitively
 # via the `zcash_primitives` dev-dependency.
-orchard = { version = "0.15.0-pre.2", default-features = false }
+orchard = { version = "0.15.0", default-features = false }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -1042,6 +1042,37 @@ mod tests {
     }
 
     #[test]
+    fn test_check_rejects_foreign_restricted_orchard_output() {
+        let sample = pczt::test_support::sample_orchard_foreign_change_pczt();
+        let expected =
+            "funded Orchard output paired with a zero-value spend does not belong to the selected account";
+
+        for result in [
+            check_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                0,
+            )
+            .map(|_| ()),
+            check_and_parse_batch_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                0,
+            )
+            .map(|_| ()),
+        ] {
+            match result {
+                Err(ZcashError::InvalidPczt(message)) if message == expected => {}
+                other => panic!("check must reject foreign restricted output, got: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn test_get_address() {
         let address = get_address(&MainNetwork, "uview1s2e0495jzhdarezq4h4xsunfk4jrq7gzg22tjjmkzpd28wgse4ejm6k7yfg8weanaghmwsvc69clwxz9f9z2hwaz4gegmna0plqrf05zkeue0nevnxzm557rwdkjzl4pl4hp4q9ywyszyjca8jl54730aymaprt8t0kxj8ays4fs682kf7prj9p24dnlcgqtnd2vnskkm7u8cwz8n0ce7yrwx967cyp6dhkc2wqprt84q0jmwzwnufyxe3j0758a9zgk9ssrrnywzkwfhu6ap6cgx3jkxs3un53n75s3");
         assert_eq!(address.unwrap(), "u1tqdskj32l9udfp0rysmca6gpz73fdqc2rmeenyhh0nfrq4vgak284ehkxefw5cf9495rdur0tparuntevp6nnetzjkyzv08m524e4swwk94asas7hm2ad5w5c64zz00hmr7nux0yhaz");
@@ -1598,6 +1629,83 @@ mod tests {
             )
             .unwrap_err(),
             ZcashError::PcztNoMyInputs
+        );
+    }
+
+    #[test]
+    fn test_check_rejects_undecryptable_ironwood_output() {
+        use zcash_vendor::pczt::Pczt;
+
+        /// Flips a byte inside the first verbatim occurrence of `needle`.
+        fn corrupt_first_occurrence(haystack: &mut [u8], needle: &[u8]) -> bool {
+            if needle.is_empty() || needle.len() > haystack.len() {
+                return false;
+            }
+            for start in 0..=haystack.len() - needle.len() {
+                if &haystack[start..start + needle.len()] == needle {
+                    haystack[start + needle.len() / 2] ^= 0xff;
+                    return true;
+                }
+            }
+            false
+        }
+
+        let sample = pczt::test_support::sample_migration_pczt();
+
+        // Extract the non-zero Ironwood output's ciphertext bytes.
+        let enc_ciphertext = {
+            let pczt = Pczt::parse(&sample.bytes).expect("sample PCZT should parse");
+            pczt.ironwood()
+                .actions()
+                .iter()
+                .find(|action| matches!(action.output().value(), Some(value) if *value != 0))
+                .expect("migration child must contain a non-zero Ironwood output")
+                .output()
+                .enc_ciphertext()
+                .clone()
+                .into_encrypted()
+                .expect("the sample's Ironwood output carries a full enc_ciphertext")
+        };
+
+        // Corrupt only the ciphertext: cmx, cv_net, the value balance, and the
+        // plaintext recipient are all untouched, so every other check still
+        // passes and only decryption/recoverability fails.
+        let mut corrupted = sample.bytes.clone();
+        assert!(
+            corrupt_first_occurrence(&mut corrupted, &enc_ciphertext),
+            "sample must embed the Ironwood output enc_ciphertext verbatim"
+        );
+        assert!(
+            Pczt::parse(&corrupted).is_ok(),
+            "corruption must keep the PCZT structurally well-formed"
+        );
+
+        let check_err = check_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &corrupted,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect_err("check must reject a PCZT with an undecryptable output");
+        assert!(
+            matches!(&check_err, ZcashError::InvalidPczt(message) if message.contains("undecryptable")),
+            "expected an undecryptable-output rejection, got {check_err:?}"
+        );
+
+        // Both review paths enforce the same output-recoverability contract.
+        assert!(
+            matches!(
+                check_and_parse_batch_pczt_cypherpunk(
+                    &pczt::test_support::Nu6_3Network,
+                    &corrupted,
+                    &sample.ufvk_text,
+                    &sample.seed_fingerprint,
+                    0,
+                ),
+                Err(ZcashError::InvalidPczt(message)) if message.contains("undecryptable")
+            ),
+            "single-pass batch review must also reject the undecryptable output"
         );
     }
 

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -216,7 +216,6 @@ fn transparent_account_pubkey_from_xpub(
 
 #[cfg(feature = "multi_coins")]
 fn reject_legacy_check_unsupported_pczt(pczt: &Pczt) -> Result<()> {
-    #[cfg(zcash_unstable = "nu6.3")]
     {
         // The legacy multi-coins check path only verifies transparent data. Reject any
         // shielded (Sapling/Orchard/Ironwood) or V6 PCZT so check, parse, and sign
@@ -386,7 +385,6 @@ mod legacy_tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_check_rejects_v6_pczt() {
         let pczt = Creator::new(
@@ -431,7 +429,6 @@ fn map_shielded_verifier_error(
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SignableShieldedPool {
     Orchard,
-    #[cfg(zcash_unstable = "nu6.3")]
     Ironwood,
 }
 
@@ -440,7 +437,6 @@ impl SignableShieldedPool {
     fn label(self) -> &'static str {
         match self {
             SignableShieldedPool::Orchard => "Orchard",
-            #[cfg(zcash_unstable = "nu6.3")]
             SignableShieldedPool::Ironwood => "Ironwood",
         }
     }
@@ -448,7 +444,6 @@ impl SignableShieldedPool {
     fn shielded_pool(self) -> pczt::ShieldedPool {
         match self {
             SignableShieldedPool::Orchard => pczt::ShieldedPool::Orchard,
-            #[cfg(zcash_unstable = "nu6.3")]
             SignableShieldedPool::Ironwood => pczt::ShieldedPool::Ironwood,
         }
     }
@@ -575,7 +570,6 @@ fn signable_shielded_actions<P: consensus::Parameters>(
         reject_unsupported_batch_pczt(&pczt)?;
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let should_process_ironwood = pczt::pczt_should_process_ironwood(&pczt);
     let mut actions = Vec::new();
     let verifier = Verifier::new(pczt)
@@ -592,7 +586,6 @@ fn signable_shielded_actions<P: consensus::Parameters>(
         })
         .map_err(map_shielded_verifier_error)?;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let verifier = if should_process_ironwood {
         verifier
             .with_ironwood::<ZcashError, _>(|bundle| {
@@ -622,7 +615,6 @@ fn ensure_shielded_actions_are_signed(
 ) -> Result<Pczt> {
     use zcash_vendor::pczt::roles::verifier::Verifier;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let should_process_ironwood = pczt::pczt_should_process_ironwood(&signed_pczt);
     let verifier = Verifier::new(signed_pczt)
         .with_orchard::<ZcashError, _>(|bundle| {
@@ -630,7 +622,6 @@ fn ensure_shielded_actions_are_signed(
         })
         .map_err(map_shielded_verifier_error)?;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let verifier = if should_process_ironwood {
         verifier
             .with_ironwood::<ZcashError, _>(|bundle| {
@@ -794,7 +785,6 @@ mod tests {
         derivation_path: Vec<u32>,
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     fn v5_pczt_with_ironwood_actions() -> Vec<u8> {
         let sample = pczt::test_support::sample_ironwood_pczt();
         let bytes = sample.bytes;
@@ -992,7 +982,6 @@ mod tests {
         assert_eq!(address.unwrap(), "u1tqdskj32l9udfp0rysmca6gpz73fdqc2rmeenyhh0nfrq4vgak284ehkxefw5cf9495rdur0tparuntevp6nnetzjkyzv08m524e4swwk94asas7hm2ad5w5c64zz00hmr7nux0yhaz");
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_pczt_ironwood_to_ironwood() {
         let sample = pczt::test_support::sample_ironwood_pczt();
@@ -1030,7 +1019,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_parse_pczt_orchard_decodes_spend_and_change() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
@@ -1073,7 +1061,6 @@ mod tests {
         .unwrap();
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_parse_and_check_ignore_unsupported_ironwood_spend_zip32_path() {
         let sample = pczt::test_support::sample_ironwood_pczt();
@@ -1117,7 +1104,6 @@ mod tests {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_parse_and_check_ignore_dummy_ironwood_spend_zip32_metadata() {
         let sample = pczt::test_support::sample_ironwood_pczt();
@@ -1156,7 +1142,6 @@ mod tests {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_parse_check_and_sign_reject_v5_pczt_with_ironwood_actions() {
         let sample = pczt::test_support::sample_ironwood_pczt();
@@ -1216,7 +1201,6 @@ mod tests {
         assert!(matches!(result.unwrap_err(), ZcashError::InvalidPczt(_)));
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_check_pczt_normalizes_and_is_idempotent() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
@@ -1288,7 +1272,6 @@ mod tests {
     const BATCH_UNSUPPORTED_SAPLING_ERROR: &str =
         "Zcash batch PCZT must not contain Sapling spends or outputs";
 
-    #[cfg(zcash_unstable = "nu6.3")]
     fn pczt_with_sapling_output() -> pczt::test_support::SamplePczt {
         let mut sample = pczt::test_support::sample_orchard_change_pczt();
         let (mut prefix, rest) =
@@ -1335,7 +1318,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_checked_batch_pczt_signs_ironwood_spend() {
         let sample = pczt::test_support::sample_ironwood_pczt();
@@ -1363,7 +1345,6 @@ mod tests {
             .any(|action| action.spend().spend_auth_sig().is_some()));
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_checked_pczt_signs_owned_orchard_actions() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
@@ -1395,7 +1376,6 @@ mod tests {
         assert_eq!(signed_actions, 2);
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_checked_pczt_rejects_foreign_seed() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
@@ -1420,7 +1400,6 @@ mod tests {
         assert!(matches!(result, Err(ZcashError::PcztNoMyInputs)));
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_checked_batch_pczt_signs_and_rejects_sapling() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
@@ -1462,7 +1441,6 @@ mod tests {
         ));
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_check_batch_pczt_accepts_orchard_and_ironwood_spends() {
         for sample in [
@@ -1494,7 +1472,6 @@ mod tests {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_check_resolves_compact_pczt_and_signs() {
         use zcash_vendor::pczt::roles::redactor::Redactor;
@@ -1571,7 +1548,6 @@ mod tests {
             .any(|action| action.spend().spend_auth_sig().is_some()));
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_check_batch_pczt_rejects_sapling_outputs() {
         let sample = pczt_with_sapling_output();

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -24,6 +24,8 @@ use zcash_vendor::{
     zip32,
 };
 
+#[cfg(feature = "cypherpunk")]
+use zcash_vendor::pczt::roles::signer::SpendAuthSignature;
 #[cfg(any(test, feature = "multi_coins", feature = "cypherpunk"))]
 use zcash_vendor::pczt::Pczt;
 
@@ -88,10 +90,9 @@ pub fn check_pczt_cypherpunk<P: consensus::Parameters>(
     )
 }
 
-/// Batch check for one `ZcashSignBatch` message: parses once, runs the full
-/// policy checks, enforces the batch shielded-action policy (the PCZT must be
-/// batch-signable by this account), and returns the normalized encoding. See
-/// `check_pczt_cypherpunk` for the normalization contract.
+/// Checks one PCZT from a batch request, enforcing the batch shielded-action
+/// policy, and returns its normalized encoding. See `check_pczt_cypherpunk`
+/// for the normalization contract.
 #[cfg(feature = "cypherpunk")]
 pub fn check_batch_pczt_cypherpunk<P: consensus::Parameters>(
     params: &P,
@@ -127,7 +128,6 @@ fn check_pczt_cypherpunk_with_policy<P: consensus::Parameters>(
     pczt.resolve_fields().map_err(|e| {
         ZcashError::InvalidPczt(alloc::format!("resolve compact PCZT fields: {e:?}"))
     })?;
-
     let account_index = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
     let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
@@ -501,10 +501,10 @@ fn compact_batch_migration_review(items: Vec<ParsedBatchItem>) -> Vec<ParsedPczt
 }
 
 /// Parses checked batch PCZTs and compacts eligible Orchard-to-Ironwood
-/// self-transfers without relying on message position.
+/// self-transfers without relying on PCZT position.
 ///
 /// Every input must be normalized bytes produced by the batch check. A batch
-/// with more than one ordinary transaction uses full per-message review.
+/// with more than one ordinary transaction uses full review for each PCZT.
 #[cfg(feature = "cypherpunk")]
 pub fn parse_batch_with_migration_summary_cypherpunk<'a, P: consensus::Parameters>(
     params: &P,
@@ -663,11 +663,12 @@ mod legacy_tests {
             BranchId::Nu6_3.into(),
             10,
             MainNetwork.coin_type(),
-            [0; 32],
-            [0; 32],
+            None,
+            None,
         )
         .unwrap()
-        .build();
+        .build()
+        .unwrap();
 
         let result = check_pczt_multi_coins(
             &MainNetwork,
@@ -983,6 +984,26 @@ fn sign_checked_pczt_with_policy<P: consensus::Parameters>(
         .map_err(|e| ZcashError::SigningError(alloc::format!("serialize signed PCZT: {e:?}")))
 }
 
+/// Extracts every Orchard-protocol spend authorization signature from a signed
+/// PCZT. Errors if the PCZT is unparseable or carries no such signature.
+#[cfg(feature = "cypherpunk")]
+pub fn extract_compact_sigs_from_signed_pczt(
+    signed_pczt: &[u8],
+) -> Result<Vec<SpendAuthSignature>> {
+    let signed_pczt = pczt::parse_pczt(signed_pczt)
+        .map_err(|_| ZcashError::InvalidPczt("invalid signed pczt data".to_string()))?;
+    let sigs =
+        zcash_vendor::pczt::roles::signer::extract_orchard_spend_auth_signatures(&signed_pczt);
+
+    if sigs.is_empty() {
+        return Err(ZcashError::SigningError(
+            "signed PCZT has no spend authorization signatures".to_string(),
+        ));
+    }
+
+    Ok(sigs)
+}
+
 #[cfg(feature = "cypherpunk")]
 #[cfg(test)]
 mod tests {
@@ -1091,11 +1112,12 @@ mod tests {
             BranchId::Nu6.into(),
             10,
             MainNetwork.coin_type(),
-            [0; 32],
-            [0; 32],
+            Some([0; 32]),
+            Some([0; 32]),
         )
         .unwrap()
         .build()
+        .unwrap()
         .serialize()
         .unwrap();
         let (mut prefix, rest) = postcard::take_from_bytes::<PcztWirePrefix>(&bytes[8..]).unwrap();
@@ -1191,7 +1213,9 @@ mod tests {
         );
         let mut builder = Builder::new(
             &params,
-            10_000_000.into(),
+            // Exercise the legacy cross-address-enabled Orchard format. NU6.3
+            // rejects this spoof at construction before the wallet check runs.
+            2_000_000.into(),
             BuildConfig::Standard {
                 sapling_anchor: None,
                 orchard_anchor: Some(orchard::Anchor::empty_tree()),
@@ -1646,6 +1670,12 @@ mod tests {
             .actions()
             .iter()
             .any(|action| action.spend().spend_auth_sig().is_some()));
+
+        let compact_sigs =
+            extract_compact_sigs_from_signed_pczt(&signed).expect("compact sigs should extract");
+        assert!(compact_sigs
+            .iter()
+            .any(|sig| sig.value_pool() == zcash_vendor::orchard::ValuePool::Ironwood));
     }
 
     #[test]
@@ -2078,7 +2108,7 @@ mod tests {
                 &ufvk_text,
                 &seed_fingerprint,
             )
-            .expect("message order must not affect migration classification");
+            .expect("PCZT order must not affect migration classification");
 
             assert_eq!(parsed.len(), 2);
             let summary = &parsed[1];
@@ -2089,7 +2119,7 @@ mod tests {
     }
 
     #[test]
-    fn test_batch_migration_summary_keeps_single_message_uncompacted() {
+    fn test_batch_migration_summary_keeps_single_pczt_uncompacted() {
         let sample = pczt::test_support::sample_migration_pczt();
         let checked = check_batch_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
@@ -2180,7 +2210,7 @@ mod tests {
             &sample.seed_fingerprint,
             0,
         )
-        .expect("per-message review must accept the memo-carrying transfer");
+        .expect("review for each PCZT must accept the memo-carrying transfer");
         let shown_memo = parsed
             .get_ironwood()
             .expect("migration must show Ironwood outputs")
@@ -2427,7 +2457,7 @@ mod tests {
                 ),
                 Err(ZcashError::InvalidPczt(message)) if message.contains("undecryptable")
             ),
-            "ordinary per-message review must also reject the undecryptable output"
+            "ordinary review for each PCZT must also reject the undecryptable output"
         );
     }
 

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -11,7 +11,13 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+// The aggregate migration review is the only consumer of these; keep them off
+// the non-cypherpunk build so it stays warning-free.
+#[cfg(feature = "cypherpunk")]
+use alloc::{format, vec};
 use pczt::structs::ParsedPczt;
+#[cfg(feature = "cypherpunk")]
+use pczt::structs::{ParsedFrom, ParsedOrchard, ParsedTo};
 use zcash_vendor::{
     zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey},
     zcash_protocol::consensus::{self},
@@ -270,7 +276,7 @@ pub fn check_and_parse_batch_pczt_cypherpunk<P: consensus::Parameters>(
 ) -> Result<ParsedPczt> {
     let mut pczt = pczt::parse_pczt(pczt_bytes)?;
     // Resolve compact field representations up front so the single-pass check
-    // sees complete actions, matching `preflight_batch_pczt_cypherpunk`.
+    // sees complete actions, matching the standalone batch check.
     pczt.resolve_fields().map_err(|e| {
         ZcashError::InvalidPczt(alloc::format!("resolve compact PCZT fields: {e:?}"))
     })?;
@@ -321,6 +327,389 @@ pub fn check_and_parse_batch_pczt_cypherpunk<P: consensus::Parameters>(
             checked_shielded.orchard,
             checked_shielded.ironwood,
         )
+    }
+}
+
+/// Values for one checked migration child, in zatoshis.
+#[cfg(feature = "cypherpunk")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BatchMigrationChildSummary {
+    input: u64,
+    output: u64,
+    fee: u64,
+}
+
+/// Totals and per-child rows for the compact migration review.
+#[cfg(feature = "cypherpunk")]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct BatchMigrationSummary {
+    migrations: u32,
+    total_input: u64,
+    total_output: u64,
+    total_fee: u64,
+    children: Vec<BatchMigrationChildSummary>,
+}
+
+#[cfg(feature = "cypherpunk")]
+impl BatchMigrationSummary {
+    /// Adds a checked child summary using checked arithmetic.
+    fn add_child(&mut self, child: &BatchMigrationSummary) -> Result<()> {
+        self.migrations = self
+            .migrations
+            .checked_add(child.migrations)
+            .ok_or_else(|| ZcashError::InvalidPczt("migration count overflow".to_string()))?;
+        self.total_input = self
+            .total_input
+            .checked_add(child.total_input)
+            .ok_or_else(|| ZcashError::InvalidPczt("migration input overflow".to_string()))?;
+        self.total_output = self
+            .total_output
+            .checked_add(child.total_output)
+            .ok_or_else(|| ZcashError::InvalidPczt("migration output overflow".to_string()))?;
+        self.total_fee = self
+            .total_fee
+            .checked_add(child.total_fee)
+            .ok_or_else(|| ZcashError::InvalidPczt("migration fee overflow".to_string()))?;
+        if child.children.is_empty() {
+            self.children.push(BatchMigrationChildSummary {
+                input: child.total_input,
+                output: child.total_output,
+                fee: child.total_fee,
+            });
+        } else {
+            self.children.extend(child.children.iter().copied());
+        }
+        Ok(())
+    }
+
+    /// Builds the display model for the compact migration review.
+    fn to_parsed_pczt(&self) -> ParsedPczt {
+        let children = if self.children.is_empty() {
+            vec![BatchMigrationChildSummary {
+                input: self.total_input,
+                output: self.total_output,
+                fee: self.total_fee,
+            }]
+        } else {
+            self.children.clone()
+        };
+
+        let orchard = ParsedOrchard::new(
+            children
+                .iter()
+                .enumerate()
+                .map(|(index, child)| {
+                    ParsedFrom::new(
+                        Some(format!(
+                            "Migration #{} Orchard note from selected account",
+                            index + 1
+                        )),
+                        pczt::parse::format_zec_value(child.input as f64),
+                        child.input,
+                        true,
+                    )
+                })
+                .collect(),
+            Vec::new(),
+        );
+        let ironwood = ParsedOrchard::new(
+            Vec::new(),
+            children
+                .iter()
+                .enumerate()
+                .map(|(index, child)| {
+                    ParsedTo::new(
+                        format!("Migration #{} wallet Ironwood output", index + 1),
+                        pczt::parse::format_zec_value(child.output as f64),
+                        child.output,
+                        true,
+                        false,
+                        None,
+                    )
+                })
+                .collect(),
+        );
+
+        ParsedPczt::new(
+            None,
+            Some(orchard),
+            Some(ironwood),
+            pczt::parse::format_zec_value(self.total_output as f64),
+            pczt::parse::format_zec_value(self.total_fee as f64),
+            false,
+        )
+    }
+}
+
+/// Requires an action value to be present, returning it (zero is a valid
+/// value; callers classify zero themselves).
+#[cfg(feature = "cypherpunk")]
+fn require_action_value(value: Option<u64>, label: &str) -> Result<u64> {
+    value.ok_or_else(|| ZcashError::InvalidPczt(format!("missing {label} value")))
+}
+
+/// Validates the funded migration shape and computes its totals.
+#[cfg(feature = "cypherpunk")]
+fn summarize_migration_actions(
+    ufvk: &UnifiedFullViewingKey,
+    pczt: &Pczt,
+) -> Result<BatchMigrationSummary> {
+    use zcash_vendor::pczt::roles::verifier::{OrchardError, Verifier};
+
+    // Reject transparent components at the wire level so their values cannot be
+    // omitted from the fee.
+    if !pczt.transparent().inputs().is_empty() {
+        return Err(ZcashError::InvalidPczt(
+            "migration summary does not support transparent inputs".to_string(),
+        ));
+    }
+    if !pczt.transparent().outputs().is_empty() {
+        return Err(ZcashError::InvalidPczt(
+            "migration summary does not support transparent outputs".to_string(),
+        ));
+    }
+
+    let mut orchard_spends = 0u32;
+    let mut orchard_outputs = 0u32;
+    let mut ironwood_spends = 0u32;
+    let mut ironwood_outputs = 0u32;
+    let mut total_input = 0u64;
+    let mut total_output = 0u64;
+
+    let map_verifier_error = |error: OrchardError<ZcashError>| match error {
+        OrchardError::Custom(error) => error,
+        error => ZcashError::InvalidDataError(format!("{error:?}")),
+    };
+
+    // Values are read through the Verifier's parsed view; the wire structs of
+    // the pinned pczt revision expose no spend-value getter.
+    let verifier = Verifier::new(pczt.clone())
+        .with_orchard(|bundle| {
+            for action in bundle.actions().iter() {
+                let spend_value = require_action_value(
+                    action.spend().value().map(|v| v.inner()),
+                    "Orchard spend",
+                )
+                .map_err(OrchardError::Custom)?;
+                if spend_value != 0 {
+                    orchard_spends = orchard_spends.checked_add(1).ok_or_else(|| {
+                        OrchardError::Custom(ZcashError::InvalidPczt(
+                            "Orchard spend count overflow".to_string(),
+                        ))
+                    })?;
+                    total_input = total_input.checked_add(spend_value).ok_or_else(|| {
+                        OrchardError::Custom(ZcashError::InvalidPczt(
+                            "migration input overflow".to_string(),
+                        ))
+                    })?;
+                }
+
+                let output_value = require_action_value(
+                    action.output().value().map(|v| v.inner()),
+                    "Orchard output",
+                )
+                .map_err(OrchardError::Custom)?;
+                if output_value != 0 {
+                    orchard_outputs = orchard_outputs.checked_add(1).ok_or_else(|| {
+                        OrchardError::Custom(ZcashError::InvalidPczt(
+                            "Orchard output count overflow".to_string(),
+                        ))
+                    })?;
+                }
+            }
+            Ok(())
+        })
+        .map_err(map_verifier_error)?;
+
+    verifier
+        .with_ironwood(|bundle| {
+            for action in bundle.actions().iter() {
+                let spend_value = require_action_value(
+                    action.spend().value().map(|v| v.inner()),
+                    "Ironwood spend",
+                )
+                .map_err(OrchardError::Custom)?;
+                if spend_value != 0 {
+                    ironwood_spends = ironwood_spends.checked_add(1).ok_or_else(|| {
+                        OrchardError::Custom(ZcashError::InvalidPczt(
+                            "Ironwood spend count overflow".to_string(),
+                        ))
+                    })?;
+                }
+
+                let output_value = require_action_value(
+                    action.output().value().map(|v| v.inner()),
+                    "Ironwood output",
+                )
+                .map_err(OrchardError::Custom)?;
+                if output_value == 0 {
+                    continue;
+                }
+
+                let recipient = action.output().recipient().ok_or_else(|| {
+                    OrchardError::Custom(ZcashError::InvalidPczt(
+                        "missing Ironwood output recipient".to_string(),
+                    ))
+                })?;
+                if !pczt::parse::is_wallet_orchard_address(ufvk, &recipient)
+                    .map_err(OrchardError::Custom)?
+                {
+                    return Err(OrchardError::Custom(ZcashError::InvalidPczt(
+                        "migration Ironwood output is not wallet-owned".to_string(),
+                    )));
+                }
+
+                ironwood_outputs = ironwood_outputs.checked_add(1).ok_or_else(|| {
+                    OrchardError::Custom(ZcashError::InvalidPczt(
+                        "Ironwood output count overflow".to_string(),
+                    ))
+                })?;
+                total_output = total_output.checked_add(output_value).ok_or_else(|| {
+                    OrchardError::Custom(ZcashError::InvalidPczt(
+                        "migration output overflow".to_string(),
+                    ))
+                })?;
+            }
+            Ok(())
+        })
+        .map_err(map_verifier_error)?;
+
+    if orchard_spends != 1 || orchard_outputs != 0 || ironwood_spends != 0 || ironwood_outputs != 1
+    {
+        return Err(ZcashError::InvalidPczt(format!(
+            "unsupported migration summary shape orchard_spends={orchard_spends} orchard_outputs={orchard_outputs} ironwood_spends={ironwood_spends} ironwood_outputs={ironwood_outputs}"
+        )));
+    }
+
+    let total_fee = total_input
+        .checked_sub(total_output)
+        .ok_or_else(|| ZcashError::InvalidPczt("migration output exceeds input".to_string()))?;
+
+    Ok(BatchMigrationSummary {
+        migrations: 1,
+        total_input,
+        total_output,
+        total_fee,
+        children: vec![BatchMigrationChildSummary {
+            input: total_input,
+            output: total_output,
+            fee: total_fee,
+        }],
+    })
+}
+
+/// Summarizes one checked Orchard-to-Ironwood migration child.
+///
+/// The caller must pass normalized bytes produced by the batch check. This
+/// rejects any detail the compact review cannot display, including funded
+/// Orchard outputs, funded Ironwood spends, and memos on the funded output.
+#[cfg(feature = "cypherpunk")]
+fn summarize_batch_migration_pczt_cypherpunk<P: consensus::Parameters>(
+    params: &P,
+    pczt: &[u8],
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+) -> Result<BatchMigrationSummary> {
+    let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
+        .map_err(|e| ZcashError::InvalidDataError(e.to_string()))?;
+    let pczt = pczt::parse_pczt(pczt)?;
+    // Reuse ordinary parsing so the summary has the same recovery and display checks.
+    let parsed = pczt::parse::parse_pczt_cypherpunk(params, seed_fingerprint, &ufvk, &pczt)?;
+    require_migration_display_shape(&parsed)?;
+    summarize_migration_actions(&ufvk, &pczt)
+}
+
+/// Parses the first PCZT normally and aggregates later migration children.
+///
+/// All inputs must be normalized bytes produced by the batch check. Returns an
+/// error when the compact representation cannot be built.
+#[cfg(feature = "cypherpunk")]
+pub fn parse_batch_with_migration_summary_cypherpunk<'a, P: consensus::Parameters>(
+    params: &P,
+    first_pczt: &[u8],
+    migration_pczts: impl IntoIterator<Item = &'a [u8]>,
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+) -> Result<Vec<ParsedPczt>> {
+    let first = parse_pczt_cypherpunk(params, first_pczt, ufvk_text, seed_fingerprint)?;
+    let mut summary = BatchMigrationSummary::default();
+    let mut has_migrations = false;
+    for child_pczt in migration_pczts {
+        has_migrations = true;
+        let child = summarize_batch_migration_pczt_cypherpunk(
+            params,
+            child_pczt,
+            ufvk_text,
+            seed_fingerprint,
+        )?;
+        summary.add_child(&child)?;
+    }
+    if !has_migrations {
+        return Err(ZcashError::InvalidPczt(
+            "migration review has no child transactions".to_string(),
+        ));
+    }
+
+    Ok(vec![first, summary.to_parsed_pczt()])
+}
+
+/// Rejects children whose ordinary review contains details the compact review
+/// would hide. The accepted shape has one Orchard spend row, one funded
+/// Ironwood output without a memo, and no transparent or Sapling components.
+#[cfg(feature = "cypherpunk")]
+fn require_migration_display_shape(parsed: &ParsedPczt) -> Result<()> {
+    let reject = |what: &str| {
+        Err(ZcashError::InvalidPczt(format!(
+            "migration summary cannot represent {what}; use the per-message review"
+        )))
+    };
+
+    // A migration child must be shielded-only Orchard→Ironwood. A transparent
+    // bundle or any Sapling component is invisible in the amounts-only summary
+    // (a transparent input would additionally understate the displayed fee), so
+    // fall back to the per-message review, which displays them. `get_transparent`
+    // is `Some` only for a non-empty bundle, so shielded-only children pass.
+    if parsed.get_transparent().is_some() {
+        return reject("transparent components");
+    }
+    if parsed.get_has_sapling() {
+        return reject("Sapling components");
+    }
+
+    let no_memo = |to: &ParsedTo| matches!(to.get_memo().as_deref(), None | Some(""));
+
+    let orchard = parsed.get_orchard();
+    let ironwood = parsed.get_ironwood();
+    let orchard_from = orchard
+        .as_ref()
+        .map(|rows| rows.get_from())
+        .unwrap_or_default();
+    let orchard_to = orchard
+        .as_ref()
+        .map(|rows| rows.get_to())
+        .unwrap_or_default();
+    let ironwood_from = ironwood
+        .as_ref()
+        .map(|rows| rows.get_from())
+        .unwrap_or_default();
+    let ironwood_to = ironwood
+        .as_ref()
+        .map(|rows| rows.get_to())
+        .unwrap_or_default();
+
+    if orchard_from.len() != 1 || !ironwood_from.is_empty() {
+        return reject("this spend shape");
+    }
+    // The migrated note is the only Orchard row; a displayable Orchard output
+    // (beyond builder dummies, which the row pass already drops) means the
+    // per-message review had something to show.
+    if !orchard_to.is_empty() {
+        return reject("Orchard outputs");
+    }
+    match ironwood_to.as_slice() {
+        [only] if only.get_amount() != 0 && no_memo(only) => Ok(()),
+        [only] if only.get_amount() != 0 => reject("an output memo"),
+        _ => reject("this output shape"),
     }
 }
 
@@ -1706,6 +2095,469 @@ mod tests {
                 Err(ZcashError::InvalidPczt(message)) if message.contains("undecryptable")
             ),
             "single-pass batch review must also reject the undecryptable output"
+        );
+    }
+
+    #[test]
+    fn test_batch_migration_summary_accepts_orchard_to_ironwood_child() {
+        let sample = pczt::test_support::sample_migration_pczt();
+
+        let summary = summarize_batch_migration_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+        )
+        .expect("migration child should summarize");
+
+        assert_eq!(
+            summary,
+            BatchMigrationSummary {
+                migrations: 1,
+                total_input: 1_010_000,
+                total_output: 990_000,
+                total_fee: 20_000,
+                children: vec![BatchMigrationChildSummary {
+                    input: 1_010_000,
+                    output: 990_000,
+                    fee: 20_000,
+                }],
+            }
+        );
+
+        let parsed = summary.to_parsed_pczt();
+        assert_eq!(parsed.get_total_transfer_value(), "0.0099 ZEC");
+        assert_eq!(parsed.get_fee_value(), "0.0002 ZEC");
+        assert_eq!(
+            parsed
+                .get_orchard()
+                .expect("summary should show Orchard inputs")
+                .get_from()
+                .len(),
+            1
+        );
+        assert_eq!(
+            parsed
+                .get_ironwood()
+                .expect("summary should show Ironwood outputs")
+                .get_to()
+                .len(),
+            1
+        );
+        assert_eq!(
+            parsed
+                .get_orchard()
+                .expect("summary should show Orchard inputs")
+                .get_from()[0]
+                .get_address()
+                .as_deref(),
+            Some("Migration #1 Orchard note from selected account")
+        );
+        assert_eq!(
+            parsed
+                .get_ironwood()
+                .expect("summary should show Ironwood outputs")
+                .get_to()[0]
+                .get_address(),
+            "Migration #1 wallet Ironwood output"
+        );
+        assert!(parsed
+            .get_ironwood()
+            .expect("summary should show Ironwood outputs")
+            .get_to()[0]
+            .get_is_change());
+    }
+
+    #[test]
+    fn test_batch_migration_summary_aggregates_multiple_children() {
+        let samples = [
+            pczt::test_support::sample_migration_pczt(),
+            pczt::test_support::sample_migration_pczt(),
+            pczt::test_support::sample_migration_pczt(),
+        ];
+        let parsed = parse_batch_with_migration_summary_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &samples[0].bytes,
+            samples[1..].iter().map(|sample| sample.bytes.as_slice()),
+            &samples[0].ufvk_text,
+            &samples[0].seed_fingerprint,
+        )
+        .expect("two migration children should aggregate");
+
+        assert_eq!(parsed.len(), 2);
+        let summary = &parsed[1];
+        assert_eq!(summary.get_total_transfer_value(), "0.0198 ZEC");
+        assert_eq!(summary.get_fee_value(), "0.0004 ZEC");
+        let inputs = summary.get_orchard().unwrap().get_from();
+        let outputs = summary.get_ironwood().unwrap().get_to();
+        assert_eq!(inputs.len(), 2);
+        assert!(inputs.iter().all(|input| input.get_amount() == 1_010_000));
+        assert_eq!(outputs.len(), 2);
+        assert!(outputs.iter().all(|output| output.get_amount() == 990_000));
+    }
+
+    #[test]
+    fn test_batch_migration_summary_requires_a_child() {
+        let first = pczt::test_support::sample_migration_pczt();
+        assert_invalid_pczt_message(
+            parse_batch_with_migration_summary_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &first.bytes,
+                core::iter::empty(),
+                &first.ufvk_text,
+                &first.seed_fingerprint,
+            ),
+            "migration review has no child transactions",
+        );
+    }
+
+    // A memo on the funded output forces fallback to the review that displays it.
+    #[test]
+    fn test_batch_migration_summary_rejects_memo_carrying_output() {
+        use zcash_vendor::zcash_protocol::memo::MemoBytes;
+
+        let sample = pczt::test_support::sample_migration_pczt_with_output_memo(
+            MemoBytes::from_bytes(b"covert note").expect("memo text fits"),
+        );
+
+        let summary_err = summarize_batch_migration_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+        )
+        .expect_err("summary must refuse a memo it cannot render");
+        assert!(
+            matches!(&summary_err, ZcashError::InvalidPczt(message) if message.contains("per-message review")),
+            "expected a display-shape rejection, got {summary_err:?}"
+        );
+
+        // Parity: the fallback per-message review shows the memo.
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("per-message review must accept the memo-carrying child");
+        let shown_memo = parsed
+            .get_ironwood()
+            .expect("migration must show Ironwood outputs")
+            .get_to()
+            .first()
+            .expect("migration must show the real output")
+            .get_memo();
+        assert_eq!(shown_memo.as_deref(), Some("covert note"));
+
+        let first = pczt::test_support::sample_migration_pczt();
+        assert!(parse_batch_with_migration_summary_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &first.bytes,
+            core::iter::once(sample.bytes.as_slice()),
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_batch_migration_summary_rejects_foreign_funded_output() {
+        let sample = pczt::test_support::sample_migration_pczt_to_account(1);
+
+        let summary_err = summarize_batch_migration_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+        )
+        .expect_err("summary must refuse a foreign funded output");
+        assert!(matches!(
+            &summary_err,
+            ZcashError::InvalidPczt(message) if message.contains("not wallet-owned")
+        ));
+
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("ordinary review should show a foreign output");
+        let outputs = parsed.get_ironwood().unwrap().get_to();
+        let output = &outputs[0];
+        assert_eq!(output.get_amount(), 990_000);
+        assert!(!output.get_is_change());
+    }
+
+    #[test]
+    fn test_batch_migration_summary_ignores_dummy_equivalent_zero_output() {
+        use zcash_vendor::zcash_protocol::memo::MemoBytes;
+
+        let sample = pczt::test_support::sample_migration_pczt_with_zero_output(
+            MemoBytes::from_bytes(b"hidden dummy memo").unwrap(),
+            false,
+        );
+        let summary = summarize_batch_migration_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+        )
+        .expect("dummy-equivalent zero output should not block the summary");
+        assert_eq!(summary.total_output, 990_000);
+        assert_eq!(summary.total_fee, 20_000);
+
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("ordinary review should accept the zero output");
+        let outputs = parsed.get_ironwood().unwrap().get_to();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].get_amount(), 990_000);
+        assert!(outputs[0].get_memo().is_none());
+    }
+
+    #[test]
+    fn test_batch_migration_summary_falls_back_for_displayable_zero_output() {
+        use zcash_vendor::zcash_protocol::memo::MemoBytes;
+
+        let sample = pczt::test_support::sample_migration_pczt_with_zero_output(
+            MemoBytes::from_bytes(b"visible zero memo").unwrap(),
+            true,
+        );
+        let summary_err = summarize_batch_migration_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+        )
+        .expect_err("displayable zero output should force ordinary review");
+        assert!(matches!(
+            &summary_err,
+            ZcashError::InvalidPczt(message) if message.contains("output shape")
+        ));
+
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("ordinary review should show the zero output");
+        let outputs = parsed.get_ironwood().unwrap().get_to();
+        assert_eq!(outputs.len(), 2);
+        let zero = outputs
+            .iter()
+            .find(|output| output.get_amount() == 0)
+            .expect("zero output should be displayed");
+        assert_eq!(zero.get_memo().as_deref(), Some("visible zero memo"));
+    }
+
+    // Transparent or Sapling components force fallback because the compact summary
+    // cannot display them or include transparent values in its fee.
+    #[test]
+    fn test_migration_display_shape_rejects_transparent_and_sapling() {
+        use crate::pczt::structs::ParsedTransparent;
+
+        // The shielded-only shape the summary can represent.
+        let orchard = ParsedOrchard::new(
+            vec![ParsedFrom::new(
+                None,
+                "0.0101 ZEC".to_string(),
+                1_010_000,
+                true,
+            )],
+            vec![],
+        );
+        let ironwood = ParsedOrchard::new(
+            vec![],
+            vec![ParsedTo::new(
+                "wallet Ironwood output".to_string(),
+                "0.0099 ZEC".to_string(),
+                990_000,
+                true,
+                false,
+                None,
+            )],
+        );
+        let build = |transparent: Option<ParsedTransparent>, has_sapling: bool| {
+            ParsedPczt::new(
+                transparent,
+                Some(orchard.clone()),
+                Some(ironwood.clone()),
+                "0.0099 ZEC".to_string(),
+                "0.0002 ZEC".to_string(),
+                has_sapling,
+            )
+        };
+
+        // Control: the pure shielded migration folds into the summary.
+        require_migration_display_shape(&build(None, false))
+            .expect("a shielded-only Orchard->Ironwood child must still summarize");
+
+        // A wallet-owned transparent input the amounts-only summary would hide
+        // (its value silently dropped from the fee) must force fallback.
+        let transparent = ParsedTransparent::new(
+            vec![ParsedFrom::new(
+                Some("t1wallet".to_string()),
+                "0.0005 ZEC".to_string(),
+                50_000,
+                true,
+            )],
+            vec![],
+        );
+        assert!(
+            matches!(
+                require_migration_display_shape(&build(Some(transparent), false)),
+                Err(ZcashError::InvalidPczt(message)) if message.contains("transparent components")
+            ),
+            "a transparent component must fall back to the per-message review",
+        );
+
+        // A Sapling component must likewise force fallback.
+        assert!(
+            matches!(
+                require_migration_display_shape(&build(None, true)),
+                Err(ZcashError::InvalidPczt(message)) if message.contains("Sapling components")
+            ),
+            "a Sapling component must fall back to the per-message review",
+        );
+    }
+
+    // An undecryptable funded output must fail both compact and ordinary review.
+    #[test]
+    fn test_batch_migration_summary_rejects_undecryptable_ironwood_output() {
+        use zcash_vendor::pczt::Pczt;
+
+        /// Flips a byte inside the first verbatim occurrence of `needle`.
+        fn corrupt_first_occurrence(haystack: &mut [u8], needle: &[u8]) -> bool {
+            if needle.is_empty() || needle.len() > haystack.len() {
+                return false;
+            }
+            for start in 0..=haystack.len() - needle.len() {
+                if &haystack[start..start + needle.len()] == needle {
+                    haystack[start + needle.len() / 2] ^= 0xff;
+                    return true;
+                }
+            }
+            false
+        }
+
+        let sample = pczt::test_support::sample_migration_pczt();
+
+        // Extract the funded Ironwood output's encrypted ciphertext bytes.
+        let enc_ciphertext = {
+            let pczt = Pczt::parse(&sample.bytes).expect("sample PCZT should parse");
+            pczt.ironwood()
+                .actions()
+                .iter()
+                .find(|action| matches!(action.output().value(), Some(value) if *value != 0))
+                .expect("migration child must contain a non-zero Ironwood output")
+                .output()
+                .enc_ciphertext()
+                .clone()
+                .into_encrypted()
+                .expect("the sample's Ironwood output carries a full enc_ciphertext")
+        };
+
+        // Corrupt only the ciphertext: cmx, cv_net, the value balance, and the
+        // plaintext recipient are all untouched, so every other check still
+        // passes and only decryption/recoverability fails.
+        let mut corrupted = sample.bytes.clone();
+        assert!(
+            corrupt_first_occurrence(&mut corrupted, &enc_ciphertext),
+            "sample must embed the Ironwood output enc_ciphertext verbatim"
+        );
+        assert!(
+            Pczt::parse(&corrupted).is_ok(),
+            "corruption must keep the PCZT structurally well-formed"
+        );
+
+        let summary_err = summarize_batch_migration_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &corrupted,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+        )
+        .expect_err("summary must reject a migration child with an undecryptable output");
+        assert!(
+            matches!(&summary_err, ZcashError::InvalidPczt(message) if message.contains("undecryptable")),
+            "expected an undecryptable-output rejection, got {summary_err:?}"
+        );
+
+        // The ordinary review must enforce the same output recovery rule.
+        assert!(
+            matches!(
+                check_and_parse_batch_pczt_cypherpunk(
+                    &pczt::test_support::Nu6_3Network,
+                    &corrupted,
+                    &sample.ufvk_text,
+                    &sample.seed_fingerprint,
+                    0,
+                ),
+                Err(ZcashError::InvalidPczt(message)) if message.contains("undecryptable")
+            ),
+            "ordinary per-message review must also reject the undecryptable output"
+        );
+    }
+
+    #[test]
+    fn test_batch_migration_summary_accepts_optional_spend_fvk() {
+        use zcash_vendor::pczt::{roles::redactor::Redactor, Pczt};
+
+        let sample = pczt::test_support::sample_migration_pczt();
+        let pczt = Pczt::parse(&sample.bytes).expect("sample PCZT should parse");
+        let redacted = Redactor::new(pczt)
+            .redact_orchard_with(|mut r| {
+                r.redact_actions(|mut ar| {
+                    ar.clear_spend_fvk();
+                });
+            })
+            .redact_ironwood_with(|mut r| {
+                r.redact_actions(|mut ar| {
+                    ar.clear_spend_fvk();
+                });
+            })
+            .finish()
+            .serialize()
+            .expect("redacted PCZT should serialize");
+
+        let summary = summarize_batch_migration_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &redacted,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+        )
+        .expect("redacted migration child should summarize");
+
+        assert_eq!(summary.migrations, 1);
+        assert_eq!(summary.total_input, 1_010_000);
+        assert_eq!(summary.total_output, 990_000);
+        assert_eq!(summary.total_fee, 20_000);
+
+        let signed = sign_checked_batch_pczt(
+            &pczt::test_support::Nu6_3Network,
+            &redacted,
+            &sample.seed,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("request redacted only by optional spend FVK should sign");
+        let parsed = Pczt::parse(&signed).expect("signed PCZT should parse");
+        assert!(
+            parsed
+                .orchard()
+                .actions()
+                .iter()
+                .any(|action| action.spend().spend_auth_sig().is_some()),
+            "redacted migration request must still produce an Orchard spend signature"
         );
     }
 

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -14,7 +14,7 @@ use alloc::{
 // The aggregate migration review is the only consumer of these; keep them off
 // the non-cypherpunk build so it stays warning-free.
 #[cfg(feature = "cypherpunk")]
-use alloc::{format, vec};
+use alloc::format;
 use pczt::structs::ParsedPczt;
 #[cfg(feature = "cypherpunk")]
 use pczt::structs::{ParsedFrom, ParsedOrchard, ParsedTo};
@@ -330,82 +330,56 @@ pub fn check_and_parse_batch_pczt_cypherpunk<P: consensus::Parameters>(
     }
 }
 
-/// Values for one checked migration child, in zatoshis.
+/// Values for one compact-eligible Orchard-to-Ironwood transfer, in zatoshis.
 #[cfg(feature = "cypherpunk")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct BatchMigrationChildSummary {
+struct BatchMigrationTransferSummary {
     input: u64,
     output: u64,
     fee: u64,
 }
 
-/// Totals and per-child rows for the compact migration review.
+/// Totals and per-transfer rows for the compact migration review.
 #[cfg(feature = "cypherpunk")]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct BatchMigrationSummary {
-    migrations: u32,
-    total_input: u64,
     total_output: u64,
     total_fee: u64,
-    children: Vec<BatchMigrationChildSummary>,
+    transfers: Vec<BatchMigrationTransferSummary>,
 }
 
 #[cfg(feature = "cypherpunk")]
 impl BatchMigrationSummary {
-    /// Adds a checked child summary using checked arithmetic.
-    fn add_child(&mut self, child: &BatchMigrationSummary) -> Result<()> {
-        self.migrations = self
-            .migrations
-            .checked_add(child.migrations)
-            .ok_or_else(|| ZcashError::InvalidPczt("migration count overflow".to_string()))?;
-        self.total_input = self
-            .total_input
-            .checked_add(child.total_input)
-            .ok_or_else(|| ZcashError::InvalidPczt("migration input overflow".to_string()))?;
+    /// Adds a compact-eligible transfer using checked arithmetic.
+    fn add_transfer(&mut self, transfer: BatchMigrationTransferSummary) -> Result<()> {
         self.total_output = self
             .total_output
-            .checked_add(child.total_output)
+            .checked_add(transfer.output)
             .ok_or_else(|| ZcashError::InvalidPczt("migration output overflow".to_string()))?;
         self.total_fee = self
             .total_fee
-            .checked_add(child.total_fee)
+            .checked_add(transfer.fee)
             .ok_or_else(|| ZcashError::InvalidPczt("migration fee overflow".to_string()))?;
-        if child.children.is_empty() {
-            self.children.push(BatchMigrationChildSummary {
-                input: child.total_input,
-                output: child.total_output,
-                fee: child.total_fee,
-            });
-        } else {
-            self.children.extend(child.children.iter().copied());
-        }
+        self.transfers.push(transfer);
         Ok(())
     }
 
     /// Builds the display model for the compact migration review.
     fn to_parsed_pczt(&self) -> ParsedPczt {
-        let children = if self.children.is_empty() {
-            vec![BatchMigrationChildSummary {
-                input: self.total_input,
-                output: self.total_output,
-                fee: self.total_fee,
-            }]
-        } else {
-            self.children.clone()
-        };
+        debug_assert!(!self.transfers.is_empty());
 
         let orchard = ParsedOrchard::new(
-            children
+            self.transfers
                 .iter()
                 .enumerate()
-                .map(|(index, child)| {
+                .map(|(index, transfer)| {
                     ParsedFrom::new(
                         Some(format!(
                             "Migration #{} Orchard note from selected account",
                             index + 1
                         )),
-                        pczt::parse::format_zec_value(child.input as f64),
-                        child.input,
+                        pczt::parse::format_zec_value(transfer.input as f64),
+                        transfer.input,
                         true,
                     )
                 })
@@ -414,14 +388,14 @@ impl BatchMigrationSummary {
         );
         let ironwood = ParsedOrchard::new(
             Vec::new(),
-            children
+            self.transfers
                 .iter()
                 .enumerate()
-                .map(|(index, child)| {
+                .map(|(index, transfer)| {
                     ParsedTo::new(
                         format!("Migration #{} wallet Ironwood output", index + 1),
-                        pczt::parse::format_zec_value(child.output as f64),
-                        child.output,
+                        pczt::parse::format_zec_value(transfer.output as f64),
+                        transfer.output,
                         true,
                         false,
                         None,
@@ -441,243 +415,25 @@ impl BatchMigrationSummary {
     }
 }
 
-/// Requires an action value to be present, returning it (zero is a valid
-/// value; callers classify zero themselves).
+/// One parsed batch item and its optional compact migration representation.
 #[cfg(feature = "cypherpunk")]
-fn require_action_value(value: Option<u64>, label: &str) -> Result<u64> {
-    value.ok_or_else(|| ZcashError::InvalidPczt(format!("missing {label} value")))
+struct ParsedBatchItem {
+    parsed: ParsedPczt,
+    migration: Option<BatchMigrationTransferSummary>,
 }
 
-/// Validates the funded migration shape and computes its totals.
-#[cfg(feature = "cypherpunk")]
-fn summarize_migration_actions(
-    ufvk: &UnifiedFullViewingKey,
-    pczt: &Pczt,
-) -> Result<BatchMigrationSummary> {
-    use zcash_vendor::pczt::roles::verifier::{OrchardError, Verifier};
-
-    // Reject transparent components at the wire level so their values cannot be
-    // omitted from the fee.
-    if !pczt.transparent().inputs().is_empty() {
-        return Err(ZcashError::InvalidPczt(
-            "migration summary does not support transparent inputs".to_string(),
-        ));
-    }
-    if !pczt.transparent().outputs().is_empty() {
-        return Err(ZcashError::InvalidPczt(
-            "migration summary does not support transparent outputs".to_string(),
-        ));
-    }
-
-    let mut orchard_spends = 0u32;
-    let mut orchard_outputs = 0u32;
-    let mut ironwood_spends = 0u32;
-    let mut ironwood_outputs = 0u32;
-    let mut total_input = 0u64;
-    let mut total_output = 0u64;
-
-    let map_verifier_error = |error: OrchardError<ZcashError>| match error {
-        OrchardError::Custom(error) => error,
-        error => ZcashError::InvalidDataError(format!("{error:?}")),
-    };
-
-    // Values are read through the Verifier's parsed view; the wire structs of
-    // the pinned pczt revision expose no spend-value getter.
-    let verifier = Verifier::new(pczt.clone())
-        .with_orchard(|bundle| {
-            for action in bundle.actions().iter() {
-                let spend_value = require_action_value(
-                    action.spend().value().map(|v| v.inner()),
-                    "Orchard spend",
-                )
-                .map_err(OrchardError::Custom)?;
-                if spend_value != 0 {
-                    orchard_spends = orchard_spends.checked_add(1).ok_or_else(|| {
-                        OrchardError::Custom(ZcashError::InvalidPczt(
-                            "Orchard spend count overflow".to_string(),
-                        ))
-                    })?;
-                    total_input = total_input.checked_add(spend_value).ok_or_else(|| {
-                        OrchardError::Custom(ZcashError::InvalidPczt(
-                            "migration input overflow".to_string(),
-                        ))
-                    })?;
-                }
-
-                let output_value = require_action_value(
-                    action.output().value().map(|v| v.inner()),
-                    "Orchard output",
-                )
-                .map_err(OrchardError::Custom)?;
-                if output_value != 0 {
-                    orchard_outputs = orchard_outputs.checked_add(1).ok_or_else(|| {
-                        OrchardError::Custom(ZcashError::InvalidPczt(
-                            "Orchard output count overflow".to_string(),
-                        ))
-                    })?;
-                }
-            }
-            Ok(())
-        })
-        .map_err(map_verifier_error)?;
-
-    verifier
-        .with_ironwood(|bundle| {
-            for action in bundle.actions().iter() {
-                let spend_value = require_action_value(
-                    action.spend().value().map(|v| v.inner()),
-                    "Ironwood spend",
-                )
-                .map_err(OrchardError::Custom)?;
-                if spend_value != 0 {
-                    ironwood_spends = ironwood_spends.checked_add(1).ok_or_else(|| {
-                        OrchardError::Custom(ZcashError::InvalidPczt(
-                            "Ironwood spend count overflow".to_string(),
-                        ))
-                    })?;
-                }
-
-                let output_value = require_action_value(
-                    action.output().value().map(|v| v.inner()),
-                    "Ironwood output",
-                )
-                .map_err(OrchardError::Custom)?;
-                if output_value == 0 {
-                    continue;
-                }
-
-                let recipient = action.output().recipient().ok_or_else(|| {
-                    OrchardError::Custom(ZcashError::InvalidPczt(
-                        "missing Ironwood output recipient".to_string(),
-                    ))
-                })?;
-                if !pczt::parse::is_wallet_orchard_address(ufvk, &recipient)
-                    .map_err(OrchardError::Custom)?
-                {
-                    return Err(OrchardError::Custom(ZcashError::InvalidPczt(
-                        "migration Ironwood output is not wallet-owned".to_string(),
-                    )));
-                }
-
-                ironwood_outputs = ironwood_outputs.checked_add(1).ok_or_else(|| {
-                    OrchardError::Custom(ZcashError::InvalidPczt(
-                        "Ironwood output count overflow".to_string(),
-                    ))
-                })?;
-                total_output = total_output.checked_add(output_value).ok_or_else(|| {
-                    OrchardError::Custom(ZcashError::InvalidPczt(
-                        "migration output overflow".to_string(),
-                    ))
-                })?;
-            }
-            Ok(())
-        })
-        .map_err(map_verifier_error)?;
-
-    if orchard_spends != 1 || orchard_outputs != 0 || ironwood_spends != 0 || ironwood_outputs != 1
-    {
-        return Err(ZcashError::InvalidPczt(format!(
-            "unsupported migration summary shape orchard_spends={orchard_spends} orchard_outputs={orchard_outputs} ironwood_spends={ironwood_spends} ironwood_outputs={ironwood_outputs}"
-        )));
-    }
-
-    let total_fee = total_input
-        .checked_sub(total_output)
-        .ok_or_else(|| ZcashError::InvalidPczt("migration output exceeds input".to_string()))?;
-
-    Ok(BatchMigrationSummary {
-        migrations: 1,
-        total_input,
-        total_output,
-        total_fee,
-        children: vec![BatchMigrationChildSummary {
-            input: total_input,
-            output: total_output,
-            fee: total_fee,
-        }],
-    })
-}
-
-/// Summarizes one checked Orchard-to-Ironwood migration child.
+/// Returns the compact representation only when the ordinary review contains
+/// exactly the details represented by a migration row.
 ///
-/// The caller must pass normalized bytes produced by the batch check. This
-/// rejects any detail the compact review cannot display, including funded
-/// Orchard outputs, funded Ironwood spends, and memos on the funded output.
+/// This classifier is valid only after the batch check has bound every funded
+/// spend to the selected account. `is_mine` is display metadata and is used
+/// here as an additional shape check, not as authorization.
 #[cfg(feature = "cypherpunk")]
-fn summarize_batch_migration_pczt_cypherpunk<P: consensus::Parameters>(
-    params: &P,
-    pczt: &[u8],
-    ufvk_text: &str,
-    seed_fingerprint: &[u8; 32],
-) -> Result<BatchMigrationSummary> {
-    let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
-        .map_err(|e| ZcashError::InvalidDataError(e.to_string()))?;
-    let pczt = pczt::parse_pczt(pczt)?;
-    // Reuse ordinary parsing so the summary has the same recovery and display checks.
-    let parsed = pczt::parse::parse_pczt_cypherpunk(params, seed_fingerprint, &ufvk, &pczt)?;
-    require_migration_display_shape(&parsed)?;
-    summarize_migration_actions(&ufvk, &pczt)
-}
-
-/// Parses the first PCZT normally and aggregates later migration children.
-///
-/// All inputs must be normalized bytes produced by the batch check. Returns an
-/// error when the compact representation cannot be built.
-#[cfg(feature = "cypherpunk")]
-pub fn parse_batch_with_migration_summary_cypherpunk<'a, P: consensus::Parameters>(
-    params: &P,
-    first_pczt: &[u8],
-    migration_pczts: impl IntoIterator<Item = &'a [u8]>,
-    ufvk_text: &str,
-    seed_fingerprint: &[u8; 32],
-) -> Result<Vec<ParsedPczt>> {
-    let first = parse_pczt_cypherpunk(params, first_pczt, ufvk_text, seed_fingerprint)?;
-    let mut summary = BatchMigrationSummary::default();
-    let mut has_migrations = false;
-    for child_pczt in migration_pczts {
-        has_migrations = true;
-        let child = summarize_batch_migration_pczt_cypherpunk(
-            params,
-            child_pczt,
-            ufvk_text,
-            seed_fingerprint,
-        )?;
-        summary.add_child(&child)?;
+fn migration_transfer_summary(parsed: &ParsedPczt) -> Option<BatchMigrationTransferSummary> {
+    if parsed.get_transparent().is_some() || parsed.get_has_sapling() {
+        return None;
     }
-    if !has_migrations {
-        return Err(ZcashError::InvalidPczt(
-            "migration review has no child transactions".to_string(),
-        ));
-    }
-
-    Ok(vec![first, summary.to_parsed_pczt()])
-}
-
-/// Rejects children whose ordinary review contains details the compact review
-/// would hide. The accepted shape has one Orchard spend row, one funded
-/// Ironwood output without a memo, and no transparent or Sapling components.
-#[cfg(feature = "cypherpunk")]
-fn require_migration_display_shape(parsed: &ParsedPczt) -> Result<()> {
-    let reject = |what: &str| {
-        Err(ZcashError::InvalidPczt(format!(
-            "migration summary cannot represent {what}; use the per-message review"
-        )))
-    };
-
-    // A migration child must be shielded-only Orchard→Ironwood. A transparent
-    // bundle or any Sapling component is invisible in the amounts-only summary
-    // (a transparent input would additionally understate the displayed fee), so
-    // fall back to the per-message review, which displays them. `get_transparent`
-    // is `Some` only for a non-empty bundle, so shielded-only children pass.
-    if parsed.get_transparent().is_some() {
-        return reject("transparent components");
-    }
-    if parsed.get_has_sapling() {
-        return reject("Sapling components");
-    }
-
     let no_memo = |to: &ParsedTo| matches!(to.get_memo().as_deref(), None | Some(""));
-
     let orchard = parsed.get_orchard();
     let ironwood = parsed.get_ironwood();
     let orchard_from = orchard
@@ -697,20 +453,82 @@ fn require_migration_display_shape(parsed: &ParsedPczt) -> Result<()> {
         .map(|rows| rows.get_to())
         .unwrap_or_default();
 
-    if orchard_from.len() != 1 || !ironwood_from.is_empty() {
-        return reject("this spend shape");
+    match (orchard_from.as_slice(), ironwood_to.as_slice()) {
+        ([from], [to])
+            if from.get_is_mine()
+                && orchard_to.is_empty()
+                && ironwood_from.is_empty()
+                && to.get_amount() != 0
+                && to.get_is_change()
+                && no_memo(to) =>
+        {
+            Some(BatchMigrationTransferSummary {
+                input: from.get_amount(),
+                output: to.get_amount(),
+                fee: from.get_amount().checked_sub(to.get_amount())?,
+            })
+        }
+        _ => None,
     }
-    // The migrated note is the only Orchard row; a displayable Orchard output
-    // (beyond builder dummies, which the row pass already drops) means the
-    // per-message review had something to show.
-    if !orchard_to.is_empty() {
-        return reject("Orchard outputs");
+}
+
+/// Replaces compact-eligible transfers with one summary when the batch contains
+/// at most one other transaction. Ambiguous batches retain full review pages.
+#[cfg(feature = "cypherpunk")]
+fn compact_batch_migration_review(items: Vec<ParsedBatchItem>) -> Vec<ParsedPczt> {
+    let migration_count = items.iter().filter(|item| item.migration.is_some()).count();
+    if items.len() <= 1 || migration_count == 0 || items.len() - migration_count > 1 {
+        return items.into_iter().map(|item| item.parsed).collect();
     }
-    match ironwood_to.as_slice() {
-        [only] if only.get_amount() != 0 && no_memo(only) => Ok(()),
-        [only] if only.get_amount() != 0 => reject("an output memo"),
-        _ => reject("this output shape"),
+
+    let mut summary = BatchMigrationSummary::default();
+    for transfer in items.iter().filter_map(|item| item.migration) {
+        // Overflow is not expected for a valid transaction batch. Full review
+        // remains safe and complete if the compact totals cannot be represented.
+        if summary.add_transfer(transfer).is_err() {
+            return items.into_iter().map(|item| item.parsed).collect();
+        }
     }
+
+    let mut compact = Vec::with_capacity(items.len() - migration_count + 1);
+    for item in items {
+        if item.migration.is_none() {
+            compact.push(item.parsed);
+        }
+    }
+    compact.push(summary.to_parsed_pczt());
+    compact
+}
+
+/// Parses checked batch PCZTs and compacts eligible Orchard-to-Ironwood
+/// self-transfers without relying on message position.
+///
+/// Every input must be normalized bytes produced by the batch check. A batch
+/// with more than one ordinary transaction uses full per-message review.
+#[cfg(feature = "cypherpunk")]
+pub fn parse_batch_with_migration_summary_cypherpunk<'a, P: consensus::Parameters>(
+    params: &P,
+    pczts: impl IntoIterator<Item = &'a [u8]>,
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+) -> Result<Vec<ParsedPczt>> {
+    let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
+        .map_err(|e| ZcashError::InvalidDataError(e.to_string()))?;
+    let mut items = Vec::new();
+    for pczt_bytes in pczts {
+        let pczt = pczt::parse_pczt(pczt_bytes)?;
+        // Parse once. The same complete display model determines whether a
+        // transaction can be represented by a compact migration row.
+        let parsed = pczt::parse::parse_pczt_cypherpunk(params, seed_fingerprint, &ufvk, &pczt)?;
+        let migration = migration_transfer_summary(&parsed);
+        items.push(ParsedBatchItem { parsed, migration });
+    }
+    if items.is_empty() {
+        return Err(ZcashError::InvalidPczt(
+            "batch review has no transactions".to_string(),
+        ));
+    }
+    Ok(compact_batch_migration_review(items))
 }
 
 #[cfg(test)]
@@ -1168,7 +986,7 @@ fn sign_checked_pczt_with_policy<P: consensus::Parameters>(
 #[cfg(feature = "cypherpunk")]
 #[cfg(test)]
 mod tests {
-    use alloc::{collections::BTreeMap, string::String, vec::Vec};
+    use alloc::{collections::BTreeMap, string::String, vec, vec::Vec};
 
     use consensus::MainNetwork;
     use keystore::algorithms::zcash::{calculate_seed_fingerprint, derive_ufvk};
@@ -2048,7 +1866,7 @@ mod tests {
                 .actions()
                 .iter()
                 .find(|action| matches!(action.output().value(), Some(value) if *value != 0))
-                .expect("migration child must contain a non-zero Ironwood output")
+                .expect("migration transfer must contain a non-zero Ironwood output")
                 .output()
                 .enc_ciphertext()
                 .clone()
@@ -2099,29 +1917,36 @@ mod tests {
     }
 
     #[test]
-    fn test_batch_migration_summary_accepts_orchard_to_ironwood_child() {
+    fn test_batch_migration_summary_accepts_orchard_to_ironwood_transfer() {
         let sample = pczt::test_support::sample_migration_pczt();
-
-        let summary = summarize_batch_migration_pczt_cypherpunk(
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
             &sample.ufvk_text,
             &sample.seed_fingerprint,
+            0,
         )
-        .expect("migration child should summarize");
+        .expect("migration transfer should pass batch review");
+        let transfer =
+            migration_transfer_summary(&parsed).expect("migration transfer should summarize");
+        assert_eq!(
+            transfer,
+            BatchMigrationTransferSummary {
+                input: 1_010_000,
+                output: 990_000,
+                fee: 20_000,
+            }
+        );
+
+        let mut summary = BatchMigrationSummary::default();
+        summary.add_transfer(transfer).unwrap();
 
         assert_eq!(
             summary,
             BatchMigrationSummary {
-                migrations: 1,
-                total_input: 1_010_000,
                 total_output: 990_000,
                 total_fee: 20_000,
-                children: vec![BatchMigrationChildSummary {
-                    input: 1_010_000,
-                    output: 990_000,
-                    fee: 20_000,
-                }],
+                transfers: vec![transfer],
             }
         );
 
@@ -2169,46 +1994,174 @@ mod tests {
     }
 
     #[test]
-    fn test_batch_migration_summary_aggregates_multiple_children() {
+    fn test_batch_migration_summary_aggregates_all_migration_only_batch() {
         let samples = [
             pczt::test_support::sample_migration_pczt(),
             pczt::test_support::sample_migration_pczt(),
             pczt::test_support::sample_migration_pczt(),
         ];
+        let checked = samples
+            .iter()
+            .map(|sample| {
+                check_batch_pczt_cypherpunk(
+                    &pczt::test_support::Nu6_3Network,
+                    &sample.bytes,
+                    &sample.ufvk_text,
+                    &sample.seed_fingerprint,
+                    0,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
         let parsed = parse_batch_with_migration_summary_cypherpunk(
             &pczt::test_support::Nu6_3Network,
-            &samples[0].bytes,
-            samples[1..].iter().map(|sample| sample.bytes.as_slice()),
+            checked.iter().map(Vec::as_slice),
             &samples[0].ufvk_text,
             &samples[0].seed_fingerprint,
         )
-        .expect("two migration children should aggregate");
+        .expect("all migration transfers should aggregate");
 
-        assert_eq!(parsed.len(), 2);
-        let summary = &parsed[1];
-        assert_eq!(summary.get_total_transfer_value(), "0.0198 ZEC");
-        assert_eq!(summary.get_fee_value(), "0.0004 ZEC");
+        assert_eq!(parsed.len(), 1);
+        let summary = &parsed[0];
+        assert_eq!(summary.get_total_transfer_value(), "0.0297 ZEC");
+        assert_eq!(summary.get_fee_value(), "0.0006 ZEC");
         let inputs = summary.get_orchard().unwrap().get_from();
         let outputs = summary.get_ironwood().unwrap().get_to();
-        assert_eq!(inputs.len(), 2);
+        assert_eq!(inputs.len(), 3);
         assert!(inputs.iter().all(|input| input.get_amount() == 1_010_000));
-        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs.len(), 3);
         assert!(outputs.iter().all(|output| output.get_amount() == 990_000));
     }
 
     #[test]
-    fn test_batch_migration_summary_requires_a_child() {
-        let first = pczt::test_support::sample_migration_pczt();
+    fn test_batch_migration_summary_is_order_independent() {
+        let split = pczt::test_support::sample_orchard_change_pczt();
+        let migration_1 = pczt::test_support::sample_migration_pczt();
+        let migration_2 = pczt::test_support::sample_migration_pczt();
+        let ufvk_text = split.ufvk_text.clone();
+        let seed_fingerprint = split.seed_fingerprint;
+        let check = |bytes: &[u8]| {
+            check_batch_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                bytes,
+                &ufvk_text,
+                &seed_fingerprint,
+                0,
+            )
+            .unwrap()
+        };
+        let split = check(&split.bytes);
+        let migration_1 = check(&migration_1.bytes);
+        let migration_2 = check(&migration_2.bytes);
+        let orders = [
+            [
+                split.as_slice(),
+                migration_1.as_slice(),
+                migration_2.as_slice(),
+            ],
+            [
+                migration_1.as_slice(),
+                split.as_slice(),
+                migration_2.as_slice(),
+            ],
+            [
+                migration_1.as_slice(),
+                migration_2.as_slice(),
+                split.as_slice(),
+            ],
+        ];
+
+        for order in orders {
+            let parsed = parse_batch_with_migration_summary_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                order,
+                &ufvk_text,
+                &seed_fingerprint,
+            )
+            .expect("message order must not affect migration classification");
+
+            assert_eq!(parsed.len(), 2);
+            let summary = &parsed[1];
+            assert_eq!(summary.get_ironwood().unwrap().get_to().len(), 2);
+            assert_eq!(summary.get_total_transfer_value(), "0.0198 ZEC");
+            assert_eq!(summary.get_fee_value(), "0.0004 ZEC");
+        }
+    }
+
+    #[test]
+    fn test_batch_migration_summary_keeps_single_message_uncompacted() {
+        let sample = pczt::test_support::sample_migration_pczt();
+        let checked = check_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+        let parsed = parse_batch_with_migration_summary_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            core::iter::once(checked.as_slice()),
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(
+            parsed[0].get_ironwood().unwrap().get_to()[0].get_address(),
+            "<internal-address>"
+        );
+    }
+
+    #[test]
+    fn test_batch_migration_summary_rejects_empty_batch() {
+        let sample = pczt::test_support::sample_migration_pczt();
         assert_invalid_pczt_message(
             parse_batch_with_migration_summary_cypherpunk(
                 &pczt::test_support::Nu6_3Network,
-                &first.bytes,
                 core::iter::empty(),
-                &first.ufvk_text,
-                &first.seed_fingerprint,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
             ),
-            "migration review has no child transactions",
+            "batch review has no transactions",
         );
+    }
+
+    #[test]
+    fn test_batch_migration_summary_keeps_ambiguous_batch_full() {
+        let ordinary_1 = pczt::test_support::sample_orchard_change_pczt();
+        let ordinary_2 = pczt::test_support::sample_orchard_change_pczt();
+        let migration = pczt::test_support::sample_migration_pczt();
+        let checked = [&ordinary_1, &migration, &ordinary_2]
+            .into_iter()
+            .map(|sample| {
+                check_batch_pczt_cypherpunk(
+                    &pczt::test_support::Nu6_3Network,
+                    &sample.bytes,
+                    &sample.ufvk_text,
+                    &sample.seed_fingerprint,
+                    0,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let parsed = parse_batch_with_migration_summary_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            checked.iter().map(Vec::as_slice),
+            &migration.ufvk_text,
+            &migration.seed_fingerprint,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.len(), 3);
+        assert!(parsed.iter().all(|item| {
+            item.get_orchard()
+                .unwrap()
+                .get_from()
+                .iter()
+                .all(|from| from.get_address().is_none())
+        }));
     }
 
     // A memo on the funded output forces fallback to the review that displays it.
@@ -2220,19 +2173,6 @@ mod tests {
             MemoBytes::from_bytes(b"covert note").expect("memo text fits"),
         );
 
-        let summary_err = summarize_batch_migration_pczt_cypherpunk(
-            &pczt::test_support::Nu6_3Network,
-            &sample.bytes,
-            &sample.ufvk_text,
-            &sample.seed_fingerprint,
-        )
-        .expect_err("summary must refuse a memo it cannot render");
-        assert!(
-            matches!(&summary_err, ZcashError::InvalidPczt(message) if message.contains("per-message review")),
-            "expected a display-shape rejection, got {summary_err:?}"
-        );
-
-        // Parity: the fallback per-message review shows the memo.
         let parsed = check_and_parse_batch_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
@@ -2240,7 +2180,7 @@ mod tests {
             &sample.seed_fingerprint,
             0,
         )
-        .expect("per-message review must accept the memo-carrying child");
+        .expect("per-message review must accept the memo-carrying transfer");
         let shown_memo = parsed
             .get_ironwood()
             .expect("migration must show Ironwood outputs")
@@ -2249,33 +2189,44 @@ mod tests {
             .expect("migration must show the real output")
             .get_memo();
         assert_eq!(shown_memo.as_deref(), Some("covert note"));
+        assert!(migration_transfer_summary(&parsed).is_none());
 
-        let first = pczt::test_support::sample_migration_pczt();
-        assert!(parse_batch_with_migration_summary_cypherpunk(
+        let migration = pczt::test_support::sample_migration_pczt();
+        let checked = [&migration, &sample]
+            .into_iter()
+            .map(|item| {
+                check_batch_pczt_cypherpunk(
+                    &pczt::test_support::Nu6_3Network,
+                    &item.bytes,
+                    &item.ufvk_text,
+                    &item.seed_fingerprint,
+                    0,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let batch = parse_batch_with_migration_summary_cypherpunk(
             &pczt::test_support::Nu6_3Network,
-            &first.bytes,
-            core::iter::once(sample.bytes.as_slice()),
+            checked.iter().map(Vec::as_slice),
             &sample.ufvk_text,
             &sample.seed_fingerprint,
         )
-        .is_err());
+        .unwrap();
+        assert_eq!(batch.len(), 2);
+        assert!(batch.iter().any(|item| {
+            item.get_ironwood()
+                .map(|pool| {
+                    pool.get_to()
+                        .iter()
+                        .any(|to| to.get_memo().as_deref() == Some("covert note"))
+                })
+                .unwrap_or(false)
+        }));
     }
 
     #[test]
     fn test_batch_migration_summary_rejects_foreign_funded_output() {
         let sample = pczt::test_support::sample_migration_pczt_to_account(1);
-
-        let summary_err = summarize_batch_migration_pczt_cypherpunk(
-            &pczt::test_support::Nu6_3Network,
-            &sample.bytes,
-            &sample.ufvk_text,
-            &sample.seed_fingerprint,
-        )
-        .expect_err("summary must refuse a foreign funded output");
-        assert!(matches!(
-            &summary_err,
-            ZcashError::InvalidPczt(message) if message.contains("not wallet-owned")
-        ));
 
         let parsed = check_and_parse_batch_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
@@ -2289,6 +2240,7 @@ mod tests {
         let output = &outputs[0];
         assert_eq!(output.get_amount(), 990_000);
         assert!(!output.get_is_change());
+        assert!(migration_transfer_summary(&parsed).is_none());
     }
 
     #[test]
@@ -2299,16 +2251,6 @@ mod tests {
             MemoBytes::from_bytes(b"hidden dummy memo").unwrap(),
             false,
         );
-        let summary = summarize_batch_migration_pczt_cypherpunk(
-            &pczt::test_support::Nu6_3Network,
-            &sample.bytes,
-            &sample.ufvk_text,
-            &sample.seed_fingerprint,
-        )
-        .expect("dummy-equivalent zero output should not block the summary");
-        assert_eq!(summary.total_output, 990_000);
-        assert_eq!(summary.total_fee, 20_000);
-
         let parsed = check_and_parse_batch_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
@@ -2317,6 +2259,10 @@ mod tests {
             0,
         )
         .expect("ordinary review should accept the zero output");
+        let transfer = migration_transfer_summary(&parsed)
+            .expect("dummy-equivalent zero output should not block the summary");
+        assert_eq!(transfer.output, 990_000);
+        assert_eq!(transfer.fee, 20_000);
         let outputs = parsed.get_ironwood().unwrap().get_to();
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0].get_amount(), 990_000);
@@ -2331,18 +2277,6 @@ mod tests {
             MemoBytes::from_bytes(b"visible zero memo").unwrap(),
             true,
         );
-        let summary_err = summarize_batch_migration_pczt_cypherpunk(
-            &pczt::test_support::Nu6_3Network,
-            &sample.bytes,
-            &sample.ufvk_text,
-            &sample.seed_fingerprint,
-        )
-        .expect_err("displayable zero output should force ordinary review");
-        assert!(matches!(
-            &summary_err,
-            ZcashError::InvalidPczt(message) if message.contains("output shape")
-        ));
-
         let parsed = check_and_parse_batch_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
@@ -2358,12 +2292,13 @@ mod tests {
             .find(|output| output.get_amount() == 0)
             .expect("zero output should be displayed");
         assert_eq!(zero.get_memo().as_deref(), Some("visible zero memo"));
+        assert!(migration_transfer_summary(&parsed).is_none());
     }
 
     // Transparent or Sapling components force fallback because the compact summary
     // cannot display them or include transparent values in its fee.
     #[test]
-    fn test_migration_display_shape_rejects_transparent_and_sapling() {
+    fn test_migration_classifier_rejects_transparent_and_sapling() {
         use crate::pczt::structs::ParsedTransparent;
 
         // The shielded-only shape the summary can represent.
@@ -2399,8 +2334,8 @@ mod tests {
         };
 
         // Control: the pure shielded migration folds into the summary.
-        require_migration_display_shape(&build(None, false))
-            .expect("a shielded-only Orchard->Ironwood child must still summarize");
+        migration_transfer_summary(&build(None, false))
+            .expect("a shielded-only Orchard-to-Ironwood transfer must still summarize");
 
         // A wallet-owned transparent input the amounts-only summary would hide
         // (its value silently dropped from the fee) must force fallback.
@@ -2413,22 +2348,10 @@ mod tests {
             )],
             vec![],
         );
-        assert!(
-            matches!(
-                require_migration_display_shape(&build(Some(transparent), false)),
-                Err(ZcashError::InvalidPczt(message)) if message.contains("transparent components")
-            ),
-            "a transparent component must fall back to the per-message review",
-        );
+        assert!(migration_transfer_summary(&build(Some(transparent), false)).is_none());
 
         // A Sapling component must likewise force fallback.
-        assert!(
-            matches!(
-                require_migration_display_shape(&build(None, true)),
-                Err(ZcashError::InvalidPczt(message)) if message.contains("Sapling components")
-            ),
-            "a Sapling component must fall back to the per-message review",
-        );
+        assert!(migration_transfer_summary(&build(None, true)).is_none());
     }
 
     // An undecryptable funded output must fail both compact and ordinary review.
@@ -2459,7 +2382,7 @@ mod tests {
                 .actions()
                 .iter()
                 .find(|action| matches!(action.output().value(), Some(value) if *value != 0))
-                .expect("migration child must contain a non-zero Ironwood output")
+                .expect("migration transfer must contain a non-zero Ironwood output")
                 .output()
                 .enc_ciphertext()
                 .clone()
@@ -2480,13 +2403,13 @@ mod tests {
             "corruption must keep the PCZT structurally well-formed"
         );
 
-        let summary_err = summarize_batch_migration_pczt_cypherpunk(
+        let summary_err = parse_batch_with_migration_summary_cypherpunk(
             &pczt::test_support::Nu6_3Network,
-            &corrupted,
+            core::iter::once(corrupted.as_slice()),
             &sample.ufvk_text,
             &sample.seed_fingerprint,
         )
-        .expect_err("summary must reject a migration child with an undecryptable output");
+        .expect_err("summary must reject a migration transfer with an undecryptable output");
         assert!(
             matches!(&summary_err, ZcashError::InvalidPczt(message) if message.contains("undecryptable")),
             "expected an undecryptable-output rejection, got {summary_err:?}"
@@ -2529,18 +2452,20 @@ mod tests {
             .serialize()
             .expect("redacted PCZT should serialize");
 
-        let summary = summarize_batch_migration_pczt_cypherpunk(
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &redacted,
             &sample.ufvk_text,
             &sample.seed_fingerprint,
+            0,
         )
-        .expect("redacted migration child should summarize");
+        .expect("redacted migration transfer should pass batch review");
+        let transfer = migration_transfer_summary(&parsed)
+            .expect("redacted migration transfer should summarize");
 
-        assert_eq!(summary.migrations, 1);
-        assert_eq!(summary.total_input, 1_010_000);
-        assert_eq!(summary.total_output, 990_000);
-        assert_eq!(summary.total_fee, 20_000);
+        assert_eq!(transfer.input, 1_010_000);
+        assert_eq!(transfer.output, 990_000);
+        assert_eq!(transfer.fee, 20_000);
 
         let signed = sign_checked_batch_pczt(
             &pczt::test_support::Nu6_3Network,

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -259,6 +259,71 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
     pczt::parse::parse_pczt_cypherpunk(params, seed_fingerprint, &ufvk, &pczt)
 }
 
+/// Validates a batch PCZT for the selected account and returns its display data.
+#[cfg(feature = "cypherpunk")]
+pub fn check_and_parse_batch_pczt_cypherpunk<P: consensus::Parameters>(
+    params: &P,
+    pczt_bytes: &[u8],
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+    account_index: u32,
+) -> Result<ParsedPczt> {
+    let mut pczt = pczt::parse_pczt(pczt_bytes)?;
+    // Resolve compact field representations up front so the single-pass check
+    // sees complete actions, matching `preflight_batch_pczt_cypherpunk`.
+    pczt.resolve_fields().map_err(|e| {
+        ZcashError::InvalidPczt(alloc::format!("resolve compact PCZT fields: {e:?}"))
+    })?;
+    let account_index = zip32::AccountId::try_from(account_index)
+        .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
+    let ufvk = UnifiedFullViewingKey::decode(params, ufvk_text)
+        .map_err(|e| ZcashError::InvalidDataError(e.to_string()))?;
+    let xpub = ufvk.transparent().ok_or(ZcashError::InvalidDataError(
+        "transparent xpub is not present".to_string(),
+    ))?;
+
+    // Validate shielded actions while collecting their display rows.
+    let (checked_shielded, pczt) = pczt::check::check_and_parse_pczt_shielded(
+        params,
+        seed_fingerprint,
+        account_index,
+        &ufvk,
+        pczt,
+    )?;
+
+    // Check the remaining transparent bundle against the same account.
+    pczt::check::check_pczt_transparent(
+        params,
+        seed_fingerprint,
+        account_index,
+        xpub,
+        &pczt,
+        false,
+    )?;
+
+    // Reuse the PCZT returned by signability validation for display assembly.
+    let (signable_actions, pczt) = signable_shielded_actions(
+        params,
+        pczt,
+        seed_fingerprint,
+        account_index,
+        ShieldedActionPolicy::Batch,
+    )?;
+
+    if signable_actions.is_empty() {
+        Err(ZcashError::PcztNoMyInputs)
+    } else {
+        // Assemble the display from the shielded rows collected above.
+        pczt::parse::parse_pczt_cypherpunk_with_checked_shielded(
+            params,
+            seed_fingerprint,
+            &pczt,
+            checked_shielded.orchard,
+            checked_shielded.ironwood,
+        )
+    }
+}
+
 #[cfg(test)]
 mod additional_tests {
     use super::*;
@@ -1470,6 +1535,70 @@ mod tests {
                 ZcashError::PcztNoMyInputs
             );
         }
+    }
+
+    #[test]
+    fn test_batch_check_and_parse_accepts_ironwood_spend() {
+        let sample = pczt::test_support::sample_ironwood_pczt();
+
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("Ironwood batch PCZT should parse");
+        assert!(parsed.get_orchard().is_some() || parsed.get_ironwood().is_some());
+
+        assert_eq!(
+            check_and_parse_batch_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                1,
+            )
+            .unwrap_err(),
+            ZcashError::PcztNoMyInputs
+        );
+    }
+
+    #[test]
+    fn test_batch_check_and_parse_accepts_orchard_to_ironwood_migration() {
+        let sample = pczt::test_support::sample_migration_pczt();
+
+        let parsed = check_and_parse_batch_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("migration batch PCZT should parse");
+        assert!(!parsed
+            .get_orchard()
+            .expect("migration must show Orchard inputs")
+            .get_from()
+            .is_empty());
+        assert!(!parsed
+            .get_ironwood()
+            .expect("migration must show Ironwood outputs")
+            .get_to()
+            .is_empty());
+        assert_eq!(parsed.get_fee_value(), "0.0002 ZEC");
+
+        assert_eq!(
+            check_and_parse_batch_pczt_cypherpunk(
+                &pczt::test_support::Nu6_3Network,
+                &sample.bytes,
+                &sample.ufvk_text,
+                &sample.seed_fingerprint,
+                1,
+            )
+            .unwrap_err(),
+            ZcashError::PcztNoMyInputs
+        );
     }
 
     #[test]

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -45,7 +45,6 @@ pub fn check_pczt_orchard<P: consensus::Parameters>(
     pczt: &Pczt,
 ) -> Result<(), ZcashError> {
     super::validate_supported_pczt(pczt)?;
-    #[cfg(zcash_unstable = "nu6.3")]
     let should_process_ironwood = super::pczt_should_process_ironwood(pczt);
     let verifier = Verifier::new(pczt.clone())
         .with_orchard(|bundle| {
@@ -61,7 +60,6 @@ pub fn check_pczt_orchard<P: consensus::Parameters>(
             Ok(())
         })
         .map_err(map_orchard_verifier_error)?;
-    #[cfg(zcash_unstable = "nu6.3")]
     if should_process_ironwood {
         verifier
             .with_ironwood(|bundle| {

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -24,6 +24,8 @@ use zcash_vendor::{
 use zcash_vendor::zcash_protocol::consensus::NetworkConstants;
 
 #[cfg(feature = "cypherpunk")]
+use super::structs::ParsedOrchard;
+#[cfg(feature = "cypherpunk")]
 use super::ShieldedPool;
 
 #[cfg(feature = "cypherpunk")]
@@ -77,6 +79,75 @@ pub fn check_pczt_orchard<P: consensus::Parameters>(
             .map_err(map_orchard_verifier_error)?;
     }
     Ok(())
+}
+
+/// Orchard and Ironwood display rows collected during shielded validation.
+/// A pool is `None` when it contains no displayable actions.
+#[cfg(feature = "cypherpunk")]
+pub(crate) struct CheckedShieldedParse {
+    pub(crate) orchard: Option<ParsedOrchard>,
+    pub(crate) ironwood: Option<ParsedOrchard>,
+}
+
+/// Validates the supported shielded bundles and collects their display rows.
+/// Returns the collected Orchard and Ironwood rows together with the PCZT.
+#[cfg(feature = "cypherpunk")]
+pub(crate) fn check_and_parse_pczt_shielded<P: consensus::Parameters>(
+    params: &P,
+    seed_fingerprint: &[u8; 32],
+    account_index: zip32::AccountId,
+    ufvk: &UnifiedFullViewingKey,
+    pczt: Pczt,
+) -> Result<(CheckedShieldedParse, Pczt), ZcashError> {
+    super::validate_supported_pczt(&pczt)?;
+    let mut parsed_orchard = None;
+    let mut parsed_ironwood = None;
+    let should_process_ironwood = super::pczt_should_process_ironwood(&pczt);
+
+    // Validate Orchard while collecting the rows shown during review.
+    let verifier = Verifier::new(pczt)
+        .with_orchard(|bundle| {
+            parsed_orchard = check_and_parse_shielded_bundle(
+                params,
+                seed_fingerprint,
+                account_index,
+                ufvk,
+                bundle,
+                ShieldedPool::Orchard,
+            )
+            .map_err(pczt::roles::verifier::OrchardError::Custom)?;
+            Ok(())
+        })
+        .map_err(map_orchard_verifier_error)?;
+
+    // Continue through Ironwood when this transaction version enables it.
+    let verifier = if should_process_ironwood {
+        verifier
+            .with_ironwood(|bundle| {
+                parsed_ironwood = check_and_parse_shielded_bundle(
+                    params,
+                    seed_fingerprint,
+                    account_index,
+                    ufvk,
+                    bundle,
+                    ShieldedPool::Ironwood,
+                )
+                .map_err(pczt::roles::verifier::OrchardError::Custom)?;
+                Ok(())
+            })
+            .map_err(map_orchard_verifier_error)?
+    } else {
+        verifier
+    };
+
+    // Return the verifier-owned PCZT for the remaining checks.
+    Ok((
+        CheckedShieldedParse {
+            orchard: parsed_orchard,
+            ironwood: parsed_ironwood,
+        },
+        verifier.finish(),
+    ))
 }
 
 pub fn check_pczt_transparent<P: consensus::Parameters>(
@@ -312,6 +383,85 @@ fn check_shielded_bundle<P: consensus::Parameters>(
 
     match calculated_value_balance {
         Ok(value_balance) if &value_balance == bundle.value_sum() => Ok(()),
+        _ => Err(ZcashError::InvalidPczt(format!(
+            "invalid {pool_label} bundle value balance"
+        ))),
+    }
+}
+
+/// Validates a shielded bundle while collecting its non-dummy display rows.
+/// Returns `None` when the bundle contains no displayable actions.
+#[cfg(feature = "cypherpunk")]
+fn check_and_parse_shielded_bundle<P: consensus::Parameters>(
+    params: &P,
+    seed_fingerprint: &[u8; 32],
+    account_index: zip32::AccountId,
+    ufvk: &UnifiedFullViewingKey,
+    bundle: &orchard::pczt::Bundle,
+    pool: ShieldedPool,
+) -> Result<Option<ParsedOrchard>, ZcashError> {
+    let pool_label = pool.label();
+    let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
+        "orchard fvk is not present".to_string(),
+    ))?;
+
+    let mut parsed_orchard = ParsedOrchard::new(vec![], vec![]);
+    // Validate and decode each action in the canonical order.
+    bundle.actions().iter().try_for_each(|action| {
+        action.verify_cv_net().map_err(|e| {
+            ZcashError::InvalidPczt(format!("invalid cv_net in {pool_label} action: {e:?}"))
+        })?;
+
+        check_action_spend(
+            params,
+            seed_fingerprint,
+            account_index,
+            fvk,
+            action.spend(),
+            pool,
+        )?;
+        action
+            .output()
+            .verify_note_commitment(action.spend())
+            .map_err(|e| {
+                ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}"))
+            })?;
+
+        // Add only real spends to the review.
+        if let Some(value) = action.spend().value() {
+            if value.inner() != 0 {
+                let parsed_from =
+                    super::parse::parse_orchard_spend(seed_fingerprint, action.spend())?;
+                parsed_orchard.add_from(parsed_from);
+            }
+        }
+
+        // Decode real outputs once and add them to the review.
+        let parsed_to = super::parse::parse_orchard_output(params, ufvk, action, pool)?;
+        if !parsed_to.get_is_dummy() {
+            parsed_orchard.add_to(parsed_to);
+        }
+
+        Ok::<_, ZcashError>(())
+    })?;
+
+    // Recompute the bundle balance from the values just reviewed.
+    let calculated_value_balance = bundle
+        .actions()
+        .iter()
+        .map(|action| {
+            action.spend().value().expect("present") - action.output().value().expect("present")
+        })
+        .sum::<Result<ValueSum, _>>();
+
+    match calculated_value_balance {
+        Ok(value_balance) if &value_balance == bundle.value_sum() => {
+            if parsed_orchard.get_from().is_empty() && parsed_orchard.get_to().is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(parsed_orchard))
+            }
+        }
         _ => Err(ZcashError::InvalidPczt(format!(
             "invalid {pool_label} bundle value balance"
         ))),

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -6,7 +6,7 @@ use crate::errors::ZcashError;
 
 #[cfg(feature = "cypherpunk")]
 use zcash_vendor::{
-    orchard::{self, keys::FullViewingKey, value::ValueSum, Address},
+    orchard::{self, keys::FullViewingKey, value::ValueSum},
     zcash_keys::keys::UnifiedFullViewingKey,
 };
 
@@ -367,7 +367,15 @@ fn check_shielded_bundle<P: consensus::Parameters>(
 ) -> Result<(), ZcashError> {
     let pool_label = pool.label();
     bundle.actions().iter().try_for_each(|action| {
-        check_action(params, seed_fingerprint, account_index, ufvk, action, pool)?;
+        check_action(
+            params,
+            seed_fingerprint,
+            account_index,
+            ufvk,
+            action,
+            bundle.flags(),
+            pool,
+        )?;
         Ok::<_, ZcashError>(())
     })?;
 
@@ -436,8 +444,9 @@ fn check_and_parse_shielded_bundle<P: consensus::Parameters>(
             }
         }
 
-        // Decode real outputs once and add them to the review.
+        // Require every real output to be recoverable for review.
         let parsed_to = super::parse::parse_orchard_output(params, ufvk, action, pool)?;
+        check_restricted_zero_value_output(ufvk, action, bundle.flags(), pool)?;
         if !parsed_to.get_is_dummy() {
             parsed_orchard.add_to(parsed_to);
         }
@@ -476,6 +485,7 @@ fn check_action<P: consensus::Parameters>(
     account_index: zip32::AccountId,
     ufvk: &UnifiedFullViewingKey,
     action: &orchard::pczt::Action,
+    flags: &orchard::bundle::Flags,
     pool: ShieldedPool,
 ) -> Result<(), ZcashError> {
     let pool_label = pool.label();
@@ -496,7 +506,7 @@ fn check_action<P: consensus::Parameters>(
         action.spend(),
         pool,
     )?;
-    check_action_output(params, ufvk, action, pool)?;
+    check_action_output(params, ufvk, action, flags, pool)?;
     Ok(())
 }
 
@@ -546,20 +556,11 @@ fn check_action_spend<P: consensus::Parameters>(
 }
 
 #[cfg(feature = "cypherpunk")]
-fn is_wallet_orchard_address(fvk: &FullViewingKey, address: &Address) -> bool {
-    let external_ivk = fvk.to_ivk(zcash_vendor::zip32::Scope::External);
-    let internal_ivk = fvk.to_ivk(zcash_vendor::zip32::Scope::Internal);
-
-    external_ivk.diversifier_index(address).is_some()
-        || internal_ivk.diversifier_index(address).is_some()
-}
-
-#[cfg(feature = "cypherpunk")]
-// check output cmx and internal-ovk output ownership constraints
 fn check_action_output<P: consensus::Parameters>(
     params: &P,
     ufvk: &UnifiedFullViewingKey,
     action: &orchard::pczt::Action,
+    flags: &orchard::bundle::Flags,
     pool: ShieldedPool,
 ) -> Result<(), ZcashError> {
     let pool_label = pool.label();
@@ -568,40 +569,39 @@ fn check_action_output<P: consensus::Parameters>(
         .verify_note_commitment(action.spend())
         .map_err(|e| ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}")))?;
 
-    let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
-        "orchard fvk is not present".to_string(),
-    ))?;
-    let external_ovk = fvk.to_ovk(zcash_vendor::zip32::Scope::External).clone();
-    let internal_ovk = fvk.to_ovk(zcash_vendor::zip32::Scope::Internal).clone();
-    let transparent_internal_ovk = ufvk
-        .transparent()
-        .map(|k| orchard::keys::OutgoingViewingKey::from(k.internal_ovk().as_bytes()));
+    // Decode and validate the recipient, rejecting non-zero outputs the device cannot review.
+    super::parse::parse_orchard_output(params, ufvk, action, pool)?;
+    check_restricted_zero_value_output(ufvk, action, flags, pool)?;
 
-    let mut keys = vec![(Some(external_ovk), false), (Some(internal_ovk), true)];
-    if let Some(ovk) = transparent_internal_ovk {
-        keys.push((Some(ovk), true));
+    Ok(())
+}
+
+#[cfg(feature = "cypherpunk")]
+fn check_restricted_zero_value_output(
+    ufvk: &UnifiedFullViewingKey,
+    action: &orchard::pczt::Action,
+    flags: &orchard::bundle::Flags,
+    pool: ShieldedPool,
+) -> Result<(), ZcashError> {
+    // A restricted action binds its spend and output to the same expanded receiver.
+    // A funded output paired with a zero-valued spend must therefore be ours.
+    let is_zero_spend = matches!(action.spend().value(), Some(value) if value.inner() == 0);
+    let is_funded_output = matches!(action.output().value(), Some(value) if value.inner() != 0);
+    if flags.cross_address_enabled() || !is_zero_spend || !is_funded_output {
+        return Ok(());
     }
 
-    for (vk, is_internal_ovk) in keys {
-        if let Some((_, address, _)) =
-            super::parse::decode_output_enc_ciphertext(action, vk.as_ref())?
-        {
-            if let Some(user_address) = action.output().user_address() {
-                super::parse::validate_orchard_user_address(params, user_address, &address)?;
-            }
-            if is_internal_ovk && !is_wallet_orchard_address(fvk, &address) {
-                return Err(ZcashError::InvalidPczt(format!(
-                    "{pool_label} output was recoverable with an internal OVK but does not belong to this wallet"
-                )));
-            }
-            break;
-        }
-    }
-
-    if let (Some(user_address), Some(recipient)) =
-        (action.output().user_address(), action.output().recipient())
-    {
-        super::parse::validate_orchard_user_address(params, user_address, recipient)?;
+    let recipient = action.output().recipient().ok_or_else(|| {
+        ZcashError::InvalidPczt(format!(
+            "missing recipient for funded {} output",
+            pool.label()
+        ))
+    })?;
+    if !super::parse::is_wallet_orchard_address(ufvk, &recipient)? {
+        return Err(ZcashError::InvalidPczt(format!(
+            "funded {} output paired with a zero-value spend does not belong to the selected account",
+            pool.label()
+        )));
     }
 
     Ok(())

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -792,7 +792,7 @@ pub(crate) mod legacy_test_support {
             keys::{AccountPrivKey, IncomingViewingKey},
         },
         zcash_protocol::{
-            consensus::{MainNetwork, Parameters},
+            consensus::{MainNetwork, NetworkUpgrade, Parameters},
             value::Zatoshis,
         },
         zip32,
@@ -868,7 +868,7 @@ pub(crate) mod legacy_test_support {
         );
         let mut builder = Builder::new(
             &params,
-            10_000_000.into(),
+            params.activation_height(NetworkUpgrade::Nu5).unwrap(),
             BuildConfig::Standard {
                 sapling_anchor: None,
                 orchard_anchor: None,

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -20,7 +20,6 @@ pub(crate) fn parse_pczt(bytes: &[u8]) -> Result<Pczt, ZcashError> {
 pub(crate) fn validate_supported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     validate_sapling_bundle_consistency(pczt)?;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     {
         if pczt_has_ironwood_actions(pczt) && !pczt_is_v6(pczt) {
             return Err(ZcashError::InvalidPczt(
@@ -46,18 +45,15 @@ pub(crate) fn validate_supported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     Ok(())
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 pub(crate) fn pczt_has_ironwood_actions(pczt: &Pczt) -> bool {
     !pczt.ironwood().actions().is_empty()
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 pub(crate) fn pczt_is_v6(pczt: &Pczt) -> bool {
     *pczt.global().tx_version() == constants::V6_TX_VERSION
         && *pczt.global().version_group_id() == constants::V6_VERSION_GROUP_ID
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 pub(crate) fn pczt_should_process_ironwood(pczt: &Pczt) -> bool {
     pczt_is_v6(pczt) || pczt_has_ironwood_actions(pczt)
 }
@@ -116,7 +112,6 @@ pub(crate) fn check_transparent_derivation<
 #[derive(Clone, Copy)]
 pub(crate) enum ShieldedPool {
     Orchard,
-    #[cfg(zcash_unstable = "nu6.3")]
     Ironwood,
 }
 
@@ -125,7 +120,6 @@ impl ShieldedPool {
     pub(crate) fn label(self) -> &'static str {
         match self {
             ShieldedPool::Orchard => "Orchard",
-            #[cfg(zcash_unstable = "nu6.3")]
             ShieldedPool::Ironwood => "Ironwood",
         }
     }
@@ -178,10 +172,7 @@ pub(crate) fn matching_seed_supported_orchard_account(
 /// Returns whether a PCZT carries anything the transparent-only legacy path
 /// cannot handle: a v6+ transaction, or any shielded (Sapling/Orchard/Ironwood)
 /// content. These must be checked, parsed, and signed by the cypherpunk build.
-#[cfg(all(
-    zcash_unstable = "nu6.3",
-    any(feature = "multi_coins", not(feature = "cypherpunk"))
-))]
+#[cfg(any(feature = "multi_coins", not(feature = "cypherpunk")))]
 pub(crate) fn pczt_requires_cypherpunk_support(pczt: &zcash_vendor::pczt::Pczt) -> bool {
     *pczt.global().tx_version() >= 6
         || !pczt.sapling().spends().is_empty()
@@ -195,20 +186,16 @@ pub(crate) mod test_support {
     use alloc::{string::String, vec, vec::Vec};
 
     use ::pczt::roles::{creator::Creator, updater::Updater};
-    #[cfg(zcash_unstable = "nu6.3")]
     use incrementalmerkletree::Retention;
     use keystore::algorithms::zcash::{calculate_seed_fingerprint, derive_ufvk};
     use rand_core::OsRng;
-    #[cfg(zcash_unstable = "nu6.3")]
     use shardtree::{store::memory::MemoryShardStore, ShardTree};
-    #[cfg(zcash_unstable = "nu6.3")]
     use zcash_note_encryption::try_note_decryption;
     use zcash_primitives::transaction::{
         builder::{BuildConfig, Builder, PcztParts, PcztResult},
         fees::zip317,
         TxVersion,
     };
-    #[cfg(zcash_unstable = "nu6.3")]
     use zcash_vendor::zcash_protocol::consensus::{BlockHeight, NetworkType, NetworkUpgrade};
     use zcash_vendor::{
         orchard,
@@ -229,11 +216,9 @@ pub(crate) mod test_support {
         pub(crate) seed_fingerprint: [u8; 32],
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[derive(Clone, Copy, Debug)]
     pub(crate) struct Nu6_3Network;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     impl Parameters for Nu6_3Network {
         fn network_type(&self) -> NetworkType {
             NetworkType::Main
@@ -247,7 +232,6 @@ pub(crate) mod test_support {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn unsupported_orchard_spend_paths() -> Vec<Vec<u32>> {
         vec![
             vec![
@@ -264,7 +248,6 @@ pub(crate) mod test_support {
         ]
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn orchard_spend_path_for_account(account_index: u32) -> Vec<u32> {
         vec![
             zip32::ChildIndex::hardened(32).index(),
@@ -273,7 +256,6 @@ pub(crate) mod test_support {
         ]
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn ironwood_pczt_with_spend_derivation(
         bytes: &[u8],
         seed_fingerprint: [u8; 32],
@@ -298,7 +280,6 @@ pub(crate) mod test_support {
             .unwrap()
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn ironwood_pczt_with_dummy_spend_derivation(
         bytes: &[u8],
         seed_fingerprint: [u8; 32],
@@ -335,7 +316,6 @@ pub(crate) mod test_support {
             .unwrap()
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn sample_ironwood_pczt() -> SamplePczt {
         let params = Nu6_3Network;
         let seed = [7u8; 32];
@@ -446,7 +426,6 @@ pub(crate) mod test_support {
     // Orchard spend -> Ironwood output: a cross-pool migration, the message type
     // the real batch uses (and the one never exercised on-device). Mirrors
     // sample_ironwood_pczt but the *spent* note is an Orchard note.
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn sample_migration_pczt() -> SamplePczt {
         let params = Nu6_3Network;
         let seed = [7u8; 32];
@@ -556,7 +535,6 @@ pub(crate) mod test_support {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     pub(crate) fn sample_orchard_change_pczt() -> SamplePczt {
         let params = MainNetwork;
         let seed = [7u8; 32];

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -200,7 +200,7 @@ pub(crate) mod test_support {
     use zcash_vendor::{
         orchard,
         pczt::Pczt,
-        zcash_keys::keys::UnifiedFullViewingKey,
+        zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey},
         zcash_protocol::{
             consensus::{BranchId, MainNetwork, Parameters},
             memo::{Memo, MemoBytes},
@@ -423,10 +423,35 @@ pub(crate) mod test_support {
         }
     }
 
-    // Orchard spend -> Ironwood output: a cross-pool migration, the message type
-    // the real batch uses (and the one never exercised on-device). Mirrors
-    // sample_ironwood_pczt but the *spent* note is an Orchard note.
+    // Orchard spend -> Ironwood output, matching one migration child in a batch.
     pub(crate) fn sample_migration_pczt() -> SamplePczt {
+        sample_migration_pczt_with_options(0, MemoBytes::empty(), None)
+    }
+
+    /// Builds a migration whose funded output carries the given memo.
+    pub(crate) fn sample_migration_pczt_with_output_memo(output_memo: MemoBytes) -> SamplePczt {
+        sample_migration_pczt_with_options(0, output_memo, None)
+    }
+
+    /// Builds a migration whose funded output belongs to the given account.
+    pub(crate) fn sample_migration_pczt_to_account(output_account: u32) -> SamplePczt {
+        sample_migration_pczt_with_options(output_account, MemoBytes::empty(), None)
+    }
+
+    /// Adds a zero-value output, optionally marked for ordinary display.
+    pub(crate) fn sample_migration_pczt_with_zero_output(
+        memo: MemoBytes,
+        displayable: bool,
+    ) -> SamplePczt {
+        sample_migration_pczt_with_options(0, MemoBytes::empty(), Some((memo, displayable)))
+    }
+
+    /// Builds a migration sample with a configurable funded recipient and optional zero output.
+    fn sample_migration_pczt_with_options(
+        output_account: u32,
+        output_memo: MemoBytes,
+        zero_output: Option<(MemoBytes, bool)>,
+    ) -> SamplePczt {
         let params = Nu6_3Network;
         let seed = [7u8; 32];
         let ufvk_text = derive_ufvk(&params, &seed, "m/32'/133'/0'").unwrap();
@@ -434,7 +459,21 @@ pub(crate) mod test_support {
         let orchard_fvk = ufvk.orchard().unwrap().clone();
         let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
         let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
-        let recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+        let spend_recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
+        let output_ufvk_text = derive_ufvk(
+            &params,
+            &seed,
+            &alloc::format!("m/32'/133'/{output_account}'"),
+        )
+        .unwrap();
+        let output_ufvk = UnifiedFullViewingKey::decode(&params, &output_ufvk_text).unwrap();
+        let output_fvk = output_ufvk.orchard().unwrap();
+        let recipient = output_fvk.address_at(0u32, orchard::keys::Scope::External);
+        let output_user_address = output_ufvk
+            .default_address(UnifiedAddressRequest::AllAvailableKeys)
+            .unwrap()
+            .0
+            .encode(&params);
 
         // The Orchard note being migrated: output (990_000) + cross-pool fee (20_000),
         // so there is no change output.
@@ -448,7 +487,12 @@ pub(crate) mod test_support {
             )
             .expect("spends-disabled flags are valid for a coinbase bundle");
             orchard_builder
-                .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+                .add_output(
+                    None,
+                    spend_recipient,
+                    value,
+                    Memo::Empty.encode().into_bytes(),
+                )
                 .unwrap();
             let (bundle, meta) = orchard_builder.build::<i64>(&mut OsRng).unwrap().unwrap();
             let action = bundle
@@ -496,17 +540,32 @@ pub(crate) mod test_support {
                 Some(orchard_ovk),
                 recipient,
                 Zatoshis::const_from_u64(990_000),
-                MemoBytes::empty(),
+                output_memo,
             )
             .unwrap();
+        if let Some((memo, _)) = zero_output.as_ref() {
+            builder
+                .add_ironwood_output::<zip317::FeeRule>(
+                    None,
+                    recipient,
+                    Zatoshis::ZERO,
+                    memo.clone(),
+                )
+                .unwrap();
+        }
         let PcztResult {
             pczt_parts,
             orchard_meta,
+            ironwood_meta,
             ..
         } = builder
             .build_for_pczt(OsRng, &zip317::FeeRule::standard())
             .unwrap();
         let spend_action_index = orchard_meta.spend_action_index(0).unwrap();
+        let displayable_zero_action = match zero_output.as_ref() {
+            Some((_, true)) => Some(ironwood_meta.output_action_index(1).unwrap()),
+            _ => None,
+        };
         let seed_fingerprint = calculate_seed_fingerprint(&seed).unwrap();
         let derivation = orchard::pczt::Zip32Derivation::parse(
             seed_fingerprint,
@@ -526,6 +585,19 @@ pub(crate) mod test_support {
             })
             .unwrap()
             .finish();
+        let pczt = if let Some(action_index) = displayable_zero_action {
+            Updater::new(pczt)
+                .update_ironwood_with(|mut bundle| {
+                    bundle.update_action_with(action_index, |mut action| {
+                        action.set_output_user_address(output_user_address);
+                        Ok(())
+                    })
+                })
+                .unwrap()
+                .finish()
+        } else {
+            pczt
+        };
 
         SamplePczt {
             bytes: pczt.serialize().unwrap(),

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -423,7 +423,7 @@ pub(crate) mod test_support {
         }
     }
 
-    // Orchard spend -> Ironwood output, matching one migration child in a batch.
+    // Orchard spend -> Ironwood output, matching one compact-eligible transfer.
     pub(crate) fn sample_migration_pczt() -> SamplePczt {
         sample_migration_pczt_with_options(0, MemoBytes::empty(), None)
     }
@@ -458,7 +458,6 @@ pub(crate) mod test_support {
         let ufvk = UnifiedFullViewingKey::decode(&params, &ufvk_text).unwrap();
         let orchard_fvk = ufvk.orchard().unwrap().clone();
         let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
-        let orchard_ovk = orchard_fvk.to_ovk(orchard::keys::Scope::External);
         let spend_recipient = orchard_fvk.address_at(0u32, orchard::keys::Scope::External);
         let output_ufvk_text = derive_ufvk(
             &params,
@@ -468,7 +467,16 @@ pub(crate) mod test_support {
         .unwrap();
         let output_ufvk = UnifiedFullViewingKey::decode(&params, &output_ufvk_text).unwrap();
         let output_fvk = output_ufvk.orchard().unwrap();
-        let recipient = output_fvk.address_at(0u32, orchard::keys::Scope::External);
+        // The compact-review fixture uses an internal Ironwood receiver. Keep
+        // the foreign-account variant decryptable for its ordinary-review test
+        // by using the selected account's external OVK.
+        let recipient = output_fvk.address_at(0u32, orchard::keys::Scope::Internal);
+        let orchard_ovk = orchard_fvk.to_ovk(if output_account == 0 {
+            orchard::keys::Scope::Internal
+        } else {
+            orchard::keys::Scope::External
+        });
+        let zero_recipient = output_fvk.address_at(0u32, orchard::keys::Scope::External);
         let output_user_address = output_ufvk
             .default_address(UnifiedAddressRequest::AllAvailableKeys)
             .unwrap()
@@ -547,7 +555,7 @@ pub(crate) mod test_support {
             builder
                 .add_ironwood_output::<zip317::FeeRule>(
                     None,
-                    recipient,
+                    zero_recipient,
                     Zatoshis::ZERO,
                     memo.clone(),
                 )

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -536,15 +536,33 @@ pub(crate) mod test_support {
     }
 
     pub(crate) fn sample_orchard_change_pczt() -> SamplePczt {
+        sample_orchard_change_pczt_for_account(0)
+    }
+
+    pub(crate) fn sample_orchard_foreign_change_pczt() -> SamplePczt {
+        sample_orchard_change_pczt_for_account(1)
+    }
+
+    fn sample_orchard_change_pczt_for_account(output_account: u32) -> SamplePczt {
         let params = MainNetwork;
         let seed = [7u8; 32];
         let ufvk_text = derive_ufvk(&params, &seed, "m/32'/133'/0'").unwrap();
         let ufvk = UnifiedFullViewingKey::decode(&params, &ufvk_text).unwrap();
         let orchard_fvk = ufvk.orchard().unwrap().clone();
         let orchard_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
+
+        let output_ufvk_text = derive_ufvk(
+            &params,
+            &seed,
+            &alloc::format!("m/32'/133'/{output_account}'"),
+        )
+        .unwrap();
+        let output_ufvk = UnifiedFullViewingKey::decode(&params, &output_ufvk_text).unwrap();
+        let output_fvk = output_ufvk.orchard().unwrap().clone();
         let recipient_scope = orchard::keys::Scope::External;
-        let recipient = orchard_fvk.address_at(0u32, recipient_scope);
-        let orchard_ovk = orchard_fvk.to_ovk(recipient_scope);
+        let spend_recipient = orchard_fvk.address_at(0u32, recipient_scope);
+        let output_recipient = output_fvk.address_at(0u32, recipient_scope);
+        let orchard_ovk = output_fvk.to_ovk(recipient_scope);
 
         let value = orchard::value::NoteValue::from_raw(1_000_000);
         let note = {
@@ -556,7 +574,12 @@ pub(crate) mod test_support {
             )
             .expect("spends-disabled flags are valid for a coinbase bundle");
             orchard_builder
-                .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+                .add_output(
+                    None,
+                    spend_recipient,
+                    value,
+                    Memo::Empty.encode().into_bytes(),
+                )
                 .unwrap();
             let (bundle, meta) = orchard_builder.build::<i64>(&mut OsRng).unwrap().unwrap();
             let action = bundle
@@ -598,9 +621,9 @@ pub(crate) mod test_support {
             .unwrap();
         builder
             .add_change_output(
-                orchard_fvk,
+                output_fvk,
                 Some(orchard_ovk),
-                recipient,
+                output_recipient,
                 orchard::value::NoteValue::from_raw(990_000),
                 Memo::Empty.encode().into_bytes(),
             )
@@ -621,21 +644,28 @@ pub(crate) mod test_support {
         .unwrap();
         let pczt = Updater::new(pczt)
             .update_orchard_with(|mut bundle| {
-                let signing_action_indices = bundle
+                let signing_action_accounts = bundle
                     .bundle()
                     .actions()
                     .iter()
                     .enumerate()
                     .filter_map(|(index, action)| {
-                        action.spend().dummy_sk().is_none().then_some(index)
+                        action.spend().dummy_sk().is_none().then(|| {
+                            let account = if action.spend().value().unwrap().inner() == 0 {
+                                output_account
+                            } else {
+                                0
+                            };
+                            (index, account)
+                        })
                     })
                     .collect::<Vec<_>>();
-                assert_eq!(signing_action_indices.len(), 2);
+                assert_eq!(signing_action_accounts.len(), 2);
 
-                for action_index in signing_action_indices {
+                for (action_index, account) in signing_action_accounts {
                     let derivation = orchard::pczt::Zip32Derivation::parse(
                         seed_fingerprint,
-                        orchard_spend_path_for_account(0),
+                        orchard_spend_path_for_account(account),
                     )
                     .unwrap();
                     bundle.update_action_with(action_index, |mut action| {

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -865,11 +865,12 @@ mod legacy_tests {
             BranchId::Nu6_3.into(),
             10,
             MainNetwork.coin_type(),
-            [0; 32],
-            [0; 32],
+            None,
+            None,
         )
         .unwrap()
-        .build();
+        .build()
+        .unwrap();
 
         let result = parse_pczt_multi_coins(&MainNetwork, &[7u8; 32], &pczt);
 

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -250,12 +250,51 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
         })
         .map_err(map_transparent_verifier_error)?;
 
+    assemble_parsed_pczt(pczt, parsed_transparent, parsed_orchard, parsed_ironwood)
+}
+
+/// Parses the transparent bundle and combines it with the supplied shielded
+/// display rows.
+#[cfg(feature = "cypherpunk")]
+pub(crate) fn parse_pczt_cypherpunk_with_checked_shielded<P: consensus::Parameters>(
+    params: &P,
+    seed_fingerprint: &[u8; 32],
+    pczt: &Pczt,
+    parsed_orchard: Option<ParsedOrchard>,
+    parsed_ironwood: Option<ParsedOrchard>,
+) -> Result<ParsedPczt, ZcashError> {
+    super::validate_supported_pczt(pczt)?;
+    let mut parsed_transparent = None;
+
+    // Parse the remaining transparent rows.
+    Verifier::new(pczt.clone())
+        .with_transparent(|bundle| {
+            parsed_transparent = parse_transparent(params, seed_fingerprint, bundle)
+                .map_err(pczt::roles::verifier::TransparentError::Custom)?;
+            Ok(())
+        })
+        .map_err(map_transparent_verifier_error)?;
+
+    // Combine all checked rows and calculate the display totals.
+    assemble_parsed_pczt(pczt, parsed_transparent, parsed_orchard, parsed_ironwood)
+}
+
+/// Assembles the per-pool parse results into the final [`ParsedPczt`],
+/// computing the transfer, change, and fee totals.
+#[cfg(feature = "cypherpunk")]
+fn assemble_parsed_pczt(
+    pczt: &Pczt,
+    parsed_transparent: Option<ParsedTransparent>,
+    parsed_orchard: Option<ParsedOrchard>,
+    parsed_ironwood: Option<ParsedOrchard>,
+) -> Result<ParsedPczt, ZcashError> {
     let mut total_input_value = 0;
     let mut total_output_value = 0;
     let mut total_change_value = 0;
     //total_input_value = total_output_value + fee_value
     //total_output_value = total_transfer_value + total_change_value
 
+    // Fold each decoded pool into the display totals.
     if let Some(orchard) = &parsed_orchard {
         total_change_value += orchard
             .get_to()
@@ -323,6 +362,7 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
         total_input_value = total_input_value.saturating_add(sapling_value_sum as u64)
     };
 
+    // Derive the transfer and fee values shown during confirmation.
     let total_transfer_value = format_zec_value((total_output_value - total_change_value) as f64);
     let fee_value = format_zec_value((total_input_value - total_output_value) as f64);
 
@@ -583,7 +623,7 @@ fn parse_orchard<P: consensus::Parameters>(
 }
 
 #[cfg(feature = "cypherpunk")]
-fn parse_orchard_spend(
+pub(crate) fn parse_orchard_spend(
     seed_fingerprint: &[u8; 32],
     spend: &orchard::pczt::Spend,
 ) -> Result<ParsedFrom, ZcashError> {
@@ -651,8 +691,11 @@ pub(crate) fn validate_orchard_user_address<P: consensus::Parameters>(
     Ok(())
 }
 
+/// Decodes one action's output into its [`ParsedTo`] display row, trying the
+/// wallet OVKs and then direct decryption. Every non-zero output must be
+/// recoverable.
 #[cfg(feature = "cypherpunk")]
-fn parse_orchard_output<P: consensus::Parameters>(
+pub(crate) fn parse_orchard_output<P: consensus::Parameters>(
     params: &P,
     ufvk: &UnifiedFullViewingKey,
     action: &orchard::pczt::Action,

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -98,52 +98,49 @@ fn format_zec_value(value: f64) -> String {
 /// - `Ok(None)` if the output cannot be decrypted.
 /// - `Err(_)` if `ovk` is `None` and the PCZT is missing fields needed to directly
 ///   decrypt the output.
+///
+/// `pool` selects the note-encryption domain used for recovery.
 #[cfg(feature = "cypherpunk")]
-pub fn decode_output_enc_ciphertext(
+pub(crate) fn decode_output_enc_ciphertext(
     action: &orchard::pczt::Action,
     ovk: Option<&OutgoingViewingKey>,
+    pool: ShieldedPool,
 ) -> Result<Option<(Note, Address, [u8; 512])>, ZcashError> {
-    // orchard 0.15.0-pre.1 splits note encryption by version: Ironwood actions carry V3
-    // note plaintexts and must be trial-decrypted with `IronwoodDomain`, while Orchard
-    // actions use the V2 `OrchardDomain`. Select the domain from the action's note version
-    // so both pools decrypt correctly.
-    let is_ironwood = matches!(*action.output().note_version(), orchard::NoteVersion::V3);
-
     if let Some(ovk) = ovk {
         let out_ciphertext = &action.output().encrypted_note().out_ciphertext;
-        Ok(if is_ironwood {
-            try_output_recovery_with_ovk(
-                &IronwoodDomain::for_pczt_action(action),
-                ovk,
-                action,
-                action.cv_net(),
-                out_ciphertext,
-            )
-        } else {
-            try_output_recovery_with_ovk(
+        Ok(match pool {
+            ShieldedPool::Orchard => try_output_recovery_with_ovk(
                 &OrchardDomain::for_pczt_action(action),
                 ovk,
                 action,
                 action.cv_net(),
                 out_ciphertext,
-            )
+            ),
+            ShieldedPool::Ironwood => try_output_recovery_with_ovk(
+                &IronwoodDomain::for_pczt_action(action),
+                ovk,
+                action,
+                action.cv_net(),
+                out_ciphertext,
+            ),
         })
     } else {
         // If we reached here, none of our OVKs matched; recover directly as the fallback.
+        let pool_label = pool.label();
 
         let recipient = action.output().recipient().ok_or_else(|| {
-            ZcashError::InvalidPczt("Missing recipient field for Orchard action".into())
+            ZcashError::InvalidPczt(format!("Missing recipient field for {pool_label} action"))
         })?;
         let value = action.output().value().ok_or_else(|| {
-            ZcashError::InvalidPczt("Missing value field for Orchard action".into())
+            ZcashError::InvalidPczt(format!("Missing value field for {pool_label} action"))
         })?;
         let rho = orchard::note::Rho::from_bytes(&action.spend().nullifier().to_bytes())
             .into_option()
             .ok_or_else(|| {
-                ZcashError::InvalidPczt("Missing rho field for Orchard action".into())
+                ZcashError::InvalidPczt(format!("Missing rho field for {pool_label} action"))
             })?;
         let rseed = action.output().rseed().ok_or_else(|| {
-            ZcashError::InvalidPczt("Missing rseed field for Orchard action".into())
+            ZcashError::InvalidPczt(format!("Missing rseed field for {pool_label} action"))
         })?;
 
         let note = orchard::Note::from_parts(
@@ -151,29 +148,36 @@ pub fn decode_output_enc_ciphertext(
             value,
             rho,
             rseed,
-            *action.output().note_version(),
+            (*action.output().note_version()).into(),
         )
         .into_option()
-        .ok_or_else(|| ZcashError::InvalidPczt("Orchard action contains invalid note".into()))?;
+        .ok_or_else(|| {
+            ZcashError::InvalidPczt(format!("{pool_label} action contains invalid note"))
+        })?;
 
-        Ok(if is_ironwood {
-            let pk_d = IronwoodDomain::get_pk_d(&note);
-            let esk = IronwoodDomain::derive_esk(&note).expect("Orchard notes are post-ZIP 212");
-            try_output_recovery_with_pkd_esk(
-                &IronwoodDomain::for_pczt_action(action),
-                pk_d,
-                esk,
-                action,
-            )
-        } else {
-            let pk_d = OrchardDomain::get_pk_d(&note);
-            let esk = OrchardDomain::derive_esk(&note).expect("Orchard notes are post-ZIP 212");
-            try_output_recovery_with_pkd_esk(
-                &OrchardDomain::for_pczt_action(action),
-                pk_d,
-                esk,
-                action,
-            )
+        Ok(match pool {
+            ShieldedPool::Orchard => {
+                let pk_d = OrchardDomain::get_pk_d(&note);
+                let esk = OrchardDomain::derive_esk(&note)
+                    .expect("Orchard-shaped notes are post-ZIP 212");
+                try_output_recovery_with_pkd_esk(
+                    &OrchardDomain::for_pczt_action(action),
+                    pk_d,
+                    esk,
+                    action,
+                )
+            }
+            ShieldedPool::Ironwood => {
+                let pk_d = IronwoodDomain::get_pk_d(&note);
+                let esk = IronwoodDomain::derive_esk(&note)
+                    .expect("Orchard-shaped notes are post-ZIP 212");
+                try_output_recovery_with_pkd_esk(
+                    &IronwoodDomain::for_pczt_action(action),
+                    pk_d,
+                    esk,
+                    action,
+                )
+            }
         })
     }
 }
@@ -644,7 +648,7 @@ pub(crate) fn parse_orchard_spend(
 }
 
 #[cfg(feature = "cypherpunk")]
-fn is_wallet_orchard_address(
+pub(crate) fn is_wallet_orchard_address(
     ufvk: &UnifiedFullViewingKey,
     address: &Address,
 ) -> Result<bool, ZcashError> {
@@ -721,10 +725,10 @@ pub(crate) fn parse_orchard_output<P: consensus::Parameters>(
         .inner();
 
     let decode_output = |vk: Option<OutgoingViewingKey>, is_internal_ovk: bool| {
-        match decode_output_enc_ciphertext(action, vk.as_ref())? {
+        match decode_output_enc_ciphertext(action, vk.as_ref(), pool)? {
             Some((note, address, memo)) => {
                 let zec_value = format_zec_value(note.value().inner() as f64);
-                let memo = decode_memo(memo);
+                let memo = decode_memo(memo)?;
 
                 // Check output recipient with decoded address here to save CPU
                 // if the address is not match, return error
@@ -878,7 +882,7 @@ mod legacy_tests {
 }
 
 #[cfg(feature = "cypherpunk")]
-fn decode_memo(memo_bytes: [u8; 512]) -> Option<String> {
+fn decode_memo(memo_bytes: [u8; 512]) -> Result<Option<String>, ZcashError> {
     let first = memo_bytes[0];
 
     //decode as utf8.
@@ -897,21 +901,24 @@ fn decode_memo(memo_bytes: [u8; 512]) -> Option<String> {
         }
         result.reverse();
 
-        return Some(String::from_utf8(result).unwrap());
+        // ZIP 302 requires text-tagged memos to contain valid UTF-8.
+        return String::from_utf8(result)
+            .map(Some)
+            .map_err(|_| ZcashError::InvalidPczt("text memo is not valid UTF-8".to_string()));
     }
 
     if first == 0xF6 {
         let temp_memo = memo_bytes.to_vec();
         let result = temp_memo[1..].iter().find(|&&v| v != 0);
         match result {
-            Some(_v) => return Some(hex::encode(memo_bytes)),
+            Some(_v) => return Ok(Some(hex::encode(memo_bytes))),
             None => {
-                return None;
+                return Ok(None);
             }
         }
     }
 
-    Some(hex::encode(memo_bytes))
+    Ok(Some(hex::encode(memo_bytes)))
 }
 
 #[cfg(feature = "cypherpunk")]
@@ -926,6 +933,18 @@ mod tests {
     };
 
     extern crate std;
+
+    #[test]
+    fn test_decode_memo_rejects_invalid_utf8() {
+        let mut memo = [0u8; 512];
+        memo[0] = 0xC3; // start of a 2-byte UTF-8 sequence...
+        memo[1] = 0x28; // ...followed by an invalid continuation byte
+
+        assert!(matches!(
+            decode_memo(memo),
+            Err(ZcashError::InvalidPczt(msg)) if msg == "text memo is not valid UTF-8"
+        ));
+    }
 
     fn p2sh_output_with_matching_seed_fingerprint(
         seed_fingerprint: [u8; 32],
@@ -968,12 +987,12 @@ mod tests {
         {
             let mut memo = [0u8; 512];
             memo[0] = 0xF6;
-            let result = decode_memo(memo);
+            let result = decode_memo(memo).unwrap();
             assert_eq!(result, None);
         }
         {
             let memo = hex::decode("74657374206b657973746f6e65206d656d6f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap().try_into().unwrap();
-            let result = decode_memo(memo);
+            let result = decode_memo(memo).unwrap();
             assert!(result.is_some());
             assert_eq!(result.unwrap(), "test keystone memo");
         }
@@ -1046,7 +1065,7 @@ mod tests {
             let mut memo = [0u8; 512];
             memo[0] = 0xF6;
             memo[1] = 0x01;
-            let result = decode_memo(memo);
+            let result = decode_memo(memo).unwrap();
             assert!(result.is_some());
             let hex_str = result.unwrap();
             assert!(hex_str.starts_with("f6"));
@@ -1054,7 +1073,7 @@ mod tests {
         {
             let mut memo = [0u8; 512];
             memo[0] = 0xF5;
-            let result = decode_memo(memo);
+            let result = decode_memo(memo).unwrap();
             assert!(result.is_some());
         }
     }
@@ -1105,7 +1124,7 @@ mod tests {
     #[test]
     fn test_decode_memo_empty() {
         let memo = [0u8; 512];
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         let decoded = result.unwrap();
         assert!(decoded.is_empty());
@@ -1114,7 +1133,7 @@ mod tests {
     #[test]
     fn test_decode_memo_full_text() {
         let memo = [b'A'; 512];
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         let decoded = result.unwrap();
         assert_eq!(decoded.len(), 512);
@@ -1125,7 +1144,7 @@ mod tests {
         let mut memo = [0u8; 512];
         let text = b"Hello World";
         memo[..text.len()].copy_from_slice(text);
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "Hello World");
     }
@@ -1135,7 +1154,7 @@ mod tests {
         let mut memo = [0u8; 512];
         let text = "测试中文".as_bytes();
         memo[..text.len()].copy_from_slice(text);
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "测试中文");
     }
@@ -1147,14 +1166,14 @@ mod tests {
         memo[0] = b'A';
         memo[1] = b'B';
         memo[2] = b'C';
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "ABC");
 
         // Test with 0xF5 (should use hex encoding)
         let mut memo = [0u8; 512];
         memo[0] = 0xF5;
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         let hex_str = result.unwrap();
         assert!(hex_str.starts_with("f5"));
@@ -1165,7 +1184,7 @@ mod tests {
         // Test 0xF6 marker with all zeros after it (should return None)
         let mut memo = [0u8; 512];
         memo[0] = 0xF6;
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert_eq!(result, None);
     }
 
@@ -1176,7 +1195,7 @@ mod tests {
         memo[0] = 0xF6;
         memo[1] = 0xFF;
         memo[2] = 0xAB;
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         let hex_str = result.unwrap();
         assert!(hex_str.starts_with("f6ff"));
@@ -1187,7 +1206,7 @@ mod tests {
         let mut memo = [0u8; 512];
         let text = b"Test!@#$%^&*()_+-=[]{}|;:',.<>?/`~";
         memo[..text.len()].copy_from_slice(text);
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "Test!@#$%^&*()_+-=[]{}|;:',.<>?/`~");
     }
@@ -1225,7 +1244,7 @@ mod tests {
         let mut memo = [0u8; 512];
         let text = b"Line1\nLine2\tTabbed";
         memo[..text.len()].copy_from_slice(text);
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "Line1\nLine2\tTabbed");
     }
@@ -1237,7 +1256,7 @@ mod tests {
         for i in 32..=126 {
             memo[i - 32] = i as u8;
         }
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         let decoded = result.unwrap();
         // Should decode all printable ASCII
@@ -1261,7 +1280,7 @@ mod tests {
         let mut memo = [0u8; 512];
         let text = b"Test123!@# ZEC Payment";
         memo[..text.len()].copy_from_slice(text);
-        let result = decode_memo(memo);
+        let result = decode_memo(memo).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "Test123!@# ZEC Payment");
     }

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -208,9 +208,7 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
 ) -> Result<ParsedPczt, ZcashError> {
     super::validate_supported_pczt(pczt)?;
     let mut parsed_orchard = None;
-    #[cfg(zcash_unstable = "nu6.3")]
     let mut parsed_ironwood = None;
-    #[cfg(zcash_unstable = "nu6.3")]
     let should_process_ironwood = super::pczt_should_process_ironwood(pczt);
     let mut parsed_transparent = None;
 
@@ -227,7 +225,6 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
             Ok(())
         })
         .map_err(map_orchard_verifier_error)?;
-    #[cfg(zcash_unstable = "nu6.3")]
     let verifier = if should_process_ironwood {
         verifier
             .with_ironwood(|bundle| {
@@ -274,7 +271,6 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
             .iter()
             .fold(0, |acc, to| acc + to.get_amount());
     }
-    #[cfg(zcash_unstable = "nu6.3")]
     if let Some(ironwood) = &parsed_ironwood {
         total_change_value += ironwood
             .get_to()
@@ -331,11 +327,6 @@ pub fn parse_pczt_cypherpunk<P: consensus::Parameters>(
     let fee_value = format_zec_value((total_input_value - total_output_value) as f64);
 
     let has_sapling = !pczt.sapling().spends().is_empty() || !pczt.sapling().outputs().is_empty();
-
-    #[cfg(zcash_unstable = "nu6.3")]
-    let parsed_ironwood = parsed_ironwood;
-    #[cfg(not(zcash_unstable = "nu6.3"))]
-    let parsed_ironwood = None;
 
     Ok(ParsedPczt::new(
         parsed_transparent,
@@ -424,7 +415,6 @@ pub fn parse_pczt_multi_coins<P: consensus::Parameters>(
 
 #[cfg(feature = "multi_coins")]
 fn reject_legacy_parse_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
-    #[cfg(zcash_unstable = "nu6.3")]
     {
         // The legacy multi-coins parser only displays transparent data. Reject any
         // shielded (Sapling/Orchard/Ironwood) or V6 PCZT instead of showing an
@@ -822,7 +812,6 @@ mod legacy_tests {
         zcash_protocol::consensus::{BranchId, MainNetwork, NetworkConstants},
     };
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_parse_rejects_v6_pczt() {
         let pczt = Creator::new(

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -81,7 +81,7 @@ fn map_transparent_verifier_error(
     }
 }
 
-fn format_zec_value(value: f64) -> String {
+pub(crate) fn format_zec_value(value: f64) -> String {
     let zec_value = format!("{:.8}", value / ZEC_DIVIDER as f64);
     let zec_value = zec_value
         .trim_end_matches('0')

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -90,7 +90,6 @@ pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
 
 #[cfg(not(feature = "cypherpunk"))]
 fn reject_legacy_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
-    #[cfg(zcash_unstable = "nu6.3")]
     {
         // The legacy helper below carries the pre-NU6.3 transparent sighash implementation.
         // It must not be used for shielded (Sapling/Orchard/Ironwood) or V6 PCZTs.
@@ -265,7 +264,6 @@ pub fn sign_and_redact_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
     let seed_fingerprint =
         calculate_seed_fingerprint(seed).map_err(|e| ZcashError::SigningError(e.to_string()))?;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let process_ironwood = super::pczt_should_process_ironwood(&pczt);
 
     // The orchard signer handles both the transparent inputs and the Orchard bundle
@@ -279,9 +277,7 @@ pub fn sign_and_redact_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
     let signer = pczt_ext::sign_transparent(signer, &orchard_signer)?;
     let signer = pczt_ext::sign_orchard(signer, &orchard_signer)?;
 
-    #[cfg(zcash_unstable = "nu6.3")]
     let ironwood_signer = SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Ironwood);
-    #[cfg(zcash_unstable = "nu6.3")]
     let signer = if process_ironwood {
         pczt_ext::sign_ironwood(signer, &ironwood_signer)?
     } else {
@@ -289,7 +285,6 @@ pub fn sign_and_redact_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
     };
 
     let mut signed = orchard_signer.signed.get();
-    #[cfg(zcash_unstable = "nu6.3")]
     {
         signed += ironwood_signer.signed.get();
     }
@@ -318,7 +313,6 @@ fn stamp_and_redact(pczt: Pczt) -> Pczt {
     // signing response does not need. This keeps the QR round trip small while
     // preserving signatures and global proprietary fields for the wallet.
     let redactor = Redactor::new(stamped_pczt).redact_orchard_with(redact_orchard_bundle);
-    #[cfg(zcash_unstable = "nu6.3")]
     let redactor = redactor.redact_ironwood_with(redact_orchard_bundle);
 
     redactor
@@ -446,12 +440,10 @@ mod tests {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     fn signable_sample_pczt() -> crate::pczt::test_support::SamplePczt {
         crate::pczt::test_support::sample_ironwood_pczt()
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_invalid_seed_fingerprint() {
         let sample = signable_sample_pczt();
@@ -467,7 +459,6 @@ mod tests {
     // bit-exact for an Orchard-only tx, a dual-pool Orchard->Ironwood migration, and an
     // Ironwood spend, so any upstream sighash change turns CI red instead of silently
     // producing wrong signatures on-device.
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_lean_sighash_control_orchard_only() {
         let sample = crate::pczt::test_support::sample_orchard_change_pczt();
@@ -483,7 +474,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_lean_sighash_migration_dualpool() {
         let sample = crate::pczt::test_support::sample_migration_pczt();
@@ -499,7 +489,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_lean_sighash_ironwood_spend() {
         // Exercises a populated Ironwood bundle with a real spend action.
@@ -518,7 +507,6 @@ mod tests {
 
     // End-to-end: an Orchard->Ironwood migration signs the Orchard spend and leaves the
     // output-only Ironwood bundle unsigned.
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_migration_signs_orchard_only() {
         let sample = crate::pczt::test_support::sample_migration_pczt();
@@ -543,7 +531,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_ironwood_spend() {
         let sample = crate::pczt::test_support::sample_ironwood_pczt();
@@ -609,7 +596,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_ironwood_spend_rejects_unsupported_zip32_path() {
         let sample = crate::pczt::test_support::sample_ironwood_pczt();
@@ -627,7 +613,6 @@ mod tests {
         }
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_ironwood_spend_ignores_dummy_zip32_metadata() {
         let sample = crate::pczt::test_support::sample_ironwood_pczt();
@@ -650,7 +635,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn test_sign_pczt_orchard_change_output_spend() {
         let sample = crate::pczt::test_support::sample_orchard_change_pczt();
@@ -671,7 +655,6 @@ mod tests {
         );
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     fn pczt_with_min_version(min_version: &[u8]) -> Pczt {
         let sample = signable_sample_pczt();
         let base = Pczt::parse(&sample.bytes).unwrap();
@@ -683,12 +666,10 @@ mod tests {
             .finish()
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     fn test_seed() -> Vec<u8> {
         [7u8; 32].to_vec()
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn firmware_equal_version_stamps_response() {
         let pczt = pczt_with_min_version(&KEYSTONE_FW_VERSION.encode());
@@ -710,7 +691,6 @@ mod tests {
         assert_eq!(request_min, &KEYSTONE_FW_VERSION.encode().to_vec());
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn firmware_older_min_version_still_stamps_response() {
         let pczt = pczt_with_min_version(&[1, 0, 0]);
@@ -725,7 +705,6 @@ mod tests {
         assert_eq!(stamp, &KEYSTONE_FW_VERSION.encode().to_vec());
     }
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn malformed_min_version_round_trips_and_stamps() {
         let pczt = pczt_with_min_version(&[1, 2]);
@@ -757,7 +736,6 @@ mod legacy_tests {
         zcash_protocol::consensus::{BranchId, MainNetwork, NetworkConstants},
     };
 
-    #[cfg(zcash_unstable = "nu6.3")]
     #[test]
     fn legacy_signing_rejects_v6_pczt() {
         let pczt = Creator::new(

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -933,11 +933,12 @@ mod legacy_tests {
             BranchId::Nu6_3.into(),
             10,
             MainNetwork.coin_type(),
-            [0; 32],
-            [0; 32],
+            None,
+            None,
         )
         .unwrap()
-        .build();
+        .build()
+        .unwrap();
 
         let result = sign_pczt(pczt, &[7u8; 32]);
 

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -31,7 +31,15 @@ use zcash_vendor::{
 };
 
 #[cfg(feature = "cypherpunk")]
-use {blake2b_simd::Hash, core::cell::Cell, core::cell::RefCell, rand_core::OsRng};
+use {
+    blake2b_simd::Hash,
+    core::{
+        cell::{Cell, RefCell},
+        mem::MaybeUninit,
+    },
+    rand_core::OsRng,
+    zeroize::Zeroize,
+};
 
 use crate::{errors::ZcashError, version::KEYSTONE_FW_VERSION};
 
@@ -102,6 +110,85 @@ fn reject_legacy_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     Ok(())
 }
 
+/// One cached spend authorizing key slot, scrubbed on replacement and drop.
+///
+/// `SpendAuthorizingKey` bottoms out in reddsa's `Copy` `SigningKey`, which
+/// holds the secret ask scalar and has no `Zeroize` or `Drop` of its own, so a
+/// plainly-dropped cache would leave the scalar bytes behind in memory.
+#[cfg(feature = "cypherpunk")]
+struct AskCacheSlot {
+    account: Option<zcash_vendor::zip32::AccountId>,
+    // `MaybeUninit` makes every post-scrub bit pattern valid without depending
+    // on private Orchard/reddsa layout invariants. The slot invariant is that
+    // this field is initialized exactly when `account` is `Some`.
+    ask: MaybeUninit<orchard::keys::SpendAuthorizingKey>,
+}
+
+// `MaybeUninit` deliberately suppresses the wrapped value's destructor. Fail
+// the build if a dependency bump gives either secret type drop glue; any change
+// to an indirect or owning representation requires a fresh zeroization audit
+// rather than silently retaining this type-specific strategy.
+#[cfg(feature = "cypherpunk")]
+const _: () = assert!(!core::mem::needs_drop::<orchard::keys::SpendAuthorizingKey>());
+#[cfg(feature = "cypherpunk")]
+const _: () = assert!(!core::mem::needs_drop::<orchard::keys::SpendingKey>());
+
+#[cfg(feature = "cypherpunk")]
+impl AskCacheSlot {
+    fn empty() -> Self {
+        Self {
+            account: None,
+            ask: MaybeUninit::uninit(),
+        }
+    }
+
+    fn get(
+        &self,
+        account: zcash_vendor::zip32::AccountId,
+    ) -> Option<&orchard::keys::SpendAuthorizingKey> {
+        if self.account == Some(account) {
+            // SAFETY: `account` is only set to `Some` after `ask` is written.
+            Some(unsafe { self.ask.assume_init_ref() })
+        } else {
+            None
+        }
+    }
+
+    fn replace(
+        &mut self,
+        account: zcash_vendor::zip32::AccountId,
+        ask: orchard::keys::SpendAuthorizingKey,
+    ) -> &orchard::keys::SpendAuthorizingKey {
+        self.account = None;
+        self.ask.zeroize();
+        self.ask.write(ask);
+        self.account = Some(account);
+
+        // SAFETY: the value was written immediately above, before `account`
+        // was set to `Some`.
+        unsafe { self.ask.assume_init_ref() }
+    }
+}
+
+#[cfg(feature = "cypherpunk")]
+impl Drop for AskCacheSlot {
+    fn drop(&mut self) {
+        self.account = None;
+        self.ask.zeroize();
+    }
+}
+
+/// One scrubbed spend authorizing key slot shared by the pool signing passes.
+#[cfg(feature = "cypherpunk")]
+struct SpendAuthCache(RefCell<AskCacheSlot>);
+
+#[cfg(feature = "cypherpunk")]
+impl SpendAuthCache {
+    fn new() -> Self {
+        Self(RefCell::new(AskCacheSlot::empty()))
+    }
+}
+
 /// Lean signer for the cypherpunk path. Drives the shallow `low_level_signer` and
 /// derives keys / signs each action in place, instead of materializing a full
 /// `RoleSigner` (which reconstructs the whole transaction to compute the sighash and
@@ -113,16 +200,13 @@ struct SeedSigner<'a> {
     seed: &'a [u8],
     seed_fingerprint: [u8; 32],
     pool: ShieldedPool,
-    /// Per-account spend authorizing key cache. The seed fingerprint and the account
-    /// key depend only on (seed, account), not on the action, so a bundle with many
-    /// actions for one account derives once. Interior mutability because the
-    /// `PcztSigner` trait signs through `&self`.
-    ask_cache: RefCell<
-        Vec<(
-            zcash_vendor::zip32::AccountId,
-            orchard::keys::SpendAuthorizingKey,
-        )>,
-    >,
+    /// Single-slot cache for the spend authorizing key. The key depends only on
+    /// (seed, account), not on the action or pool, so consecutive actions for one
+    /// account derive once and the Orchard and Ironwood passes can share it. A
+    /// change of account replaces and scrubs the old key. Interior mutability is
+    /// needed because `PcztSigner` signs through `&self`; the slot lives inline
+    /// in the signing call and never touches the heap.
+    ask_cache: &'a SpendAuthCache,
     /// Number of authorizations produced, so `sign_pczt` can distinguish "nothing of
     /// ours to sign" (`PcztNoMyInputs`) from a successful signing.
     signed: Cell<usize>,
@@ -130,40 +214,63 @@ struct SeedSigner<'a> {
 
 #[cfg(feature = "cypherpunk")]
 impl<'a> SeedSigner<'a> {
-    fn new(seed: &'a [u8], seed_fingerprint: [u8; 32], pool: ShieldedPool) -> Self {
+    fn new(
+        seed: &'a [u8],
+        seed_fingerprint: [u8; 32],
+        pool: ShieldedPool,
+        ask_cache: &'a SpendAuthCache,
+    ) -> Self {
         Self {
             seed,
             seed_fingerprint,
             pool,
-            ask_cache: RefCell::new(Vec::new()),
+            ask_cache,
             signed: Cell::new(0),
         }
     }
 
-    fn spend_authorizing_key(
+    /// Derives the spend authorizing key for `account_index` from the seed,
+    /// scrubbing the intermediate spending key before returning.
+    fn derive_spend_authorizing_key(
         &self,
         account_index: zcash_vendor::zip32::AccountId,
     ) -> Result<orchard::keys::SpendAuthorizingKey, ZcashError> {
-        if let Some((_, ask)) = self
-            .ask_cache
-            .borrow()
-            .iter()
-            .find(|(cached, _)| *cached == account_index)
-        {
-            return Ok(ask.clone());
-        }
-        let osk = orchard::keys::SpendingKey::from_zip32_seed(self.seed, 133, account_index)
-            .map_err(|e| {
-                ZcashError::SigningError(format!(
-                    "failed to derive {} spending key: {e:?}",
-                    self.pool.label()
-                ))
-            })?;
-        let ask = orchard::keys::SpendAuthorizingKey::from(&osk);
-        self.ask_cache
-            .borrow_mut()
-            .push((account_index, ask.clone()));
+        let mut osk = MaybeUninit::new(
+            orchard::keys::SpendingKey::from_zip32_seed(self.seed, 133, account_index).map_err(
+                |e| {
+                    ZcashError::SigningError(format!(
+                        "failed to derive {} spending key: {e:?}",
+                        self.pool.label()
+                    ))
+                },
+            )?,
+        );
+        // SAFETY: `osk` was initialized immediately above and is only scrubbed
+        // after this borrow ends.
+        let ask = orchard::keys::SpendAuthorizingKey::from(unsafe { osk.assume_init_ref() });
+        osk.zeroize();
         Ok(ask)
+    }
+
+    /// Looks up (or derives and caches) the spend authorizing key for
+    /// `account_index` and runs `f` against it in place, so no unscrubbed
+    /// copies of the key are handed out. On an account change, the slot scrubs
+    /// the old key in place before storing the replacement.
+    fn with_spend_authorizing_key<R>(
+        &self,
+        account_index: zcash_vendor::zip32::AccountId,
+        f: impl FnOnce(&orchard::keys::SpendAuthorizingKey) -> Result<R, ZcashError>,
+    ) -> Result<R, ZcashError> {
+        // Mutably borrowed across `f`, which is fine: `f` only signs and never
+        // re-enters the cache.
+        let mut cache = self.ask_cache.0.borrow_mut();
+        if cache.get(account_index).is_none() {
+            let ask = self.derive_spend_authorizing_key(account_index)?;
+            cache.replace(account_index, ask);
+        }
+        f(cache
+            .get(account_index)
+            .expect("cache contains the requested account"))
     }
 }
 
@@ -229,16 +336,17 @@ impl PcztSigner for SeedSigner<'_> {
             return Ok(());
         };
 
-        let ask = self.spend_authorizing_key(account_index)?;
-        action
-            .sign(
-                hash.as_bytes().try_into().expect("sighash is 32 bytes"),
-                &ask,
-                OsRng,
-            )
-            .map_err(|e| {
-                ZcashError::SigningError(format!("failed to sign {pool_label} action: {e:?}"))
-            })?;
+        self.with_spend_authorizing_key(account_index, |ask| {
+            action
+                .sign(
+                    hash.as_bytes().try_into().expect("sighash is 32 bytes"),
+                    ask,
+                    OsRng,
+                )
+                .map_err(|e| {
+                    ZcashError::SigningError(format!("failed to sign {pool_label} action: {e:?}"))
+                })
+        })?;
         self.signed.set(self.signed.get() + 1);
         Ok(())
     }
@@ -266,32 +374,33 @@ pub fn sign_and_redact_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Pczt> {
 
     let process_ironwood = super::pczt_should_process_ironwood(&pczt);
 
-    // The orchard signer handles both the transparent inputs and the Orchard bundle
-    // (the pool only changes error labels for shielded actions). Ironwood gets its own.
-    let orchard_signer = SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Orchard);
+    // Keep one scrubbed key slot and one lean signer for both pool passes.
+    let ask_cache = SpendAuthCache::new();
+    let mut seed_signer =
+        SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Orchard, &ask_cache);
 
-    // Propagate the signer error directly (it is already a ZcashError): the strict
-    // validation in SeedSigner::sign_orchard returns ZcashError::InvalidPczt for bad
-    // ZIP 32 paths, which callers/tests distinguish from generic SigningError.
+    // The Orchard pass also handles transparent inputs; the pool only changes
+    // error labels and ZIP 32 matching for shielded actions. Propagate signer
+    // errors directly so strict path validation remains `InvalidPczt`.
     let signer = low_level_signer::Signer::new(pczt);
-    let signer = pczt_ext::sign_transparent(signer, &orchard_signer)?;
-    let signer = pczt_ext::sign_orchard(signer, &orchard_signer)?;
+    let signer = pczt_ext::sign_transparent(signer, &seed_signer)?;
+    let signer = pczt_ext::sign_orchard(signer, &seed_signer)?;
 
-    let ironwood_signer = SeedSigner::new(seed, seed_fingerprint, ShieldedPool::Ironwood);
     let signer = if process_ironwood {
-        pczt_ext::sign_ironwood(signer, &ironwood_signer)?
+        seed_signer.pool = ShieldedPool::Ironwood;
+        pczt_ext::sign_ironwood(signer, &seed_signer)?
     } else {
         signer
     };
 
-    let mut signed = orchard_signer.signed.get();
-    {
-        signed += ironwood_signer.signed.get();
-    }
-    if signed == 0 {
+    if seed_signer.signed.get() == 0 {
         return Err(ZcashError::PcztNoMyInputs);
     }
 
+    // The low-level signer does not borrow the cache, so scrub the cached key
+    // before finishing and redacting the response.
+    drop(seed_signer);
+    drop(ask_cache);
     Ok(stamp_and_redact(signer.finish()))
 }
 
@@ -438,6 +547,88 @@ mod tests {
             Err(ZcashError::InvalidPczt(message)) if message == expected => {}
             other => panic!("unexpected InvalidPczt result: {other:?}"),
         }
+    }
+
+    use zcash_vendor::{
+        pasta_curves::{group::ff::Field, Fq},
+        zip32,
+    };
+
+    /// Extracts the ask scalar bytes via public API only: randomizing by zero
+    /// returns `rsk = ask + 0 = ask`.
+    fn ask_scalar_bytes(ask: &orchard::keys::SpendAuthorizingKey) -> [u8; 32] {
+        (&ask.randomize(&Fq::ZERO)).into()
+    }
+
+    #[test]
+    fn test_ask_cache_slot_zeroizes_on_drop() {
+        let seed = [7u8; 32];
+        let osk = orchard::keys::SpendingKey::from_zip32_seed(&seed, 133, zip32::AccountId::ZERO)
+            .unwrap();
+        let mut storage = MaybeUninit::<AskCacheSlot>::uninit();
+        let slot = storage.write(AskCacheSlot::empty());
+        slot.replace(
+            zip32::AccountId::ZERO,
+            orchard::keys::SpendAuthorizingKey::from(&osk),
+        );
+        assert_ne!(
+            ask_scalar_bytes(slot.get(zip32::AccountId::ZERO).unwrap()),
+            [0u8; 32],
+            "a real ask must not start out zero"
+        );
+
+        // The outer `MaybeUninit` keeps the backing storage alive after the
+        // slot itself is dropped.
+        unsafe { core::ptr::drop_in_place(storage.as_mut_ptr()) };
+
+        // SAFETY: `Drop` initialized every byte of the still-allocated
+        // `MaybeUninit<SpendAuthorizingKey>` storage to zero. `addr_of!`
+        // projects the dropped slot without reading it.
+        let bytes = unsafe {
+            let ask_storage = core::ptr::addr_of!((*storage.as_ptr()).ask);
+            core::slice::from_raw_parts(
+                ask_storage.cast::<u8>(),
+                core::mem::size_of::<MaybeUninit<orchard::keys::SpendAuthorizingKey>>(),
+            )
+        };
+        assert!(
+            bytes.iter().all(|b| *b == 0),
+            "cached ask storage must be fully scrubbed"
+        );
+    }
+
+    #[test]
+    fn test_ask_cache_shared_single_slot_consistent() {
+        let seed = [7u8; 32];
+        let fingerprint = calculate_seed_fingerprint(&seed).unwrap();
+        let cache = SpendAuthCache::new();
+        let mut signer = SeedSigner::new(&seed, fingerprint, ShieldedPool::Orchard, &cache);
+        let account = |i: u32| zip32::AccountId::try_from(i).unwrap();
+        let fresh = |i: u32| {
+            let osk = orchard::keys::SpendingKey::from_zip32_seed(&seed, 133, account(i)).unwrap();
+            ask_scalar_bytes(&orchard::keys::SpendAuthorizingKey::from(&osk))
+        };
+
+        // Empty-slot miss, hit, replace-on-miss, hit-after-replace, and
+        // cross-pool reuse all hand out exactly the key a fresh derivation
+        // produces. The same signer and slot are reused across pool passes.
+        for (pool, i) in [
+            (ShieldedPool::Orchard, 0u32),
+            (ShieldedPool::Orchard, 0),
+            (ShieldedPool::Ironwood, 1),
+            (ShieldedPool::Ironwood, 1),
+            (ShieldedPool::Orchard, 0),
+            (ShieldedPool::Ironwood, 2),
+        ] {
+            signer.pool = pool;
+            let bytes = signer
+                .with_spend_authorizing_key(account(i), |ask| Ok(ask_scalar_bytes(ask)))
+                .unwrap();
+            assert_eq!(bytes, fresh(i), "account {i} must match a fresh derivation");
+        }
+
+        // The slot holds exactly the most recently used account's key.
+        assert_eq!(cache.0.borrow().account, Some(account(2)));
     }
 
     fn signable_sample_pczt() -> crate::pczt::test_support::SamplePczt {

--- a/rust/keystore/src/algorithms/zcash/mod.rs
+++ b/rust/keystore/src/algorithms/zcash/mod.rs
@@ -2,7 +2,6 @@ use core::str::FromStr;
 
 use alloc::string::{String, ToString};
 use bitcoin::bip32::{ChildNumber, DerivationPath};
-use rand_core::{CryptoRng, RngCore};
 use zcash_vendor::{
     zcash_keys::keys::UnifiedSpendingKey,
     zcash_protocol::consensus,
@@ -10,12 +9,6 @@ use zcash_vendor::{
 };
 
 use crate::algorithms::utils::is_all_zero_or_ff;
-
-#[cfg(feature = "cypherpunk")]
-use zcash_vendor::orchard::{
-    self,
-    keys::{SpendAuthorizingKey, SpendingKey},
-};
 
 use crate::errors::{KeystoreError, Result};
 
@@ -68,39 +61,6 @@ pub fn calculate_seed_fingerprint(seed: &[u8]) -> Result<[u8; 32]> {
         "Invalid seed, cannot calculate ZIP-32 Seed Fingerprint".into(),
     ))?;
     Ok(sfp.to_bytes())
-}
-
-#[cfg(feature = "cypherpunk")]
-pub fn sign_message_orchard<R: RngCore + CryptoRng>(
-    action: &mut orchard::pczt::Action,
-    seed: &[u8],
-    sighash: [u8; 32],
-    path: &[zip32::ChildIndex],
-    rng: R,
-) -> Result<()> {
-    ensure_non_trivial_seed(seed)?;
-    let coin_type = 133;
-
-    if path.len() == 3
-        && path[0] == zip32::ChildIndex::hardened(32)
-        && path[1] == zip32::ChildIndex::hardened(coin_type)
-    {
-        let account_id = zip32::AccountId::try_from(path[2].index() - (1 << 31)).expect("valid");
-
-        let osk = SpendingKey::from_zip32_seed(seed, coin_type, account_id).unwrap();
-
-        let osak = SpendAuthorizingKey::from(&osk);
-
-        action
-            .sign(sighash, &osak, rng)
-            .map_err(|e| KeystoreError::ZcashOrchardSign(format!("{e:?}")))
-    } else {
-        // Keystone only generates UFVKs at the above path; ignore all other signature
-        // requests.
-        Err(KeystoreError::ZcashOrchardSign(format!(
-            "invalid orchard account path: {path:?}"
-        )))
-    }
 }
 
 #[cfg(feature = "cypherpunk")]

--- a/rust/rust_c/Cargo.toml
+++ b/rust/rust_c/Cargo.toml
@@ -26,6 +26,7 @@ aes = { workspace = true }
 cbc = { workspace = true }
 cipher = { workspace = true }
 minicbor = { workspace = true }
+postcard = { version = "1.0.3", default-features = false, optional = true }
 #keystone owned
 sim_qr_reader = { workspace = true, optional = true }
 keystore = { workspace = true, default-features = false }
@@ -83,7 +84,7 @@ sui = ["dep:app_sui"]
 ton = ["dep:app_ton"]
 tron = ["dep:app_tron"]
 xrp = ["dep:app_xrp"]
-zcash = ["dep:app_zcash", "dep:zcash_vendor"]
+zcash = ["dep:app_zcash", "dep:postcard", "dep:zcash_vendor"]
 zcash_multi_coins = ["zcash", "app_zcash/multi_coins"]
 zcash_cypherpunk = ["zcash", "app_zcash/cypherpunk"]
 monero = ["dep:app_monero"]

--- a/rust/rust_c/src/common/ur.rs
+++ b/rust/rust_c/src/common/ur.rs
@@ -715,6 +715,8 @@ impl_response!(URParseMultiResult);
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
 
     #[test]
@@ -746,18 +748,35 @@ mod tests {
             full_result.free();
         }
 
-        let zcash_result = UREncodeResult::encode_full_response(
+        let zcash_sign_result = UREncodeResult::encode_full_response(
             vec![0; FRAGMENT_UNLIMITED_LENGTH + 1],
             "zcash-sign-result".to_string(),
         );
-        assert_eq!(zcash_result.error_code, ErrorCodes::Success as u32);
-        assert!(!zcash_result.is_multi_part);
-        assert!(zcash_result.encoder.is_null());
-        let zcash_data = unsafe { recover_c_char(zcash_result.data) };
+        assert_eq!(zcash_sign_result.error_code, ErrorCodes::Success as u32);
+        assert!(!zcash_sign_result.is_multi_part);
+        assert!(zcash_sign_result.encoder.is_null());
+        let zcash_data = unsafe { recover_c_char(zcash_sign_result.data) };
         assert!(zcash_data.starts_with("UR:ZCASH-SIGN-RESULT/"));
         assert!(!zcash_data.contains("/1-"));
         unsafe {
-            zcash_result.free();
+            zcash_sign_result.free();
+        }
+
+        let zcash_batch_sig_result = UREncodeResult::encode_full_response(
+            vec![0; FRAGMENT_UNLIMITED_LENGTH + 1],
+            "zcash-batch-sig-result".to_string(),
+        );
+        assert_eq!(
+            zcash_batch_sig_result.error_code,
+            ErrorCodes::Success as u32
+        );
+        assert!(!zcash_batch_sig_result.is_multi_part);
+        assert!(zcash_batch_sig_result.encoder.is_null());
+        let zcash_data = unsafe { recover_c_char(zcash_batch_sig_result.data) };
+        assert!(zcash_data.starts_with("UR:ZCASH-BATCH-SIG-RESULT/"));
+        assert!(!zcash_data.contains("/1-"));
+        unsafe {
+            zcash_batch_sig_result.free();
         }
     }
 }

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -37,6 +37,8 @@ use zeroize::Zeroize;
 const ZCASH_BATCH_MAX_PCZTS: usize = 50;
 #[cfg(feature = "cypherpunk")]
 const ZCASH_BATCH_MAX_TOTAL_BYTES: usize = 512 * 1024;
+#[cfg(feature = "cypherpunk")]
+const ZCASH_BATCH_REQUEST_HEADER_LEN: usize = 12;
 
 #[no_mangle]
 pub unsafe extern "C" fn derive_zcash_ufvk(
@@ -284,10 +286,41 @@ fn validate_zcash_batch_envelope(request_id: &[u8], data: &[u8]) -> Result<(), R
     Ok(())
 }
 
+/// Rejects an oversized top-level count before Postcard allocates the PCZT vector.
+#[cfg(feature = "cypherpunk")]
+fn validate_zcash_batch_request_count(data: &[u8]) -> Result<(), RustCError> {
+    let Some(header) = data.get(..ZCASH_BATCH_REQUEST_HEADER_LEN) else {
+        return Ok(());
+    };
+
+    // Leave malformed or unknown headers to the canonical parser so it retains
+    // its existing error. The pinned parser recognizes PCZT versions 1 and 2.
+    let pczt_version = u32::from_le_bytes(header[8..12].try_into().unwrap());
+    if &header[..8] != b"PCZB\x01\0\0\0" || !matches!(pczt_version, 1 | 2) {
+        return Ok(());
+    }
+
+    // Decode only the sequence length; malformed bodies remain the canonical
+    // parser's responsibility.
+    let Ok((pczt_count, _)) =
+        postcard::take_from_bytes::<usize>(&data[ZCASH_BATCH_REQUEST_HEADER_LEN..])
+    else {
+        return Ok(());
+    };
+    if pczt_count > ZCASH_BATCH_MAX_PCZTS {
+        return Err(RustCError::UnsupportedTransaction(format!(
+            "Zcash batch supports at most {ZCASH_BATCH_MAX_PCZTS} PCZTs"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Parses the bounded outer registry into the PCZT crate's batch request.
 #[cfg(feature = "cypherpunk")]
 fn parse_zcash_batch_registry(registry: &ZcashSignBatch) -> Result<BatchSignRequest, RustCError> {
     validate_zcash_batch_envelope(registry.get_request_id(), registry.get_data())?;
+    validate_zcash_batch_request_count(registry.get_data())?;
     BatchSignRequest::parse(registry.get_data())
         .map_err(|e| RustCError::InvalidData(format!("invalid PCZT batch request: {e:?}")))
 }
@@ -968,6 +1001,30 @@ mod tests {
             Err(RustCError::UnsupportedTransaction(message))
                 if message.contains("batch request exceeds")
         ));
+    }
+
+    #[cfg(feature = "cypherpunk")]
+    #[test]
+    fn test_zcash_batch_rejects_count_before_parse() {
+        let mut request = empty_batch_request();
+        request[ZCASH_BATCH_REQUEST_HEADER_LEN] = ZCASH_BATCH_MAX_PCZTS as u8;
+        validate_zcash_batch_request_count(&request).unwrap();
+
+        let mut overlong_small_count = empty_batch_request();
+        overlong_small_count[ZCASH_BATCH_REQUEST_HEADER_LEN] = 0x81;
+        overlong_small_count.push(0);
+        validate_zcash_batch_request_count(&overlong_small_count).unwrap();
+
+        // The body declares 51 PCZTs but omits them. Reaching the count error
+        // proves the limit is enforced before the full request is parsed.
+        request[ZCASH_BATCH_REQUEST_HEADER_LEN] += 1;
+        let registry = ZcashSignBatch::new(vec![0xaa], request);
+        assert_eq!(
+            parse_zcash_batch_registry(&registry).unwrap_err(),
+            RustCError::UnsupportedTransaction(format!(
+                "Zcash batch supports at most {ZCASH_BATCH_MAX_PCZTS} PCZTs"
+            ))
+        );
     }
 
     #[cfg(feature = "cypherpunk")]

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -402,8 +402,9 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
         Ok(items) => items,
         Err(e) => return TransactionParseResult::from(e).c_ptr(),
     };
-    // FFI display structs leak if dropped (freed via free_TransactionParseResult_*,
-    // not Drop), so build them only after every message has parsed.
+    // Convert only after every message has parsed. These FFI values own heap
+    // allocations freed by `free_TransactionParseResult_DisplayZcashBatch`, not
+    // Rust `Drop`; an early return after partial conversion would leak memory.
     let display_items: Vec<DisplayPczt> = parsed_items.iter().map(DisplayPczt::from).collect();
 
     TransactionParseResult::success(DisplayZcashBatch::from(display_items).c_ptr()).c_ptr()

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -23,20 +23,20 @@ use structs::DisplayPczt;
 use structs::DisplayZcashBatch;
 use structs::ZcashCheckedPczt;
 use ur_registry::traits::RegistryItem;
+use ur_registry::zcash::zcash_batch_sig_result::ZcashBatchSigResult;
 use ur_registry::zcash::zcash_pczt::ZcashPczt;
-use ur_registry::zcash::zcash_sign_batch::{
-    ZcashSignBatch, ZcashSignMessage, ZCASH_SIGN_BATCH_NETWORK_MAINNET, ZCASH_SIGN_BATCH_VERSION,
-    ZCASH_SIGN_MESSAGE_KIND_PCZT_V1,
-};
-use ur_registry::zcash::zcash_sign_result::{ZcashSignMessageResult, ZcashSignResult};
-use zcash_vendor::zcash_protocol::consensus::MainNetwork;
+use ur_registry::zcash::zcash_sign_batch::ZcashSignBatch;
+#[cfg(feature = "cypherpunk")]
+use zcash_vendor::pczt::roles::signer::batch::{BatchSignRequest, BatchSignResponse};
+use zcash_vendor::{pczt::Pczt, zcash_protocol::consensus::MainNetwork};
 use zeroize::Zeroize;
 
-// Batch memory is intentionally bounded by message count rather than separate
-// byte caps. With the supported pczt-v1 messages, a full 35-message batch used
-// about 35% of RAM on target hardware. Revisit this if new message kinds or
-// substantially larger payload encodings are added.
-const ZCASH_BATCH_MAX_MESSAGES: usize = 35;
+// Cap both per-PCZT overhead and variable-size payload data to leave headroom
+// in shared device memory while processing a batch.
+#[cfg(feature = "cypherpunk")]
+const ZCASH_BATCH_MAX_PCZTS: usize = 50;
+#[cfg(feature = "cypherpunk")]
+const ZCASH_BATCH_MAX_TOTAL_BYTES: usize = 512 * 1024;
 
 #[no_mangle]
 pub unsafe extern "C" fn derive_zcash_ufvk(
@@ -207,82 +207,121 @@ pub unsafe extern "C" fn parse_zcash_tx_multi_coins(
     }
 }
 
-fn validate_zcash_batch(batch: &ZcashSignBatch) -> Result<(), RustCError> {
-    let messages = batch.get_messages();
-    if batch.get_version() != ZCASH_SIGN_BATCH_VERSION {
-        return Err(RustCError::UnsupportedTransaction(format!(
-            "unsupported Zcash batch version {}",
-            batch.get_version()
-        )));
-    }
-    if batch.get_network() != ZCASH_SIGN_BATCH_NETWORK_MAINNET {
-        return Err(RustCError::UnsupportedTransaction(
-            "only Zcash mainnet batch signing is supported".to_string(),
-        ));
-    }
-    if batch.get_request_id().is_empty() {
+/// Enforces the count, canonical byte, and exact payload uniqueness limits.
+#[cfg(feature = "cypherpunk")]
+fn validate_zcash_batch_payloads(payloads: &[Vec<u8>]) -> Result<(), RustCError> {
+    if payloads.is_empty() {
         return Err(RustCError::InvalidData(
-            "Zcash batch has no request id".to_string(),
+            "Zcash batch has no PCZTs".to_string(),
         ));
     }
-    if !batch.get_atomic() {
-        return Err(RustCError::UnsupportedTransaction(
-            "Zcash batch signing requires atomic=true".to_string(),
-        ));
-    }
-    if messages.is_empty() {
-        return Err(RustCError::InvalidData(
-            "Zcash batch has no messages".to_string(),
-        ));
-    }
-    if messages.len() > ZCASH_BATCH_MAX_MESSAGES {
+    if payloads.len() > ZCASH_BATCH_MAX_PCZTS {
         return Err(RustCError::UnsupportedTransaction(format!(
-            "Zcash batch supports at most {ZCASH_BATCH_MAX_MESSAGES} messages"
+            "Zcash batch supports at most {ZCASH_BATCH_MAX_PCZTS} PCZTs"
         )));
     }
 
-    for (index, message) in messages.iter().enumerate() {
-        if message.get_kind() != ZCASH_SIGN_MESSAGE_KIND_PCZT_V1 {
+    let mut total_payload_bytes = 0usize;
+    let mut payload_digests = Vec::with_capacity(payloads.len());
+    for (index, payload) in payloads.iter().enumerate() {
+        if payload.is_empty() {
+            return Err(RustCError::InvalidData(format!(
+                "Zcash batch PCZT {index} has no payload"
+            )));
+        }
+        total_payload_bytes = total_payload_bytes.saturating_add(payload.len());
+        if total_payload_bytes > ZCASH_BATCH_MAX_TOTAL_BYTES {
             return Err(RustCError::UnsupportedTransaction(format!(
-                "unsupported Zcash batch message kind {}",
-                message.get_kind()
-            )));
-        }
-        if message.get_id().is_empty() {
-            return Err(RustCError::InvalidData(format!(
-                "Zcash batch message {index} has no id"
-            )));
-        }
-        if message.get_payload().is_empty() {
-            return Err(RustCError::InvalidData(format!(
-                "Zcash batch message {index} has no payload"
+                "Zcash batch PCZTs exceed {ZCASH_BATCH_MAX_TOTAL_BYTES} bytes"
             )));
         }
 
-        let digest = sha256(message.get_payload());
-        if let Some(expected_digest) = message.get_payload_digest() {
-            if expected_digest.as_slice() != digest.as_slice() {
-                return Err(RustCError::InvalidData(format!(
-                    "Zcash batch message {index} payload digest mismatch"
-                )));
-            }
+        let digest = sha256(payload);
+        if payload_digests.contains(&digest) {
+            return Err(RustCError::InvalidData(
+                "Zcash batch contains duplicate PCZTs".to_string(),
+            ));
         }
-
-        for previous in &messages[..index] {
-            if sha256(previous.get_payload()) == digest {
-                return Err(RustCError::InvalidData(
-                    "Zcash batch contains duplicate payloads".to_string(),
-                ));
-            }
-            if previous.get_id() == message.get_id() {
-                return Err(RustCError::InvalidData(
-                    "Zcash batch contains duplicate message ids".to_string(),
-                ));
-            }
-        }
+        payload_digests.push(digest);
     }
 
     Ok(())
+}
+
+/// Serializes one logical batch PCZT into its canonical standalone encoding.
+#[cfg(feature = "cypherpunk")]
+fn serialize_batch_pczt(pczt: &Pczt) -> Result<Vec<u8>, RustCError> {
+    pczt.clone()
+        .serialize()
+        .map_err(|e| RustCError::InvalidData(format!("encode PCZT in batch request: {e:?}")))
+}
+
+/// Applies firmware batch limits to the request body owned by the PCZT crate.
+#[cfg(feature = "cypherpunk")]
+fn validate_zcash_batch(batch: &BatchSignRequest) -> Result<Vec<Vec<u8>>, RustCError> {
+    let payloads = batch
+        .pczts()
+        .iter()
+        .map(serialize_batch_pczt)
+        .collect::<Result<Vec<_>, _>>()?;
+    validate_zcash_batch_payloads(&payloads)?;
+    Ok(payloads)
+}
+
+/// Bounds the outer request before parsing or retaining its checked state.
+#[cfg(feature = "cypherpunk")]
+fn validate_zcash_batch_envelope(request_id: &[u8], data: &[u8]) -> Result<(), RustCError> {
+    if request_id.is_empty() {
+        return Err(RustCError::InvalidData(
+            "Zcash batch request id must not be empty".to_string(),
+        ));
+    }
+    if request_id.len().saturating_add(data.len()) > ZCASH_BATCH_MAX_TOTAL_BYTES {
+        return Err(RustCError::UnsupportedTransaction(format!(
+            "Zcash batch request exceeds {ZCASH_BATCH_MAX_TOTAL_BYTES} bytes"
+        )));
+    }
+    Ok(())
+}
+
+/// Parses the bounded outer registry into the PCZT crate's batch request.
+#[cfg(feature = "cypherpunk")]
+fn parse_zcash_batch_registry(registry: &ZcashSignBatch) -> Result<BatchSignRequest, RustCError> {
+    validate_zcash_batch_envelope(registry.get_request_id(), registry.get_data())?;
+    BatchSignRequest::parse(registry.get_data())
+        .map_err(|e| RustCError::InvalidData(format!("invalid PCZT batch request: {e:?}")))
+}
+
+/// Reopens the exact normalized envelope retained by the check step.
+#[cfg(feature = "cypherpunk")]
+fn parse_checked_zcash_batch(data: &[u8]) -> Result<(Vec<u8>, BatchSignRequest), RustCError> {
+    let registry = ZcashSignBatch::try_from(data.to_vec()).map_err(|e| {
+        RustCError::InvalidData(format!("decode checked Zcash batch envelope: {e:?}"))
+    })?;
+    let batch = parse_zcash_batch_registry(&registry)?;
+    Ok((registry.get_request_id().to_vec(), batch))
+}
+
+/// Retains normalized PCZTs and their request id as checked firmware state.
+#[cfg(feature = "cypherpunk")]
+fn encode_checked_zcash_batch(request_id: &[u8], data: Vec<u8>) -> Result<Vec<u8>, RustCError> {
+    validate_zcash_batch_envelope(request_id, &data)?;
+    ZcashSignBatch::new(request_id.to_vec(), data)
+        .try_into()
+        .map_err(|e| {
+            RustCError::InvalidData(format!("encode normalized Zcash batch envelope: {e:?}"))
+        })
+}
+
+/// Wraps the PCZT crate's signature response with its echoed request id.
+#[cfg(feature = "cypherpunk")]
+fn encode_zcash_batch_sig_result(
+    request_id: Vec<u8>,
+    data: Vec<u8>,
+) -> Result<Vec<u8>, RustCError> {
+    ZcashBatchSigResult::new(request_id, data)
+        .try_into()
+        .map_err(|e| RustCError::InvalidData(format!("encode Zcash batch result envelope: {e:?}")))
 }
 
 #[cfg(feature = "cypherpunk")]
@@ -302,55 +341,64 @@ pub unsafe extern "C" fn check_zcash_batch_tx_cypherpunk(
         ))
         .c_ptr();
     }
-    let batch = extract_ptr_with_type!(tx, ZcashSignBatch);
+    let registry = extract_ptr_with_type!(tx, ZcashSignBatch);
+    let batch = match parse_zcash_batch_registry(registry) {
+        Ok(batch) => batch,
+        Err(e) => return TransactionCheckResult::from(e).c_ptr(),
+    };
+    let request_id = registry.get_request_id().to_vec();
     let ufvk_text = unsafe { recover_c_char(ufvk) };
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
 
-    if let Err(e) = validate_zcash_batch(batch) {
-        return TransactionCheckResult::from(e).c_ptr();
-    }
+    let payloads = match validate_zcash_batch(&batch) {
+        Ok(payloads) => payloads,
+        Err(e) => return TransactionCheckResult::from(e).c_ptr(),
+    };
 
-    let mut checked_messages = Vec::with_capacity(batch.get_messages().len());
-    for message in batch.get_messages() {
+    let mut checked_pczts = Vec::with_capacity(payloads.len());
+    for payload in payloads {
         match app_zcash::check_batch_pczt_cypherpunk(
             &MainNetwork,
-            message.get_payload(),
+            &payload,
             &ufvk_text,
             seed_fingerprint,
             account_index,
         ) {
             Ok(normalized) => {
-                let digest = sha256(&normalized).to_vec();
-                checked_messages.push(ZcashSignMessage::new(
-                    message.get_id().clone(),
-                    message.get_kind(),
-                    normalized,
-                    Some(digest),
-                ));
+                let pczt = match Pczt::parse(&normalized) {
+                    Ok(pczt) => pczt,
+                    Err(e) => {
+                        return TransactionCheckResult::from(RustCError::InvalidData(format!(
+                            "parse normalized PCZT in batch request: {e:?}"
+                        )))
+                        .c_ptr();
+                    }
+                };
+                checked_pczts.push(pczt);
             }
             Err(e) => return TransactionCheckResult::from(e).c_ptr(),
         }
     }
 
-    // Rebuild the envelope around the normalized payloads (with re-stamped
-    // per-message digests) so parse/sign consume exactly what was checked.
-    let normalized_batch = ZcashSignBatch::new(
-        batch.get_version(),
-        batch.get_request_id().clone(),
-        batch.get_network(),
-        checked_messages,
-        Some(true),
-    );
-    match TryInto::<Vec<u8>>::try_into(normalized_batch) {
-        Ok(bytes) => {
-            *checked_batch = ZcashCheckedPczt::new(bytes).c_ptr();
-            TransactionCheckResult::new().c_ptr()
+    // Rebuild the Postcard request around the normalized PCZTs so parse/sign
+    // consume exactly what was checked, then preserve the outer request id for
+    // the eventual batch result.
+    let normalized_request = match BatchSignRequest::new(checked_pczts).serialize() {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return TransactionCheckResult::from(RustCError::InvalidData(format!(
+                "encode normalized PCZT batch request: {e:?}"
+            )))
+            .c_ptr();
         }
-        // The encode error is a ur-registry error type; TransactionCheckResult
-        // has no From impl for it, so map explicitly.
-        Err(e) => TransactionCheckResult::from(RustCError::InvalidData(format!("{e:?}"))).c_ptr(),
-    }
+    };
+    let normalized_batch = match encode_checked_zcash_batch(&request_id, normalized_request) {
+        Ok(bytes) => bytes,
+        Err(e) => return TransactionCheckResult::from(e).c_ptr(),
+    };
+    *checked_batch = ZcashCheckedPczt::new(normalized_batch).c_ptr();
+    TransactionCheckResult::new().c_ptr()
 }
 
 #[cfg(feature = "cypherpunk")]
@@ -378,31 +426,36 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
         Ok(bytes) => bytes,
         Err(e) => return TransactionParseResult::from(e).c_ptr(),
     };
-    let batch = match ZcashSignBatch::try_from(bytes.to_vec()) {
-        Ok(batch) => batch,
-        Err(e) => {
-            return TransactionParseResult::from(RustCError::InvalidData(format!("{e:?}"))).c_ptr()
-        }
+    let batch = match parse_checked_zcash_batch(bytes) {
+        Ok((_, batch)) => batch,
+        Err(e) => return TransactionParseResult::from(e).c_ptr(),
     };
     let ufvk_text = unsafe { recover_c_char(ufvk) };
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
 
-    // The checked bytes are parsed once. Eligible Orchard-to-Ironwood transfers
-    // are folded by content; ambiguous batches keep their ordinary review pages.
+    // Serialize the normalized PCZTs once, then parse each into a complete
+    // display model. Eligible Orchard-to-Ironwood transfers are folded by
+    // content; ambiguous batches keep their ordinary review pages.
+    let payloads = match batch
+        .pczts()
+        .iter()
+        .map(serialize_batch_pczt)
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(payloads) => payloads,
+        Err(e) => return TransactionParseResult::from(e).c_ptr(),
+    };
     let parsed_items = match app_zcash::parse_batch_with_migration_summary_cypherpunk(
         &MainNetwork,
-        batch
-            .get_messages()
-            .iter()
-            .map(|message| message.get_payload().as_slice()),
+        payloads.iter().map(Vec::as_slice),
         &ufvk_text,
         seed_fingerprint,
     ) {
         Ok(items) => items,
         Err(e) => return TransactionParseResult::from(e).c_ptr(),
     };
-    // Convert only after every message has parsed. These FFI values own heap
+    // Convert only after every PCZT has parsed. These FFI values own heap
     // allocations freed by `free_TransactionParseResult_DisplayZcashBatch`, not
     // Rust `Drop`; an early return after partial conversion would leak memory.
     let display_items: Vec<DisplayPczt> = parsed_items.iter().map(DisplayPczt::from).collect();
@@ -439,8 +492,8 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
     let mut seed = extract_array_mut!(seed, u8, seed_len as usize);
 
     let result = match checked.checked_bytes() {
-        Ok(bytes) => match ZcashSignBatch::try_from(bytes.to_vec()) {
-            Ok(batch) => match calculate_seed_fingerprint(seed) {
+        Ok(bytes) => match parse_checked_zcash_batch(bytes) {
+            Ok((request_id, batch)) => match calculate_seed_fingerprint(seed) {
                 Ok(seed_fingerprint) => {
                     if &seed_fingerprint != expected_seed_fingerprint {
                         seed.zeroize();
@@ -449,22 +502,32 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
 
                     let mut results = Vec::new();
                     let mut error = None;
-                    for message in batch.get_messages() {
+                    // Preserve request order and emit nothing unless every PCZT signs.
+                    for pczt in batch.pczts() {
+                        let payload = match serialize_batch_pczt(pczt) {
+                            Ok(payload) => payload,
+                            Err(e) => {
+                                error = Some(UREncodeResult::from(e).c_ptr());
+                                break;
+                            }
+                        };
                         match app_zcash::sign_checked_batch_pczt(
                             &MainNetwork,
-                            message.get_payload(),
+                            &payload,
                             seed,
                             &seed_fingerprint,
                             account_index,
                         ) {
                             Ok(payload) => {
-                                let payload_digest = sha256(&payload).to_vec();
-                                results.push(ZcashSignMessageResult::signed(
-                                    message.get_id().clone(),
-                                    message.get_kind(),
-                                    payload,
-                                    payload_digest,
-                                ));
+                                match app_zcash::extract_compact_sigs_from_signed_pczt(&payload) {
+                                    Ok(compact_sigs) => {
+                                        results.push(compact_sigs);
+                                    }
+                                    Err(e) => {
+                                        error = Some(UREncodeResult::from(e).c_ptr());
+                                        break;
+                                    }
+                                }
                             }
                             Err(e) => {
                                 error = Some(UREncodeResult::from(e).c_ptr());
@@ -476,33 +539,41 @@ unsafe fn sign_zcash_batch_tx_cypherpunk_dynamic(
                     if let Some(error) = error {
                         error
                     } else {
-                        let result = ZcashSignResult::new(
-                            ZCASH_SIGN_BATCH_VERSION,
-                            batch.get_request_id().clone(),
-                            results,
-                        );
-                        match TryInto::<Vec<u8>>::try_into(result) {
+                        let response = BatchSignResponse::new(results);
+                        match response.serialize() {
                             Ok(bytes) => {
-                                let registry_type = ZcashSignResult::get_registry_type().get_type();
-                                if allow_multipart {
-                                    UREncodeResult::encode(
-                                        bytes,
-                                        registry_type,
-                                        max_fragment_length,
-                                    )
-                                    .c_ptr()
-                                } else {
-                                    UREncodeResult::encode_full_response(bytes, registry_type)
-                                        .c_ptr()
+                                let registry_type =
+                                    ZcashBatchSigResult::get_registry_type().get_type();
+                                match encode_zcash_batch_sig_result(request_id, bytes) {
+                                    Ok(cbor) => {
+                                        if allow_multipart {
+                                            UREncodeResult::encode(
+                                                cbor,
+                                                registry_type,
+                                                max_fragment_length,
+                                            )
+                                            .c_ptr()
+                                        } else {
+                                            UREncodeResult::encode_full_response(
+                                                cbor,
+                                                registry_type,
+                                            )
+                                            .c_ptr()
+                                        }
+                                    }
+                                    Err(e) => UREncodeResult::from(e).c_ptr(),
                                 }
                             }
-                            Err(e) => UREncodeResult::from(e).c_ptr(),
+                            Err(e) => UREncodeResult::from(RustCError::InvalidData(format!(
+                                "encode PCZT batch response: {e:?}"
+                            )))
+                            .c_ptr(),
                         }
                     }
                 }
                 Err(e) => UREncodeResult::from(e).c_ptr(),
             },
-            Err(e) => UREncodeResult::from(RustCError::InvalidData(format!("{e:?}"))).c_ptr(),
+            Err(e) => UREncodeResult::from(e).c_ptr(),
         },
         Err(e) => UREncodeResult::from(e).c_ptr(),
     };
@@ -789,211 +860,182 @@ mod tests {
 
     use super::*;
 
-    fn test_zcash_batch(messages: Vec<ZcashSignMessage>) -> ZcashSignBatch {
-        ZcashSignBatch::new(
-            ZCASH_SIGN_BATCH_VERSION,
-            b"test-request".to_vec(),
-            ZCASH_SIGN_BATCH_NETWORK_MAINNET,
-            messages,
-            Some(true),
-        )
+    #[cfg(feature = "cypherpunk")]
+    fn test_zcash_payloads(count: usize) -> Vec<Vec<u8>> {
+        (0..count)
+            .map(|index| format!("pczt-{index}").into_bytes())
+            .collect()
     }
 
-    fn test_zcash_message(id: &[u8], payload: &[u8]) -> ZcashSignMessage {
-        ZcashSignMessage::new(
-            id.to_vec(),
-            ZCASH_SIGN_MESSAGE_KIND_PCZT_V1,
-            payload.to_vec(),
-            Some(sha256(payload).to_vec()),
-        )
-    }
-
+    #[cfg(feature = "cypherpunk")]
     #[test]
-    fn test_validate_zcash_batch_accepts_valid_envelope() {
-        let batch = test_zcash_batch(vec![
-            test_zcash_message(b"one", b"pczt-one"),
-            test_zcash_message(b"two", b"pczt-two"),
-        ]);
+    fn test_validate_zcash_batch_accepts_valid_payloads() {
+        let payloads = test_zcash_payloads(2);
 
-        validate_zcash_batch(&batch).unwrap();
+        validate_zcash_batch_payloads(&payloads).unwrap();
     }
 
+    #[cfg(feature = "cypherpunk")]
     #[test]
-    fn test_validate_zcash_batch_accepts_missing_atomic_as_default() {
-        let batch = ZcashSignBatch::new(
-            ZCASH_SIGN_BATCH_VERSION,
-            b"test-request".to_vec(),
-            ZCASH_SIGN_BATCH_NETWORK_MAINNET,
-            vec![test_zcash_message(b"one", b"pczt-one")],
-            None,
-        );
+    fn test_validate_zcash_batch_accepts_max_pczts() {
+        let payloads = test_zcash_payloads(ZCASH_BATCH_MAX_PCZTS);
 
-        validate_zcash_batch(&batch).unwrap();
+        validate_zcash_batch_payloads(&payloads).unwrap();
     }
 
+    #[cfg(feature = "cypherpunk")]
     #[test]
-    fn test_validate_zcash_batch_accepts_max_messages() {
-        let batch = test_zcash_batch(
-            (0..ZCASH_BATCH_MAX_MESSAGES)
-                .map(|index| {
-                    test_zcash_message(
-                        format!("id-{index}").as_bytes(),
-                        format!("pczt-{index}").as_bytes(),
-                    )
-                })
-                .collect(),
-        );
+    fn test_validate_zcash_batch_rejects_oversized_total_payload() {
+        // Three PCZTs whose summed payloads cross the byte bound: the count cap
+        // alone no longer bounds RAM, so the byte bound must reject this.
+        let big = vec![0xAB; ZCASH_BATCH_MAX_TOTAL_BYTES / 2];
+        let payloads = vec![big.clone(), [big.as_slice(), &[0x01]].concat(), vec![0x02]];
 
-        validate_zcash_batch(&batch).unwrap();
-    }
-
-    #[test]
-    fn test_validate_zcash_batch_rejects_version_network_and_atomic_policy() {
-        let message = test_zcash_message(b"one", b"pczt-one");
-
-        let wrong_version = ZcashSignBatch::new(
-            ZCASH_SIGN_BATCH_VERSION + 1,
-            b"test-request".to_vec(),
-            ZCASH_SIGN_BATCH_NETWORK_MAINNET,
-            vec![message.clone()],
-            Some(true),
-        );
+        let error = validate_zcash_batch_payloads(&payloads).unwrap_err();
         assert!(matches!(
-            validate_zcash_batch(&wrong_version),
-            Err(RustCError::UnsupportedTransaction(message))
-                if message.contains("unsupported Zcash batch version")
-        ));
-
-        let wrong_network = ZcashSignBatch::new(
-            ZCASH_SIGN_BATCH_VERSION,
-            b"test-request".to_vec(),
-            ZCASH_SIGN_BATCH_NETWORK_MAINNET + 1,
-            vec![message.clone()],
-            Some(true),
-        );
-        assert!(matches!(
-            validate_zcash_batch(&wrong_network),
-            Err(RustCError::UnsupportedTransaction(message))
-                if message.contains("only Zcash mainnet")
-        ));
-
-        let non_atomic = ZcashSignBatch::new(
-            ZCASH_SIGN_BATCH_VERSION,
-            b"test-request".to_vec(),
-            ZCASH_SIGN_BATCH_NETWORK_MAINNET,
-            vec![message],
-            Some(false),
-        );
-        assert!(matches!(
-            validate_zcash_batch(&non_atomic),
-            Err(RustCError::UnsupportedTransaction(message))
-                if message.contains("atomic=true")
+            error,
+            RustCError::UnsupportedTransaction(message)
+                if message.contains("PCZTs exceed")
         ));
     }
 
+    #[cfg(feature = "cypherpunk")]
     #[test]
-    fn test_validate_zcash_batch_rejects_empty_request_id_and_messages() {
-        let empty_request_id = ZcashSignBatch::new(
-            ZCASH_SIGN_BATCH_VERSION,
-            vec![],
-            ZCASH_SIGN_BATCH_NETWORK_MAINNET,
-            vec![test_zcash_message(b"one", b"pczt-one")],
-            Some(true),
-        );
+    fn test_validate_zcash_batch_rejects_empty_batch_and_payload() {
         assert_eq!(
-            validate_zcash_batch(&empty_request_id).unwrap_err(),
-            RustCError::InvalidData("Zcash batch has no request id".to_string())
+            validate_zcash_batch_payloads(&[]).unwrap_err(),
+            RustCError::InvalidData("Zcash batch has no PCZTs".to_string())
         );
 
-        let empty_messages = test_zcash_batch(vec![]);
         assert_eq!(
-            validate_zcash_batch(&empty_messages).unwrap_err(),
-            RustCError::InvalidData("Zcash batch has no messages".to_string())
+            validate_zcash_batch_payloads(&[vec![]]).unwrap_err(),
+            RustCError::InvalidData("Zcash batch PCZT 0 has no payload".to_string())
         );
     }
 
+    #[cfg(feature = "cypherpunk")]
     #[test]
-    fn test_validate_zcash_batch_rejects_invalid_message_fields() {
-        let unsupported_kind = ZcashSignMessage::new(
-            b"one".to_vec(),
-            ZCASH_SIGN_MESSAGE_KIND_PCZT_V1 + 1,
-            b"pczt-one".to_vec(),
-            Some(sha256(b"pczt-one").to_vec()),
-        );
-        assert!(matches!(
-            validate_zcash_batch(&test_zcash_batch(vec![unsupported_kind])),
-            Err(RustCError::UnsupportedTransaction(message))
-                if message.contains("unsupported Zcash batch message kind")
-        ));
-
-        let empty_message_id = test_zcash_message(b"", b"pczt-one");
-        assert_eq!(
-            validate_zcash_batch(&test_zcash_batch(vec![empty_message_id])).unwrap_err(),
-            RustCError::InvalidData("Zcash batch message 0 has no id".to_string())
-        );
-
-        let empty_payload = test_zcash_message(b"one", b"");
-        assert_eq!(
-            validate_zcash_batch(&test_zcash_batch(vec![empty_payload])).unwrap_err(),
-            RustCError::InvalidData("Zcash batch message 0 has no payload".to_string())
-        );
-    }
-
-    #[test]
-    fn test_validate_zcash_batch_rejects_too_many_messages() {
-        let batch = test_zcash_batch(
-            (0..=ZCASH_BATCH_MAX_MESSAGES)
-                .map(|index| {
-                    test_zcash_message(
-                        format!("id-{index}").as_bytes(),
-                        format!("pczt-{index}").as_bytes(),
-                    )
-                })
-                .collect(),
-        );
+    fn test_validate_zcash_batch_rejects_too_many_pczts() {
+        let payloads = test_zcash_payloads(ZCASH_BATCH_MAX_PCZTS + 1);
 
         assert!(matches!(
-            validate_zcash_batch(&batch),
+            validate_zcash_batch_payloads(&payloads),
             Err(RustCError::UnsupportedTransaction(message))
                 if message.contains("supports at most")
         ));
     }
 
+    #[cfg(feature = "cypherpunk")]
     #[test]
-    fn test_validate_zcash_batch_rejects_duplicate_ids_and_payloads() {
-        let duplicate_ids = test_zcash_batch(vec![
-            test_zcash_message(b"same", b"pczt-one"),
-            test_zcash_message(b"same", b"pczt-two"),
-        ]);
+    fn test_validate_zcash_batch_rejects_duplicate_pczts() {
+        let duplicate_payloads = vec![b"pczt".to_vec(), b"pczt".to_vec()];
         assert_eq!(
-            validate_zcash_batch(&duplicate_ids).unwrap_err(),
-            RustCError::InvalidData("Zcash batch contains duplicate message ids".to_string())
-        );
-
-        let duplicate_payloads = test_zcash_batch(vec![
-            test_zcash_message(b"one", b"pczt"),
-            test_zcash_message(b"two", b"pczt"),
-        ]);
-        assert_eq!(
-            validate_zcash_batch(&duplicate_payloads).unwrap_err(),
-            RustCError::InvalidData("Zcash batch contains duplicate payloads".to_string())
+            validate_zcash_batch_payloads(&duplicate_payloads).unwrap_err(),
+            RustCError::InvalidData("Zcash batch contains duplicate PCZTs".to_string())
         );
     }
 
+    #[cfg(feature = "cypherpunk")]
+    fn empty_batch_request() -> Vec<u8> {
+        BatchSignRequest::new(vec![]).serialize().unwrap()
+    }
+
+    #[cfg(feature = "cypherpunk")]
     #[test]
-    fn test_validate_zcash_batch_rejects_payload_digest_mismatch() {
-        let message = ZcashSignMessage::new(
-            b"one".to_vec(),
-            ZCASH_SIGN_MESSAGE_KIND_PCZT_V1,
-            b"pczt-one".to_vec(),
-            Some(sha256(b"different-payload").to_vec()),
-        );
-        let batch = test_zcash_batch(vec![message]);
+    fn test_checked_zcash_batch_preserves_request_id() {
+        let request_id = vec![0xaa, 0xbb];
+        let checked = encode_checked_zcash_batch(&request_id, empty_batch_request()).unwrap();
+
+        let (decoded_request_id, batch) = parse_checked_zcash_batch(&checked).unwrap();
+
+        assert_eq!(decoded_request_id, request_id);
+        assert!(batch.pczts().is_empty());
+    }
+
+    #[cfg(feature = "cypherpunk")]
+    #[test]
+    fn test_zcash_batch_rejects_invalid_envelope_bounds() {
+        let registry = ZcashSignBatch::new(vec![], empty_batch_request());
 
         assert_eq!(
-            validate_zcash_batch(&batch).unwrap_err(),
-            RustCError::InvalidData("Zcash batch message 0 payload digest mismatch".to_string())
+            parse_zcash_batch_registry(&registry).unwrap_err(),
+            RustCError::InvalidData("Zcash batch request id must not be empty".to_string())
         );
+
+        let oversized = ZcashSignBatch::new(vec![0xaa], vec![0; ZCASH_BATCH_MAX_TOTAL_BYTES]);
+        assert!(matches!(
+            parse_zcash_batch_registry(&oversized),
+            Err(RustCError::UnsupportedTransaction(message))
+                if message.contains("batch request exceeds")
+        ));
+    }
+
+    #[cfg(feature = "cypherpunk")]
+    #[test]
+    fn test_encode_zcash_batch_sig_result_wraps_pczt_response() {
+        use zcash_vendor::{orchard::ValuePool, pczt::roles::signer::SpendAuthSignature};
+
+        let request_id = vec![0xaa, 0xbb];
+        let response = BatchSignResponse::new(vec![
+            vec![SpendAuthSignature::from_parts(
+                ValuePool::Orchard,
+                0,
+                [0x11; 64],
+            )],
+            vec![SpendAuthSignature::from_parts(
+                ValuePool::Ironwood,
+                3,
+                [0x22; 64],
+            )],
+        ]);
+        let response_bytes = response.serialize().unwrap();
+
+        let cbor =
+            encode_zcash_batch_sig_result(request_id.clone(), response_bytes.clone()).unwrap();
+        let decoded = ZcashBatchSigResult::try_from(cbor).unwrap();
+
+        assert_eq!(decoded.get_request_id(), request_id);
+        assert_eq!(decoded.get_data(), response_bytes);
+        assert_eq!(
+            BatchSignResponse::parse(decoded.get_data()).unwrap(),
+            response
+        );
+    }
+
+    /// The batch signer fails closed: with no checked batch stored (a null
+    /// container) it refuses and produces no signature UR.
+    #[cfg(feature = "cypherpunk")]
+    #[test]
+    fn test_sign_zcash_batch_refuses_without_checked_batch() {
+        for unlimited in [false, true] {
+            let result = unsafe {
+                if unlimited {
+                    sign_zcash_batch_tx_cypherpunk_unlimited(
+                        core::ptr::null_mut(),
+                        core::ptr::null_mut(),
+                        0,
+                        false,
+                        core::ptr::null_mut(),
+                        0,
+                    )
+                } else {
+                    sign_zcash_batch_tx_cypherpunk(
+                        core::ptr::null_mut(),
+                        core::ptr::null_mut(),
+                        0,
+                        false,
+                        core::ptr::null_mut(),
+                        0,
+                    )
+                }
+            };
+            assert!(!result.is_null());
+            assert!(
+                unsafe { (*result).data.is_null() },
+                "signing without a checked batch must not produce a signature UR"
+            );
+            unsafe { Box::from_raw(result).free() };
+        }
     }
 
     #[test]

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -388,7 +388,18 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
 
-    let mut display_items = Vec::new();
+    if batch.get_messages().len() > 1 {
+        // The normalized bytes already passed the batch check. Try the compact
+        // review; if it cannot be built, use the ordinary per-message review below.
+        if let Ok(display_items) =
+            parse_zcash_batch_as_first_plus_migrations(&batch, &ufvk_text, seed_fingerprint)
+        {
+            return TransactionParseResult::success(DisplayZcashBatch::from(display_items).c_ptr())
+                .c_ptr();
+        }
+    }
+
+    let mut parsed_items = Vec::new();
     for message in batch.get_messages() {
         match app_zcash::parse_pczt_cypherpunk(
             &MainNetwork,
@@ -396,12 +407,45 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
             &ufvk_text,
             seed_fingerprint,
         ) {
-            Ok(pczt) => display_items.push(DisplayPczt::from(&pczt)),
+            Ok(pczt) => parsed_items.push(pczt),
             Err(e) => return TransactionParseResult::from(e).c_ptr(),
         }
     }
+    // FFI display structs leak if dropped (freed via free_TransactionParseResult_*,
+    // not Drop), so build them only after every message has parsed.
+    let display_items: Vec<DisplayPczt> = parsed_items.iter().map(DisplayPczt::from).collect();
 
     TransactionParseResult::success(DisplayZcashBatch::from(display_items).c_ptr()).c_ptr()
+}
+
+/// Parses message 0 normally and folds later migration children into one summary.
+/// The caller uses errors to select the ordinary per-message review.
+#[cfg(feature = "cypherpunk")]
+fn parse_zcash_batch_as_first_plus_migrations(
+    batch: &ZcashSignBatch,
+    ufvk_text: &str,
+    seed_fingerprint: &[u8; 32],
+) -> app_zcash::errors::Result<Vec<DisplayPczt>> {
+    let messages = batch.get_messages();
+    // The caller requires at least two messages, so message 0 is present.
+    debug_assert!(messages.len() > 1);
+    let first_message = &messages[0];
+    let parsed_items = app_zcash::parse_batch_with_migration_summary_cypherpunk(
+        &MainNetwork,
+        first_message.get_payload(),
+        messages
+            .iter()
+            .skip(1)
+            .map(|message| message.get_payload().as_slice()),
+        ufvk_text,
+        seed_fingerprint,
+    )?;
+
+    // Materialize the FFI display structs only after every fallible step: their
+    // nested FFI-owned allocations are freed through free_TransactionParseResult_*,
+    // not Drop, so building one before an Err (which sends the caller down the
+    // per-message fallback) would leak it on every non-migration batch review.
+    Ok(parsed_items.iter().map(DisplayPczt::from).collect())
 }
 
 #[cfg(feature = "cypherpunk")]

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -388,64 +388,25 @@ pub unsafe extern "C" fn parse_zcash_batch_tx_cypherpunk(
     let seed_fingerprint = extract_array!(seed_fingerprint, u8, 32);
     let seed_fingerprint = seed_fingerprint.try_into().unwrap();
 
-    if batch.get_messages().len() > 1 {
-        // The normalized bytes already passed the batch check. Try the compact
-        // review; if it cannot be built, use the ordinary per-message review below.
-        if let Ok(display_items) =
-            parse_zcash_batch_as_first_plus_migrations(&batch, &ufvk_text, seed_fingerprint)
-        {
-            return TransactionParseResult::success(DisplayZcashBatch::from(display_items).c_ptr())
-                .c_ptr();
-        }
-    }
-
-    let mut parsed_items = Vec::new();
-    for message in batch.get_messages() {
-        match app_zcash::parse_pczt_cypherpunk(
-            &MainNetwork,
-            message.get_payload(),
-            &ufvk_text,
-            seed_fingerprint,
-        ) {
-            Ok(pczt) => parsed_items.push(pczt),
-            Err(e) => return TransactionParseResult::from(e).c_ptr(),
-        }
-    }
+    // The checked bytes are parsed once. Eligible Orchard-to-Ironwood transfers
+    // are folded by content; ambiguous batches keep their ordinary review pages.
+    let parsed_items = match app_zcash::parse_batch_with_migration_summary_cypherpunk(
+        &MainNetwork,
+        batch
+            .get_messages()
+            .iter()
+            .map(|message| message.get_payload().as_slice()),
+        &ufvk_text,
+        seed_fingerprint,
+    ) {
+        Ok(items) => items,
+        Err(e) => return TransactionParseResult::from(e).c_ptr(),
+    };
     // FFI display structs leak if dropped (freed via free_TransactionParseResult_*,
     // not Drop), so build them only after every message has parsed.
     let display_items: Vec<DisplayPczt> = parsed_items.iter().map(DisplayPczt::from).collect();
 
     TransactionParseResult::success(DisplayZcashBatch::from(display_items).c_ptr()).c_ptr()
-}
-
-/// Parses message 0 normally and folds later migration children into one summary.
-/// The caller uses errors to select the ordinary per-message review.
-#[cfg(feature = "cypherpunk")]
-fn parse_zcash_batch_as_first_plus_migrations(
-    batch: &ZcashSignBatch,
-    ufvk_text: &str,
-    seed_fingerprint: &[u8; 32],
-) -> app_zcash::errors::Result<Vec<DisplayPczt>> {
-    let messages = batch.get_messages();
-    // The caller requires at least two messages, so message 0 is present.
-    debug_assert!(messages.len() > 1);
-    let first_message = &messages[0];
-    let parsed_items = app_zcash::parse_batch_with_migration_summary_cypherpunk(
-        &MainNetwork,
-        first_message.get_payload(),
-        messages
-            .iter()
-            .skip(1)
-            .map(|message| message.get_payload().as_slice()),
-        ufvk_text,
-        seed_fingerprint,
-    )?;
-
-    // Materialize the FFI display structs only after every fallible step: their
-    // nested FFI-owned allocations are freed through free_TransactionParseResult_*,
-    // not Drop, so building one before an Err (which sends the caller down the
-    // per-message fallback) would leak it on every non-migration batch review.
-    Ok(parsed_items.iter().map(DisplayPczt::from).collect())
 }
 
 #[cfg(feature = "cypherpunk")]

--- a/rust/zcash_vendor/Cargo.toml
+++ b/rust/zcash_vendor/Cargo.toml
@@ -61,7 +61,7 @@ rust_tools = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(zcash_unstable, values("nu6.3", "zfuture"))',
+    'cfg(zcash_unstable, values("zfuture"))',
 ] }
 
 [dev-dependencies]

--- a/rust/zcash_vendor/Cargo.toml
+++ b/rust/zcash_vendor/Cargo.toml
@@ -41,7 +41,7 @@ chacha20poly1305 = { version = "0.10.1", default-features = false, features = [
 ] }
 postcard = { version = "1.0.3", features = ["alloc"] }
 getset = { version = "0.1.3" }
-orchard = { version = "0.15.0-pre.2", default-features = false, optional = true }
+orchard = { version = "0.15.0", default-features = false, optional = true }
 pczt = { version = "0.7", default-features = false }
 serde = { workspace = true }
 serde_with = { version = "3.11.0", features = [

--- a/rust/zcash_vendor/src/pczt_ext.rs
+++ b/rust/zcash_vendor/src/pczt_ext.rs
@@ -337,24 +337,17 @@ fn hash_orchard_txid_empty() -> Hash {
 // This is consensus-critical and must stay bit-exact with upstream. The
 // `shielded_sig_commitment == RoleSigner::shielded_sighash` oracle tests in
 // apps/zcash/src/pczt/sign.rs guard it (red CI on any upstream drift).
-#[cfg(zcash_unstable = "nu6.3")]
 const ZCASH_ORCHARD_V6_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrchardH_v6";
-#[cfg(zcash_unstable = "nu6.3")]
 const ZCASH_IRONWOOD_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIronwd_H_v6";
-#[cfg(zcash_unstable = "nu6.3")]
 const ZCASH_IRONWOOD_ACTIONS_COMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActCH_v6";
-#[cfg(zcash_unstable = "nu6.3")]
 const ZCASH_IRONWOOD_ACTIONS_MEMOS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActMH_v6";
-#[cfg(zcash_unstable = "nu6.3")]
 const ZCASH_IRONWOOD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActNH_v6";
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn is_v6(pczt: &Pczt) -> bool {
     *pczt.global().tx_version() == zcash_protocol::constants::V6_TX_VERSION
         && *pczt.global().version_group_id() == zcash_protocol::constants::V6_VERSION_GROUP_ID
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn has_ironwood(pczt: &Pczt) -> bool {
     !pczt.ironwood().actions().is_empty()
 }
@@ -363,7 +356,6 @@ fn has_ironwood(pczt: &Pczt) -> bool {
 /// upstream `orchard::bundle::commitments::hash_bundle_txid_data_with_domain` for the
 /// `ORCHARD_V6` / `IRONWOOD_V6` domains: the three ZIP-244 action sub-hashes, the flag
 /// byte, the value balance, and — unlike v5 — NO anchor (`effects_anchor = Omit`).
-#[cfg(zcash_unstable = "nu6.3")]
 fn digest_orchard_shaped_v6(
     bundle: &pczt::orchard::Bundle,
     bundle_personalization: &[u8; 16],
@@ -406,7 +398,6 @@ fn digest_orchard_shaped_v6(
     h.finalize()
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn digest_orchard_v6(pczt: &Pczt) -> Hash {
     digest_orchard_shaped_v6(
         pczt.orchard(),
@@ -417,7 +408,6 @@ fn digest_orchard_v6(pczt: &Pczt) -> Hash {
     )
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn digest_ironwood_v6(pczt: &Pczt) -> Hash {
     digest_orchard_shaped_v6(
         pczt.ironwood(),
@@ -428,17 +418,14 @@ fn digest_ironwood_v6(pczt: &Pczt) -> Hash {
     )
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn hash_orchard_v6_txid_empty() -> Hash {
     hasher(ZCASH_ORCHARD_V6_HASH_PERSONALIZATION).finalize()
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn hash_ironwood_v6_txid_empty() -> Hash {
     hasher(ZCASH_IRONWOOD_HASH_PERSONALIZATION).finalize()
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 fn shielded_sig_commitment_v6(
     pczt: &Pczt,
     lock_time: u32,
@@ -487,8 +474,11 @@ fn shielded_sig_commitment_v6(
 /// `pub` so the `app_zcash` consensus oracle tests can assert it stays bit-exact against
 /// the upstream RoleSigner sighash (any divergence turns CI red rather than producing
 /// wrong on-device signatures).
-pub fn shielded_sig_commitment(pczt: &Pczt, lock_time: u32, input_info: Option<SignableInput>) -> Hash {
-    #[cfg(zcash_unstable = "nu6.3")]
+pub fn shielded_sig_commitment(
+    pczt: &Pczt,
+    lock_time: u32,
+    input_info: Option<SignableInput>,
+) -> Hash {
     if is_v6(pczt) {
         return shielded_sig_commitment_v6(pczt, lock_time, input_info);
     }
@@ -680,7 +670,7 @@ where
 /// is the one parsed and mutated. Dummy/output-only actions (value 0 or absent) are
 /// skipped, so an Orchard→Ironwood migration (Ironwood output-only) produces no
 /// Ironwood signature here.
-#[cfg(all(feature = "orchard", zcash_unstable = "nu6.3"))]
+#[cfg(feature = "orchard")]
 pub fn sign_ironwood<T>(llsigner: Signer, signer: &T) -> Result<Signer, T::Error>
 where
     T: PcztSigner,

--- a/rust/zcash_vendor/src/pczt_ext.rs
+++ b/rust/zcash_vendor/src/pczt_ext.rs
@@ -214,6 +214,13 @@ fn action_cv_net(action: &pczt::orchard::Action) -> &[u8; 32] {
     action.cv_net().as_ref().unwrap_or(&ZERO)
 }
 
+/// The action's note commitment bytes for the sighash. Like `cv_net`, `cmx` is
+/// optional in the v2 PCZT wire model and is resolved and checked before signing.
+fn action_cmx(action: &pczt::orchard::Action) -> &[u8; 32] {
+    static ZERO: [u8; 32] = [0; 32];
+    action.output().cmx().as_ref().unwrap_or(&ZERO)
+}
+
 /// The output's encrypted note ciphertext for the sighash. `resolve_fields` restores the
 /// full ciphertext from a memo-plaintext-only (`EncCiphertext::MemoPlaintext`) output; see
 /// [`action_cv_net`] for why the zero fallback is unreachable in the signing path.
@@ -236,7 +243,7 @@ fn digest_orchard(pczt: &Pczt) -> Hash {
         let enc_ciphertext = action_enc_ciphertext(action.output());
 
         ch.update(action.spend().nullifier());
-        ch.update(action.output().cmx());
+        ch.update(action_cmx(action));
         ch.update(action.output().ephemeral_key());
         ch.update(&enc_ciphertext[..ENC_CIPHERTEXT_COMPACT_LEN]);
 
@@ -277,7 +284,9 @@ fn hash_sapling_spends(pczt: &Pczt) -> Hash {
             ch.update(s_spend.nullifier());
 
             nh.update(s_spend.cv());
-            nh.update(pczt.sapling().anchor());
+            // Checked v5 spends require an anchor. Zero only keeps digesting
+            // malformed unchecked data infallible; it cannot yield a valid transaction.
+            nh.update(pczt.sapling().anchor().as_ref().unwrap_or(&[0u8; 32]));
             nh.update(s_spend.rk());
         }
 
@@ -387,7 +396,7 @@ fn digest_orchard_shaped_v6(
         let enc_ciphertext = action_enc_ciphertext(action.output());
 
         ch.update(action.spend().nullifier());
-        ch.update(action.output().cmx());
+        ch.update(action_cmx(action));
         ch.update(action.output().ephemeral_key());
         ch.update(&enc_ciphertext[..ENC_CIPHERTEXT_COMPACT_LEN]);
 

--- a/rust/zcash_vendor/src/pczt_ext.rs
+++ b/rust/zcash_vendor/src/pczt_ext.rs
@@ -192,6 +192,18 @@ fn hash_transparent_tx_id(t_digests: Option<TransparentDigests>) -> Hash {
 /// 52 (compact) | 512 (memo) | 16 (non-compact).
 const ORCHARD_ENC_CIPHERTEXT_SIZE: usize = 580;
 
+/// Byte layout of Sapling, Orchard, and Ironwood `enc_ciphertext` fields used by
+/// the transaction digests:
+/// the first [`ENC_CIPHERTEXT_COMPACT_LEN`] bytes are the compact note ciphertext (the
+/// `*CHash` digests), bytes up to [`ENC_CIPHERTEXT_MEMO_END`] are the encrypted memo (the
+/// `*MHash` digests), and the remainder is hashed with the non-compact fields. For
+/// Orchard/Ironwood, `action_enc_ciphertext` returns a buffer of exactly
+/// [`ORCHARD_ENC_CIPHERTEXT_SIZE`] bytes, so slicing at these boundaries never panics;
+/// `pub` so signing preconditions elsewhere can reference the same constants.
+pub const ENC_CIPHERTEXT_COMPACT_LEN: usize = 52;
+/// See [`ENC_CIPHERTEXT_COMPACT_LEN`]: 52 compact bytes + 512 memo bytes.
+pub const ENC_CIPHERTEXT_MEMO_END: usize = ENC_CIPHERTEXT_COMPACT_LEN + 512;
+
 /// The action's value-commitment bytes for the sighash. `cv_net` is `Option` in the v2
 /// PCZT wire model; the checked-PCZT preflight resolves it and `check::verify_cv_net`
 /// rejects any still-missing value before signing, so it is always present here. The zero
@@ -221,16 +233,18 @@ fn digest_orchard(pczt: &Pczt) -> Hash {
     let mut nh = hasher(ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION);
 
     for action in pczt.orchard().actions().iter() {
+        let enc_ciphertext = action_enc_ciphertext(action.output());
+
         ch.update(action.spend().nullifier());
         ch.update(action.output().cmx());
         ch.update(action.output().ephemeral_key());
-        ch.update(&action_enc_ciphertext(action.output())[..52]);
+        ch.update(&enc_ciphertext[..ENC_CIPHERTEXT_COMPACT_LEN]);
 
-        mh.update(&action_enc_ciphertext(action.output())[52..564]);
+        mh.update(&enc_ciphertext[ENC_CIPHERTEXT_COMPACT_LEN..ENC_CIPHERTEXT_MEMO_END]);
 
         nh.update(action_cv_net(action));
         nh.update(action.spend().rk());
-        nh.update(&action_enc_ciphertext(action.output())[564..]);
+        nh.update(&enc_ciphertext[ENC_CIPHERTEXT_MEMO_END..]);
         nh.update(action.output().out_ciphertext());
     }
 
@@ -284,12 +298,12 @@ fn hash_sapling_outputs(pczt: &Pczt) -> Hash {
         for s_out in pczt.sapling().outputs() {
             ch.update(s_out.cmu());
             ch.update(s_out.ephemeral_key());
-            ch.update(&s_out.enc_ciphertext()[..52]);
+            ch.update(&s_out.enc_ciphertext()[..ENC_CIPHERTEXT_COMPACT_LEN]);
 
-            mh.update(&s_out.enc_ciphertext()[52..564]);
+            mh.update(&s_out.enc_ciphertext()[ENC_CIPHERTEXT_COMPACT_LEN..ENC_CIPHERTEXT_MEMO_END]);
 
             nh.update(s_out.cv());
-            nh.update(&s_out.enc_ciphertext()[564..]);
+            nh.update(&s_out.enc_ciphertext()[ENC_CIPHERTEXT_MEMO_END..]);
             nh.update(s_out.out_ciphertext());
         }
 
@@ -370,16 +384,18 @@ fn digest_orchard_shaped_v6(
     let mut nh = hasher(noncompact_personalization);
 
     for action in bundle.actions().iter() {
+        let enc_ciphertext = action_enc_ciphertext(action.output());
+
         ch.update(action.spend().nullifier());
         ch.update(action.output().cmx());
         ch.update(action.output().ephemeral_key());
-        ch.update(&action_enc_ciphertext(action.output())[..52]);
+        ch.update(&enc_ciphertext[..ENC_CIPHERTEXT_COMPACT_LEN]);
 
-        mh.update(&action_enc_ciphertext(action.output())[52..564]);
+        mh.update(&enc_ciphertext[ENC_CIPHERTEXT_COMPACT_LEN..ENC_CIPHERTEXT_MEMO_END]);
 
         nh.update(action_cv_net(action));
         nh.update(action.spend().rk());
-        nh.update(&action_enc_ciphertext(action.output())[564..]);
+        nh.update(&enc_ciphertext[ENC_CIPHERTEXT_MEMO_END..]);
         nh.update(action.output().out_ciphertext());
     }
 
@@ -628,8 +644,9 @@ where
     llsigner.sign_orchard_with::<T::Error, _>(|pczt, signable, tx_modifiable| {
         let lock_time = determine_lock_time(pczt.global(), pczt.transparent().inputs())
             .ok_or(transparent::pczt::ParseError::InvalidRequiredHeightLocktime)?;
+        let shielded_hash = shielded_sig_commitment(pczt, lock_time, None);
         signable.actions_mut().iter_mut().try_for_each(|action| {
-            sign_orchard_action(pczt, lock_time, signer, action, tx_modifiable)
+            sign_orchard_action(signer, action, &shielded_hash, tx_modifiable)
         })
     })
 }
@@ -639,12 +656,13 @@ where
 /// derivation and signs wallet-controlled spends, including zero-value ones), so we
 /// must NOT pre-filter by value here — that would drop a wallet-controlled zero-value
 /// spend. `tx_modifiable` is cleared only when this call adds a new signature.
+/// The caller supplies the transaction-wide shielded sighash shared by every action in
+/// the bundle. Added signatures do not affect this hash.
 #[cfg(feature = "orchard")]
 fn sign_orchard_action<T>(
-    pczt: &Pczt,
-    lock_time: u32,
     signer: &T,
     action: &mut orchard::pczt::Action,
+    shielded_hash: &Hash,
     tx_modifiable: &mut u8,
 ) -> Result<(), T::Error>
 where
@@ -655,7 +673,7 @@ where
         return Ok(());
     }
     let had_sig = action.spend().spend_auth_sig().is_some();
-    signer.sign_orchard(action, shielded_sig_commitment(pczt, lock_time, None))?;
+    signer.sign_orchard(action, shielded_hash.clone())?;
     if !had_sig && action.spend().spend_auth_sig().is_some() {
         *tx_modifiable &= !(FLAG_TRANSPARENT_INPUTS_MODIFIABLE
             | FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE
@@ -681,8 +699,9 @@ where
     llsigner.sign_ironwood_with::<T::Error, _>(|pczt, signable, tx_modifiable| {
         let lock_time = determine_lock_time(pczt.global(), pczt.transparent().inputs())
             .ok_or(transparent::pczt::ParseError::InvalidRequiredHeightLocktime)?;
+        let shielded_hash = shielded_sig_commitment(pczt, lock_time, None);
         signable.actions_mut().iter_mut().try_for_each(|action| {
-            sign_orchard_action(pczt, lock_time, signer, action, tx_modifiable)
+            sign_orchard_action(signer, action, &shielded_hash, tx_modifiable)
         })
     })
 }

--- a/src/ui/gui_chain/multi/gui_zcash.c
+++ b/src/ui/gui_chain/multi/gui_zcash.c
@@ -389,6 +389,8 @@ UREncodeResult *GuiSignZcashCypherpunkWithSeed(void *data,
 
     memset_s(seed, sizeof(seed), 0, sizeof(seed));
     ClearSecretCache();
+    // Signing can exceed the lock timeout; restart it before restoring auto-lock.
+    ClearLockScreenTime();
     SetLockScreen(enable);
     return encodeResult;
 }

--- a/src/ui/gui_model/gui_model.c
+++ b/src/ui/gui_model/gui_model.c
@@ -1456,6 +1456,8 @@ static int32_t ModelParseTransaction(const void *indata, uint32_t inDataLen, Bac
         GuiApiEmitSignal(SIG_TRANSACTION_PARSE_FAIL, parsedResult, sizeof(parsedResult));
     }
     GuiApiEmitSignal(SIG_HIDE_TRANSACTION_LOADING, NULL, 0);
+    // Parsing can exceed the lock timeout, so restart it before re-enabling auto-lock.
+    ClearLockScreenTime();
     SetPageLockScreen(true);
     return SUCCESS_CODE;
 }

--- a/src/ui/gui_widgets/gui_transaction_signature_widgets.c
+++ b/src/ui/gui_widgets/gui_transaction_signature_widgets.c
@@ -60,6 +60,7 @@ void GuiTransactionSignatureRefresh(void)
 void GuiTransactionSignatureHandleURGenerate(char *data, uint16_t len)
 {
     GuiAnimantingQRCodeFirstUpdate(data, len);
+    ClearLockScreenTime();
 }
 
 void GuiTransactionSignatureHandleURUpdate(char *data, uint16_t len)
@@ -70,6 +71,7 @@ void GuiTransactionSignatureHandleURUpdate(char *data, uint16_t len)
 void GuiTransactionSignatureHandleURGenerateFail(void *param)
 {
     GuiPendingHintBoxRemove();
+    ClearLockScreenTime();
     UREncodeResult *result = NULL;
     if (param != NULL) {
         result = *(UREncodeResult **)param;


### PR DESCRIPTION
Builds on the preceding Zcash cleanup, single-pass review, and migration-review layers. Because the upstream feature branch cannot host contributor-owned intermediate branches, this head is cumulative; the final commit specific to this layer adopts PCZT-owned batch messages, returns compact signature responses, and applies firmware batch boundaries.

Batch requests and responses use the PCZT crate’s versioned serialization inside SDK UR registry envelopes. The outer envelope carries opaque batch bytes plus a request ID, which firmware preserves through check, display, and signing and echoes in the result. The PCZT encoding contains no transport or per-PCZT IDs, and the response carries only the Orchard and Ironwood spend authorization signatures in request order.

Firmware rejects empty and duplicate batches, caps requests at 50 PCZTs and 512 KiB, and signs the exact normalized payloads retained by the check step. The Zcash and SDK revisions remain pinned until the corresponding crate changes are published.

Validated by the downstream Fmt Check, Unit Test And Code coverage, and rust_c Zcash FFI test jobs.