### PR TITLE
Fix Zcash batch state and UFVK buffers

### DIFF
--- a/src/managers/account_manager.c
+++ b/src/managers/account_manager.c
@@ -652,7 +652,7 @@ static void SetZcashUFVK(uint8_t accountIndex, const char* ufvk)
 {
     ASSERT(accountIndex <= 2);
     g_zcashUFVKcache.accountIndex = accountIndex;
-    strcpy_s(g_zcashUFVKcache.ufvkCache, ZCASH_UFVK_MAX_LEN, ufvk);
+    strcpy_s(g_zcashUFVKcache.ufvkCache, sizeof(g_zcashUFVKcache.ufvkCache), ufvk);
 }
 
 static void SetZcashSFP(uint8_t accountIndex, const uint8_t* seedFingerprint)
@@ -665,7 +665,7 @@ static void SetZcashSFP(uint8_t accountIndex, const uint8_t* seedFingerprint)
 
 static void ClearZcashUFVK()
 {
-    memset_s(g_zcashUFVKcache.ufvkCache, ZCASH_UFVK_MAX_LEN, '\0', ZCASH_UFVK_MAX_LEN);
+    memset_s(g_zcashUFVKcache.ufvkCache, sizeof(g_zcashUFVKcache.ufvkCache), '\0', sizeof(g_zcashUFVKcache.ufvkCache));
     memset_s(g_zcashUFVKcache.seedFingerprint, 32, 0, 32);
 }
 
@@ -673,7 +673,7 @@ int32_t GetZcashUFVK(uint8_t accountIndex, char* outUFVK)
 {
     ASSERT(accountIndex <= 2);
     if (g_zcashUFVKcache.accountIndex == accountIndex) {
-        strcpy_s(outUFVK, ZCASH_UFVK_MAX_LEN, g_zcashUFVKcache.ufvkCache);
+        strcpy_s(outUFVK, ZCASH_UFVK_BUFFER_SIZE, g_zcashUFVKcache.ufvkCache);
         return SUCCESS_CODE;
     }
     return ERR_ZCASH_INVALID_ACCOUNT_INDEX;
@@ -771,8 +771,8 @@ int32_t SetupZcashCache(uint8_t accountIndex, const char* password)
         return ret;
     }
 
-    char ufvk[ZCASH_UFVK_MAX_LEN] = {'\0'};
-    strcpy_s(ufvk, ZCASH_UFVK_MAX_LEN, response->data);
+    char ufvk[ZCASH_UFVK_BUFFER_SIZE] = {'\0'};
+    strcpy_s(ufvk, sizeof(ufvk), response->data);
     free_simple_response_c_char(response);
     SetZcashUFVK(accountIndex, ufvk);
     CLEAR_ARRAY(ufvk);

--- a/src/managers/account_manager.h
+++ b/src/managers/account_manager.h
@@ -8,6 +8,7 @@
 
 #define WALLET_NAME_MAX_LEN                 16
 #define ZCASH_UFVK_MAX_LEN                  384
+#define ZCASH_UFVK_BUFFER_SIZE              (ZCASH_UFVK_MAX_LEN + 1)
 
 typedef enum {
     PASSCODE_TYPE_PIN,
@@ -48,7 +49,7 @@ typedef struct {
 
 typedef struct {
     uint8_t accountIndex;
-    char ufvkCache[ZCASH_UFVK_MAX_LEN + 1];
+    char ufvkCache[ZCASH_UFVK_BUFFER_SIZE];
     uint8_t seedFingerprint[32];
 } ZcashUFVKCache_t;
 

--- a/src/ui/gui_chain/multi/gui_zcash.c
+++ b/src/ui/gui_chain/multi/gui_zcash.c
@@ -54,7 +54,7 @@ void *GuiGetZcashGUIData(void)
         parseResult = parse_zcash_tx_multi_coins(g_checkedPczt, sfp);
 #endif
 #ifdef CYPHERPUNK_VERSION
-        char ufvk[ZCASH_UFVK_MAX_LEN] = {'\0'};
+        char ufvk[ZCASH_UFVK_BUFFER_SIZE] = {'\0'};
         GetZcashUFVK(GetCurrentAccountIndex(), ufvk);
         parseResult = parse_zcash_tx_cypherpunk(g_checkedPczt, ufvk, sfp);
 #endif
@@ -344,7 +344,7 @@ PtrT_TransactionCheckResult GuiGetZcashCheckResult(void)
     return check_zcash_tx_multi_coins(data, xpub, sfp, zcash_account_index, mnemonicType == MNEMONIC_TYPE_SLIP39, &g_checkedPczt);
 #endif
 #ifdef CYPHERPUNK_VERSION
-    char ufvk[ZCASH_UFVK_MAX_LEN + 1] = {0};
+    char ufvk[ZCASH_UFVK_BUFFER_SIZE] = {0};
     GetZcashUFVK(GetCurrentAccountIndex(), ufvk);
     return check_zcash_tx_cypherpunk(data, ufvk, sfp, zcash_account_index, !IsZcashSupportedForCurrentMnemonic(), &g_checkedPczt);
 #endif

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_connect_wallet_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_connect_wallet_widgets.c
@@ -354,7 +354,7 @@ UREncodeResult *GuiGetZecData(void)
     ZcashKey data[1];
     keys->data = data;
     keys->size = 1;
-    char ufvk[384] = {'\0'};
+    char ufvk[ZCASH_UFVK_BUFFER_SIZE] = {'\0'};
     uint8_t sfp[32];
     GetZcashUFVK(GetCurrentAccountIndex(), ufvk);
     GetZcashSFP(GetCurrentAccountIndex(), sfp);

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
@@ -148,7 +148,7 @@ PtrT_TransactionCheckResult GuiGetZcashBatchCheckResult(void)
     uint8_t sfp[32] = {0};
     uint32_t zcashAccountIndex = 0;
     uint8_t accountNum = 0;
-    char ufvk[ZCASH_UFVK_MAX_LEN + 1] = {0};
+    char ufvk[ZCASH_UFVK_BUFFER_SIZE] = {0};
 
     FreeCheckedBatch();
 
@@ -409,7 +409,7 @@ static void *GuiParseZcashBatchData(void)
     uint8_t sfp[32];
     GetZcashSFP(GetCurrentAccountIndex(), sfp);
 
-    char ufvk[ZCASH_UFVK_MAX_LEN + 1] = {0};
+    char ufvk[ZCASH_UFVK_BUFFER_SIZE] = {0};
     GetZcashUFVK(GetCurrentAccountIndex(), ufvk);
     g_parseResult = parse_zcash_batch_tx_cypherpunk(
         g_checkedBatch,

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
@@ -372,7 +372,7 @@ static void GuiRenderCurrentTransaction(bool showSignSlider)
 
 void GuiZcashBatchWidgetsRefresh(void)
 {
-    if (g_parseResult == NULL || g_parseResult->error_code != 0) {
+    if (g_parseResult == NULL || g_parseResult->error_code != 0 || g_displayZcashBatch == NULL) {
         return;
     }
 

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
@@ -406,7 +406,7 @@ static void *GuiParseZcashBatchData(void)
         free_TransactionCheckResult(checkResult);
     }
 
-    uint8_t sfp[32];
+    uint8_t sfp[32] = {0};
     GetZcashSFP(GetCurrentAccountIndex(), sfp);
 
     char ufvk[ZCASH_UFVK_BUFFER_SIZE] = {0};

--- a/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
+++ b/src/ui/gui_widgets/multi/cypherpunk/gui_zcash_batch_widgets.c
@@ -12,6 +12,7 @@
 #include "gui_zcash.h"
 #include "keystore.h"
 #include "screen_manager.h"
+#include "fetch_sensitive_data_task.h"
 #include "general/eapdu_services/service_resolve_ur.h"
 #include "user_memory.h"
 
@@ -46,6 +47,10 @@ static lv_obj_t *g_signSlider = NULL;
 static lv_obj_t *g_parseErrorHintBox = NULL;
 static KeyboardWidget_t *g_keyboardWidget = NULL;
 
+typedef struct {
+    ZcashCheckedPczt *checkedBatch;
+} ZcashCheckedBatchCleanup_t;
+
 static void *GuiParseZcashBatchData(void);
 static void CheckSliderProcessHandler(lv_event_t *e);
 static void GuiRenderCurrentTransaction(bool showSignSlider);
@@ -67,6 +72,32 @@ static void FreeCheckedBatch(void)
     }
 }
 
+static int32_t FreeCheckedBatchAsync(const void *data, uint32_t dataLen)
+{
+    if (data == NULL || dataLen != sizeof(ZcashCheckedBatchCleanup_t)) {
+        return ERR_GENERAL_FAIL;
+    }
+
+    const ZcashCheckedBatchCleanup_t *cleanup = data;
+    free_zcash_checked_pczt(cleanup->checkedBatch);
+    return SUCCESS_CODE;
+}
+
+static void DeferFreeCheckedBatch(void)
+{
+    if (g_checkedBatch == NULL) {
+        return;
+    }
+
+    ZcashCheckedBatchCleanup_t cleanup = {
+        .checkedBatch = g_checkedBatch,
+    };
+    g_checkedBatch = NULL;
+
+    // Signing uses this pointer on the same FIFO task, so its destructor cannot overtake it.
+    AsyncExecute(FreeCheckedBatchAsync, &cleanup, sizeof(cleanup));
+}
+
 static void ClearPageData(void)
 {
     g_currentTxIndex = 0;
@@ -74,7 +105,7 @@ static void ClearPageData(void)
     g_currentTransaction = NULL;
     g_displayZcashBatch = NULL;
 
-    FreeCheckedBatch();
+    DeferFreeCheckedBatch();
 
     if (g_parseResult != NULL) {
         free_TransactionParseResult_DisplayZcashBatch(g_parseResult);

--- a/src/ui/gui_widgets/multi/gui_standard_receive_widgets.c
+++ b/src/ui/gui_widgets/multi/gui_standard_receive_widgets.c
@@ -917,7 +917,7 @@ static void ModelGetAddress(uint32_t index, AddressDataItem_t *item)
 
 #ifdef CYPHERPUNK_VERSION
     if (g_chainCard == HOME_WALLET_CARD_ZEC) {
-        char ufvk[ZCASH_UFVK_MAX_LEN] = {'\0'};
+        char ufvk[ZCASH_UFVK_BUFFER_SIZE] = {'\0'};
         GetZcashUFVK(GetCurrentAccountIndex(), ufvk);
 
         result = generate_zcash_default_address(ufvk);


### PR DESCRIPTION
Fix the valid findings from the latest Zcash review. This adds terminator capacity to every Zcash UFVK buffer, guards batch refresh state, initializes the seed fingerprint before parsing, and defers checked batch cleanup on the signing task so page teardown cannot free input that is still in use.

The USB rejection path is intentionally unchanged because the shared response handler resets the request ID after sending the rejection. A repository wide strcpy_s audit is kept separate because the remaining calls are pre-existing and use mixed size semantics.
