### PR TITLE
fix: resolve simulator timing issue with spinner animation

### DIFF
--- a/src/ui/gui_widgets/gui_import_phrase_widgets.c
+++ b/src/ui/gui_widgets/gui_import_phrase_widgets.c
@@ -161,16 +161,16 @@ int8_t GuiImportPhraseNextTile(const char *passphrase)
         } else {
             SetNavBarLeftBtn(g_pageWidget->navBarWidget, NVS_LEFT_BUTTON_BUTT, NULL, NULL);
             g_importSinglePhraseTileView.currentTile++;
-            GuiModelBip39CalWriteSe(bip39);
             GuiCreateCircleAroundAnimation(lv_scr_act(), -40);
+            GuiModelBip39CalWriteSe(bip39);
         }
         break;
     case SINGLE_PHRASE_PASSPHRASE:
         SetNavBarLeftBtn(g_pageWidget->navBarWidget, NVS_LEFT_BUTTON_BUTT, NULL, NULL);
         SetNavBarRightBtn(g_pageWidget->navBarWidget, NVS_RIGHT_BUTTON_BUTT, NULL, NULL);
         SetNavBarMidBtn(g_pageWidget->navBarWidget, NVS_MID_BUTTON_BUTT, NULL, NULL);
-        GuiModelBip39CalWriteSe(bip39);
         GuiCreateCircleAroundAnimation(lv_scr_act(), -40);
+        GuiModelBip39CalWriteSe(bip39);
         break;
     }
 


### PR DESCRIPTION
## Description

This PR fixes a timing issue in the simulator where the spinner animation doesn't work correctly during mnemonic import.

## Problem

In simulator mode, `AsyncExecute` is synchronous (direct function call), which causes a timing issue:

```c
// Before fix:
GuiModelBip39CalWriteSe(bip39);      // Sync execution, sends SIGNAL immediately
GuiCreateCircleAroundAnimation(...);  // Creates spinner AFTER signal already processed
```

The signal is dispatched and processed before the spinner is created, so the spinner never gets stopped.

## Fix

Swap the order to create the spinner first:

```c
// After fix:
GuiCreateCircleAroundAnimation(...);  // Create spinner first
GuiModelBip39CalWriteSe(bip39);      // Then sync execution
```

This ensures the spinner exists when the signal is dispatched, allowing it to be properly stopped.

## Testing

- Verified in simulator: spinner appears and disappears correctly during mnemonic import
- No regression on real device (AsyncExecute is asynchronous on real hardware)

## Notes

This issue only affects the simulator. On real hardware, `AsyncExecute` is truly asynchronous, so the order doesn't matter. However, this fix makes the code correct in both modes.