### PR TITLE
fix: resolve mnemonic confirmation crash (issue #2032)

### DIFF
--- a/src/ui/gui_views/gui_views.c
+++ b/src/ui/gui_views/gui_views.c
@@ -198,7 +198,6 @@ void GuiWriteSeResult(bool en, int32_t errCode)
         strcpy_s(wallet.name, WALLET_NAME_MAX_LEN + 1, GetCurrentKbWalletName());
         GuiNvsBarSetWalletName(GetCurrentKbWalletName());
         GuiNvsBarSetWalletIcon(GuiGetEmojiIconImg());
-        GuiCloseToTargetView(&g_initView);
         GuiFrameOpenViewWithParam(&g_lockView, NULL, 0);
         GuiLockScreenHidden();
         GuiFrameOpenView(&g_homeView);

--- a/src/ui/gui_widgets/gui_single_phrase_widgets.c
+++ b/src/ui/gui_widgets/gui_single_phrase_widgets.c
@@ -385,7 +385,6 @@ int8_t GuiSinglePhraseNextTile(const char *passphrase)
             SetMidBtnLabel(g_pageWidget->navBarWidget, NVS_BAR_MID_LABEL, _("Passphrase"));
             SetNavBarRightBtn(g_pageWidget->navBarWidget, NVS_BAR_QUESTION_MARK, OpenPassphraseTutorialHandler, NULL);
         } else {
-            g_singlePhraseTileView.currentTile++;
             SetNavBarLeftBtn(g_pageWidget->navBarWidget, NVS_LEFT_BUTTON_BUTT, NULL, NULL);
             SetNavBarRightBtn(g_pageWidget->navBarWidget, NVS_RIGHT_BUTTON_BUTT, NULL, NULL);
             WriteSE();


### PR DESCRIPTION
## Description

This PR fixes the crash/hang that occurs during mnemonic confirmation in the simulator (issue #2032).

## Root Cause

Two bugs were identified:

### Bug 1: Double `currentTile` increment
In `gui_single_phrase_widgets.c`, the `GuiSinglePhraseNextTile` function has:
- A `currentTile++` inside the `CONFIRM_PHRASE` case (when passphrase not needed)
- Another `currentTile++` after the switch statement

This causes the tile index to skip one step, leading to unexpected behavior.

### Bug 2: `GuiCloseToTargetView` cascade destruction
In `gui_views.c`, the `GuiWriteSeResult` function calls `GuiCloseToTargetView(&g_initView)` which cascades through views and calls their DeInit handlers. When a view's DeInit destroys LVGL objects, it can corrupt sibling views' objects, leading to a segfault in `lv_obj_del`.

## Fix

1. **Remove duplicate `currentTile++`**: Delete the `currentTile++` inside the `CONFIRM_PHRASE` case, keeping only the one after the switch statement.

2. **Skip cascade view closure**: Remove `GuiCloseToTargetView(&g_initView)` and directly open the lock+home views. This avoids the cascade destruction that corrupts LVGL objects.

## Testing

- Verified in simulator: mnemonic confirmation flow completes without crash
- Tested both scenarios: creating new wallet and importing existing mnemonic
- No regression in other flows

## Related Issues

Closes #2032