### PR TITLE
Limit Zcash batches to 40 PCZTs and free review widgets

### DIFF
--- a/docs/protocols/ur_registrys/zcash.md
+++ b/docs/protocols/ur_registrys/zcash.md
@@ -63,7 +63,7 @@ carries the PCZT-owned response in its own opaque `data` field. It also reports
 the signing firmware version once for the entire response.
 
 Batch version 1 is supported by cypherpunk firmware and currently accepts up to
-40 PCZTs. The encoded batch data and request id together, and the canonical PCZT
+35 PCZTs. The encoded batch data and request id together, and the canonical PCZT
 payloads after decoding, must each fit within 512 KiB. The operation is atomic.
 If any PCZT is invalid or cannot be signed, Keystone returns an error instead of
 a partial result. PCZT entries with identical canonical encodings are rejected.

--- a/docs/protocols/ur_registrys/zcash.md
+++ b/docs/protocols/ur_registrys/zcash.md
@@ -63,7 +63,7 @@ carries the PCZT-owned response in its own opaque `data` field. It also reports
 the signing firmware version once for the entire response.
 
 Batch version 1 is supported by cypherpunk firmware and currently accepts up to
-50 PCZTs. The encoded batch data and request id together, and the canonical PCZT
+35 PCZTs. The encoded batch data and request id together, and the canonical PCZT
 payloads after decoding, must each fit within 512 KiB. The operation is atomic.
 If any PCZT is invalid or cannot be signed, Keystone returns an error instead of
 a partial result. PCZT entries with identical canonical encodings are rejected.

--- a/docs/protocols/ur_registrys/zcash.md
+++ b/docs/protocols/ur_registrys/zcash.md
@@ -63,7 +63,7 @@ carries the PCZT-owned response in its own opaque `data` field. It also reports
 the signing firmware version once for the entire response.
 
 Batch version 1 is supported by cypherpunk firmware and currently accepts up to
-35 PCZTs. The encoded batch data and request id together, and the canonical PCZT
+40 PCZTs. The encoded batch data and request id together, and the canonical PCZT
 payloads after decoding, must each fit within 512 KiB. The operation is atomic.
 If any PCZT is invalid or cannot be signed, Keystone returns an error instead of
 a partial result. PCZT entries with identical canonical encodings are rejected.

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -40,7 +40,7 @@ use zeroize::Zeroize;
 // Cap both per-PCZT overhead and variable-size payload data to leave headroom
 // in shared device memory while processing a batch.
 #[cfg(feature = "cypherpunk")]
-const ZCASH_BATCH_MAX_PCZTS: usize = 35;
+const ZCASH_BATCH_MAX_PCZTS: usize = 40;
 #[cfg(feature = "cypherpunk")]
 const ZCASH_BATCH_MAX_TOTAL_BYTES: usize = 512 * 1024;
 #[cfg(feature = "cypherpunk")]
@@ -1061,7 +1061,7 @@ mod tests {
         overlong_small_count.push(0);
         validate_zcash_batch_request_count(&overlong_small_count).unwrap();
 
-        // The body declares 36 PCZTs but omits them. Reaching the count error
+        // The body declares 41 PCZTs but omits them. Reaching the count error
         // proves the limit is enforced before the full request is parsed.
         request[ZCASH_BATCH_REQUEST_HEADER_LEN] += 1;
         let registry = ZcashSignBatch::new(vec![0xaa], request);

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -40,7 +40,7 @@ use zeroize::Zeroize;
 // Cap both per-PCZT overhead and variable-size payload data to leave headroom
 // in shared device memory while processing a batch.
 #[cfg(feature = "cypherpunk")]
-const ZCASH_BATCH_MAX_PCZTS: usize = 50;
+const ZCASH_BATCH_MAX_PCZTS: usize = 35;
 #[cfg(feature = "cypherpunk")]
 const ZCASH_BATCH_MAX_TOTAL_BYTES: usize = 512 * 1024;
 #[cfg(feature = "cypherpunk")]
@@ -1061,7 +1061,7 @@ mod tests {
         overlong_small_count.push(0);
         validate_zcash_batch_request_count(&overlong_small_count).unwrap();
 
-        // The body declares 51 PCZTs but omits them. Reaching the count error
+        // The body declares 36 PCZTs but omits them. Reaching the count error
         // proves the limit is enforced before the full request is parsed.
         request[ZCASH_BATCH_REQUEST_HEADER_LEN] += 1;
         let registry = ZcashSignBatch::new(vec![0xaa], request);

--- a/rust/rust_c/src/zcash/mod.rs
+++ b/rust/rust_c/src/zcash/mod.rs
@@ -40,7 +40,7 @@ use zeroize::Zeroize;
 // Cap both per-PCZT overhead and variable-size payload data to leave headroom
 // in shared device memory while processing a batch.
 #[cfg(feature = "cypherpunk")]
-const ZCASH_BATCH_MAX_PCZTS: usize = 40;
+const ZCASH_BATCH_MAX_PCZTS: usize = 35;
 #[cfg(feature = "cypherpunk")]
 const ZCASH_BATCH_MAX_TOTAL_BYTES: usize = 512 * 1024;
 #[cfg(feature = "cypherpunk")]
@@ -1061,7 +1061,7 @@ mod tests {
         overlong_small_count.push(0);
         validate_zcash_batch_request_count(&overlong_small_count).unwrap();
 
-        // The body declares 41 PCZTs but omits them. Reaching the count error
+        // The body declares 36 PCZTs but omits them. Reaching the count error
         // proves the limit is enforced before the full request is parsed.
         request[ZCASH_BATCH_REQUEST_HEADER_LEN] += 1;
         let registry = ZcashSignBatch::new(vec![0xaa], request);

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
@@ -191,6 +191,10 @@ void GuiZcashBatchWidgetsVerifyPasswordSuccess(void)
         return;
     }
     uint8_t viewType = ZcashBatchTx;
+    // Free the review widgets before allocating the signature view.
+    GUI_DEL_OBJ(g_txContainer)
+    GUI_DEL_OBJ(g_bottomBtnContainer)
+    GUI_DEL_OBJ(g_signSlider)
     GuiFrameOpenViewWithParam(&g_transactionSignatureView, &viewType, sizeof(viewType));
 }
 


### PR DESCRIPTION
Limit cypherpunk Zcash batch signing to 40 PCZTs and update the protocol documentation. Before opening the signature view, delete the batch review container, bottom button container, and slider so their LVGL allocations do not overlap with the signature and result QR allocations. This addresses the device SRAM failure observed during that transition while retaining the selected 40-PCZT ceiling.