### PR TITLE
Address Zcash upstream review feedback

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1678,7 +1678,8 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1798,14 +1799,6 @@ name = "f4jumble"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
-dependencies = [
- "blake2b_simd",
-]
-
-[[package]]
-name = "f4jumble"
-version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3041,8 +3034,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
-source = "git+https://github.com/zcash/orchard?rev=8995ee7e26f8b654a5457d05c95ee5b3132b3edd#8995ee7e26f8b654a5457d05c95ee5b3132b3edd"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04153a90834b939edd03c3e1b3ff15c9d305b9224c5e196faf3a490d21dfa299"
 dependencies = [
  "aes",
  "bitvec",
@@ -3142,8 +3136,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.7.0"
-source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
+version = "0.8.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fb3f5ea64b891d40cff8182aca0bd7d063c9460920546fe7066860b781de91"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4814,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "ur-registry"
 version = "1.0.5"
-source = "git+https://github.com/KeystoneHQ/keystone-sdk-rust.git?rev=c2119436f5246be05b1ba877a7e6b63f51c01339#c2119436f5246be05b1ba877a7e6b63f51c01339"
+source = "git+https://github.com/KeystoneHQ/keystone-sdk-rust.git?rev=4131bae5407e31633c01edf9c324094aca69341a#4131bae5407e31633c01edf9c324094aca69341a"
 dependencies = [
  "bs58",
  "hex",
@@ -5412,12 +5407,13 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c)",
+ "f4jumble",
  "zcash_encoding",
  "zcash_protocol",
 ]
@@ -5425,7 +5421,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -5435,7 +5432,8 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36391ebfce7df2510c6564f79e608ed93f1c0692c6464e2397b248e06dae3912"
 dependencies = [
  "bech32 0.11.0",
  "bip32",
@@ -5474,7 +5472,8 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdbeccc05bfe63b6dee9e989c6ff5027421741562a4853c36504dd621f6a81b1"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5504,7 +5503,8 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2973d210e74ebd81adc50828fbbb284ab6aaa099308097c42c47dc63cf3420fc"
 dependencies = [
  "corez",
  "hex",
@@ -5543,7 +5543,8 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash?rev=878db2074ae8ac2682d3e6c61c00f7018b6adc0c#878db2074ae8ac2682d3e6c61c00f7018b6adc0c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e0f8c142bed366ed5886dcfa8772ec90b5420cc127e6cdb76b6744c53a287b"
 dependencies = [
  "bip32",
  "bs58",
@@ -5575,7 +5576,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "chacha20poly1305",
- "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "f4jumble",
  "ff",
  "fpe",
  "getset",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -76,7 +76,7 @@ core2 = { version = "0.9.4", package = "no_std_io2", default-features = false }
 thiserror = { version = "1.0", package = "thiserror-core", default-features = false }
 rsa = { version = "0.8.2", default-features = false }
 sha1 = { version = "0.10.5", default-features = false }
-ur-registry = "1.0.5"
+ur-registry = "=1.0.5"
 ur-parse-lib = "1.0.4"
 sui-transaction-types-core = { git = "https://github.com/KeystoneHQ/sui.git", tag = "mainnet-nostd-v1.69.2.1", default-features = false, features = ["alloc"] }
 ed25519-bip32-core = { version = "0.1.1", default-features = false }
@@ -122,15 +122,6 @@ zeroize = { version = "1.8.2", default-features = false }
 # third party dependencies end
 
 [patch.crates-io]
-pczt = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
-zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "878db2074ae8ac2682d3e6c61c00f7018b6adc0c" }
-# Keep `orchard` aligned with the pinned PCZT/librustzcash revision.
-orchard = { git = "https://github.com/zcash/orchard", rev = "8995ee7e26f8b654a5457d05c95ee5b3132b3edd" }
-# Use the SDK rev that wraps PCZT-owned Postcard messages as opaque UR data,
-# correlates requests and results, and reports one firmware version per batch result.
-ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust.git", rev = "c2119436f5246be05b1ba877a7e6b63f51c01339" }
+# The published crate does not yet include the PCZT-owned batch messages or
+# firmware version in batch results.
+ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust.git", rev = "4131bae5407e31633c01edf9c324094aca69341a" }

--- a/rust/apps/zcash/Cargo.toml
+++ b/rust/apps/zcash/Cargo.toml
@@ -27,7 +27,7 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 keystore = { path = "../../keystore" }
-pczt = { version = "0.8.0-rc.1", default-features = false, features = ["io-finalizer", "orchard", "sapling", "transparent", "zcp-builder"] }
+pczt = { version = "0.8.0-rc.1", default-features = false, features = ["io-finalizer", "orchard", "sapling", "spend-finalizer", "transparent", "zcp-builder"] }
 zcash_primitives = { version = "0.29.0", default-features = false, features = ["circuits", "test-dependencies", "transparent-inputs"] }
 incrementalmerkletree = { version = "0.8.2", default-features = false }
 shardtree = "0.6.2"

--- a/rust/apps/zcash/Cargo.toml
+++ b/rust/apps/zcash/Cargo.toml
@@ -27,14 +27,14 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 keystore = { path = "../../keystore" }
-pczt = { version = "0.7", default-features = false, features = ["io-finalizer", "orchard", "sapling", "transparent", "zcp-builder"] }
-zcash_primitives = { version = "0.29.0-pre.0", default-features = false, features = ["circuits", "test-dependencies", "transparent-inputs"] }
+pczt = { version = "0.8.0-rc.1", default-features = false, features = ["io-finalizer", "orchard", "sapling", "transparent", "zcp-builder"] }
+zcash_primitives = { version = "0.29.0", default-features = false, features = ["circuits", "test-dependencies", "transparent-inputs"] }
 incrementalmerkletree = { version = "0.8.2", default-features = false }
 shardtree = "0.6.2"
 # Nameable only so the transparent-only `legacy_test_support` can spell the
 # `BuildConfig::orchard_pool_bundle_type` value; orchard is already built transitively
 # via the `zcash_primitives` dev-dependency.
-orchard = { version = "0.15.0", default-features = false }
+orchard = { version = "0.15.1", default-features = false }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -225,12 +225,12 @@ fn transparent_account_pubkey_from_xpub(
 #[cfg(feature = "multi_coins")]
 fn reject_unsupported_pczt(pczt: &Pczt) -> Result<()> {
     {
-        // The legacy multi-coins check path only verifies transparent data. Reject any
-        // shielded (Sapling/Orchard/Ironwood) or V6 PCZT so check, parse, and sign
-        // enforce the same transparent-only boundary.
-        if pczt::pczt_requires_cypherpunk_support(pczt) {
+        // The multi-coins check path only verifies transparent data. Reject shielded
+        // content and unknown transaction formats so check, parse, and sign enforce
+        // the same transparent-only boundary.
+        if pczt::pczt_is_unsupported_by_transparent_only(pczt) {
             return Err(ZcashError::InvalidPczt(
-                "Shielded or V6 PCZTs require cypherpunk checking support".to_string(),
+                "PCZT is not supported by transparent-only checking".to_string(),
             ));
         }
     }
@@ -719,10 +719,7 @@ pub fn sign_pczt(pczt: &[u8], seed: &[u8]) -> Result<Vec<u8>> {
 #[cfg(all(test, feature = "multi_coins", not(feature = "cypherpunk")))]
 mod legacy_tests {
     use super::*;
-    use zcash_vendor::{
-        pczt::roles::creator::Creator,
-        zcash_protocol::consensus::{BranchId, MainNetwork, NetworkConstants},
-    };
+    use zcash_vendor::zcash_protocol::consensus::MainNetwork;
 
     fn assert_invalid_pczt_message<T: core::fmt::Debug>(result: Result<T>, expected: &str) {
         match result {
@@ -788,31 +785,18 @@ mod legacy_tests {
     }
 
     #[test]
-    fn legacy_check_rejects_v6_pczt() {
-        let pczt = Creator::new(
-            BranchId::Nu6_3.into(),
-            10,
-            MainNetwork.coin_type(),
-            None,
-            None,
-        )
-        .unwrap()
-        .build()
-        .unwrap();
+    fn legacy_check_accepts_transparent_only_v6_pczt() {
+        let sample = pczt::legacy_test_support::legacy_transparent_v6_sample();
+        assert!(pczt::pczt_is_v6(&Pczt::parse(&sample.bytes).unwrap()));
 
-        let result = check_pczt_multi_coins(
+        check_pczt_multi_coins(
             &MainNetwork,
-            &pczt.serialize().unwrap(),
-            "not-an-xpub",
-            &[7u8; 32],
+            &sample.bytes,
+            &sample.xpub,
+            &sample.seed_fingerprint,
             0,
-        );
-
-        assert!(matches!(
-            result,
-            Err(ZcashError::InvalidPczt(msg))
-                if msg == "Shielded or V6 PCZTs require cypherpunk checking support"
-        ));
+        )
+        .expect("transparent-only v6 PCZT should pass checking");
     }
 }
 

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -718,8 +718,39 @@ pub fn sign_pczt(pczt: &[u8], seed: &[u8]) -> Result<Vec<u8>> {
 
 #[cfg(all(test, feature = "multi_coins", not(feature = "cypherpunk")))]
 mod legacy_tests {
+    use alloc::{collections::BTreeMap, string::String, vec::Vec};
+
     use super::*;
-    use zcash_vendor::zcash_protocol::consensus::MainNetwork;
+    use serde::{Deserialize, Serialize};
+    use zcash_vendor::zcash_protocol::consensus::{BranchId, MainNetwork};
+
+    #[derive(Serialize, Deserialize)]
+    struct PcztGlobalPrefix {
+        global: GlobalMirror,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct GlobalMirror {
+        tx_version: u32,
+        version_group_id: u32,
+        consensus_branch_id: u32,
+        fallback_lock_time: Option<u32>,
+        expiry_height: u32,
+        coin_type: u32,
+        tx_modifiable: u8,
+        proprietary: BTreeMap<String, Vec<u8>>,
+    }
+
+    fn pczt_with_consensus_branch_id(bytes: &[u8], branch_id: BranchId) -> Vec<u8> {
+        let (mut prefix, rest) =
+            postcard::take_from_bytes::<PcztGlobalPrefix>(&bytes[8..]).unwrap();
+        prefix.global.consensus_branch_id = branch_id.into();
+
+        let mut encoded = bytes[..8].to_vec();
+        encoded = postcard::to_extend(&prefix, encoded).unwrap();
+        encoded.extend_from_slice(rest);
+        encoded
+    }
 
     fn assert_invalid_pczt_message<T: core::fmt::Debug>(result: Result<T>, expected: &str) {
         match result {
@@ -797,6 +828,35 @@ mod legacy_tests {
             0,
         )
         .expect("transparent-only v6 PCZT should pass checking");
+    }
+
+    #[test]
+    fn legacy_rejects_v6_before_nu6_3() {
+        let sample = pczt::legacy_test_support::legacy_transparent_v6_sample();
+        let bytes = pczt_with_consensus_branch_id(&sample.bytes, BranchId::Nu6);
+        let pczt = Pczt::parse(&bytes).unwrap();
+        assert!(pczt::pczt_is_v6(&pczt));
+
+        assert_invalid_pczt_message(
+            check_pczt_multi_coins(
+                &MainNetwork,
+                &bytes,
+                &sample.xpub,
+                &sample.seed_fingerprint,
+                0,
+            ),
+            "PCZT is not supported by transparent-only checking",
+        );
+        assert_invalid_pczt_message(
+            parse_pczt_multi_coins(&MainNetwork, &bytes, &sample.seed_fingerprint),
+            "PCZT is not supported by transparent-only parsing",
+        );
+        assert_eq!(
+            sign_pczt(&bytes, &sample.seed),
+            Err(ZcashError::SigningError(
+                "PCZT is not supported by transparent-only signing".to_string()
+            ))
+        );
     }
 }
 

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -1844,6 +1844,56 @@ mod tests {
     }
 
     #[test]
+    fn test_v1_pczt_orchard_check_parse_and_sign() {
+        let sample = pczt::test_support::sample_legacy_orchard_change_pczt();
+        let v1_pczt = ::pczt::v1::Pczt::try_from(Pczt::parse(&sample.bytes).unwrap())
+            .unwrap()
+            .serialize();
+        assert_eq!(&v1_pczt[..8], b"PCZT\x01\0\0\0");
+
+        let parsed = parse_pczt_cypherpunk(
+            &MainNetwork,
+            &v1_pczt,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+        )
+        .unwrap();
+        assert!(parsed.get_ironwood().is_none());
+        let orchard = parsed
+            .get_orchard()
+            .expect("v1 Orchard bundle should decode");
+        assert_eq!(orchard.get_from().len(), 1);
+        assert!(orchard.get_from()[0].get_is_mine());
+        assert_eq!(orchard.get_from()[0].get_value(), "0.01 ZEC");
+        assert_eq!(orchard.get_to().len(), 1);
+        assert_eq!(orchard.get_to()[0].get_value(), "0.0099 ZEC");
+        assert_eq!(parsed.get_fee_value(), "0.0001 ZEC");
+
+        let normalized = check_pczt_cypherpunk(
+            &MainNetwork,
+            &v1_pczt,
+            &sample.ufvk_text,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+        let signed = sign_checked_pczt(
+            &MainNetwork,
+            &normalized,
+            &sample.seed,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .unwrap();
+        assert!(Pczt::parse(&signed)
+            .unwrap()
+            .orchard()
+            .actions()
+            .iter()
+            .any(|action| action.spend().spend_auth_sig().is_some()));
+    }
+
+    #[test]
     fn test_parse_ignores_and_check_rejects_unsupported_ironwood_spend_zip32_path() {
         let sample = pczt::test_support::sample_ironwood_pczt();
         let parsed_pczt = parse_pczt_cypherpunk(

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -1904,21 +1904,41 @@ mod tests {
     }
 
     #[test]
-    fn test_v1_pczt_orchard_check_parse_and_sign() {
-        let sample = pczt::test_support::sample_legacy_orchard_change_pczt();
-        let v1_pczt = ::pczt::v1::Pczt::try_from(Pczt::parse(&sample.bytes).unwrap())
-            .unwrap()
-            .serialize();
-        assert_eq!(&v1_pczt[..8], b"PCZT\x01\0\0\0");
+    fn test_v1_pczt_transparent_orchard_check_parse_and_sign() {
+        let sample = pczt::test_support::sample_legacy_transparent_orchard_pczt();
+        assert_eq!(&sample.bytes[..8], b"PCZT\x01\0\0\0");
+
+        let fixture = Pczt::parse(&sample.bytes).unwrap();
+        assert_eq!(*fixture.global().tx_version(), constants::V5_TX_VERSION);
+        assert_eq!(fixture.transparent().inputs().len(), 1);
+        assert_eq!(fixture.transparent().outputs().len(), 1);
+        assert_eq!(fixture.orchard().actions().len(), 2);
+        assert!(fixture
+            .orchard()
+            .actions()
+            .iter()
+            .all(|action| action.spend().spend_auth_sig().is_none()));
+        assert!(fixture.ironwood().actions().is_empty());
 
         let parsed = parse_pczt_cypherpunk(
             &MainNetwork,
-            &v1_pczt,
+            &sample.bytes,
             &sample.ufvk_text,
             &sample.seed_fingerprint,
         )
         .unwrap();
         assert!(parsed.get_ironwood().is_none());
+
+        let transparent = parsed
+            .get_transparent()
+            .expect("v1 transparent bundle should decode");
+        assert_eq!(transparent.get_from().len(), 1);
+        assert!(transparent.get_from()[0].get_is_mine());
+        assert_eq!(transparent.get_from()[0].get_value(), "0.01 ZEC");
+        assert_eq!(transparent.get_to().len(), 1);
+        assert_eq!(transparent.get_to()[0].get_value(), "0.0099 ZEC");
+        assert!(!transparent.get_to()[0].get_is_change());
+
         let orchard = parsed
             .get_orchard()
             .expect("v1 Orchard bundle should decode");
@@ -1926,17 +1946,27 @@ mod tests {
         assert!(orchard.get_from()[0].get_is_mine());
         assert_eq!(orchard.get_from()[0].get_value(), "0.01 ZEC");
         assert_eq!(orchard.get_to().len(), 1);
-        assert_eq!(orchard.get_to()[0].get_value(), "0.0099 ZEC");
-        assert_eq!(parsed.get_fee_value(), "0.0001 ZEC");
+        assert_eq!(orchard.get_to()[0].get_value(), "0.00995 ZEC");
+        assert!(orchard.get_to()[0].get_is_change());
+        assert_eq!(parsed.get_fee_value(), "0.00015 ZEC");
 
         let normalized = check_pczt_cypherpunk(
             &MainNetwork,
-            &v1_pczt,
+            &sample.bytes,
             &sample.ufvk_text,
             &sample.seed_fingerprint,
             0,
         )
         .unwrap();
+        assert!(matches!(
+            ::pczt::roles::spend_finalizer::SpendFinalizer::new(Pczt::parse(&normalized).unwrap())
+                .finalize_spends()
+                .unwrap_err(),
+            ::pczt::roles::spend_finalizer::Error::TransparentFinalize(
+                zcash_vendor::transparent::pczt::SpendFinalizerError::MissingSignature
+            )
+        ));
+
         let signed = sign_checked_pczt(
             &MainNetwork,
             &normalized,
@@ -1945,12 +1975,23 @@ mod tests {
             0,
         )
         .unwrap();
-        assert!(Pczt::parse(&signed)
-            .unwrap()
+        let signed = Pczt::parse(&signed).unwrap();
+
+        ::pczt::roles::spend_finalizer::SpendFinalizer::new(signed.clone())
+            .finalize_spends()
+            .expect("the one transparent input should be signed");
+
+        let signed_orchard_actions = signed
             .orchard()
             .actions()
             .iter()
-            .any(|action| action.spend().spend_auth_sig().is_some()));
+            .enumerate()
+            .filter_map(|(index, action)| {
+                action.spend().spend_auth_sig().is_some().then_some(index)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(signed_orchard_actions, vec![0]);
+        assert!(signed.ironwood().actions().is_empty());
     }
 
     #[test]

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -145,7 +145,7 @@ fn check_pczt_cypherpunk_with_policy<P: consensus::Parameters>(
         "transparent xpub is not present".to_string(),
     ))?;
     pczt::check::check_pczt_orchard(params, seed_fingerprint, account_index, &ufvk, &pczt)?;
-    pczt::check::check_pczt_transparent(
+    let has_my_transparent_input = pczt::check::check_pczt_transparent(
         params,
         seed_fingerprint,
         account_index,
@@ -153,18 +153,11 @@ fn check_pczt_cypherpunk_with_policy<P: consensus::Parameters>(
         &pczt,
         false,
     )?;
-
-    let pczt = match policy {
-        ShieldedActionPolicy::Single => pczt,
-        ShieldedActionPolicy::Batch => {
-            let (actions, pczt) =
-                signable_shielded_actions(params, pczt, seed_fingerprint, account_index, policy)?;
-            if actions.is_empty() {
-                return Err(ZcashError::PcztNoMyInputs);
-            }
-            pczt
-        }
-    };
+    let (signable_actions, pczt) =
+        signable_shielded_actions(params, pczt, seed_fingerprint, account_index, policy)?;
+    if signable_actions.is_empty() && !has_my_transparent_input {
+        return Err(ZcashError::PcztNoMyInputs);
+    }
 
     pczt.serialize()
         .map_err(|e| ZcashError::InvalidPczt(alloc::format!("serialize normalized PCZT: {e:?}")))
@@ -2372,8 +2365,20 @@ mod tests {
     }
 
     #[test]
-    fn test_sign_checked_pczt_rejects_foreign_seed() {
+    fn test_check_and_sign_pczt_reject_foreign_seed() {
         let sample = pczt::test_support::sample_orchard_change_pczt();
+        let foreign_seed = [9u8; 32];
+        let foreign_fingerprint = calculate_seed_fingerprint(&foreign_seed).unwrap();
+
+        let check_result = check_pczt_cypherpunk(
+            &pczt::test_support::Nu6_3Network,
+            &sample.bytes,
+            &sample.ufvk_text,
+            &foreign_fingerprint,
+            0,
+        );
+        assert!(matches!(check_result, Err(ZcashError::PcztNoMyInputs)));
+
         let normalized = check_pczt_cypherpunk(
             &pczt::test_support::Nu6_3Network,
             &sample.bytes,
@@ -2382,8 +2387,6 @@ mod tests {
             0,
         )
         .unwrap();
-        let foreign_seed = [9u8; 32];
-        let foreign_fingerprint = calculate_seed_fingerprint(&foreign_seed).unwrap();
 
         let result = sign_checked_pczt(
             &pczt::test_support::Nu6_3Network,
@@ -2393,6 +2396,21 @@ mod tests {
             0,
         );
         assert!(matches!(result, Err(ZcashError::PcztNoMyInputs)));
+    }
+
+    #[test]
+    fn test_check_pczt_accepts_owned_transparent_input() {
+        let sample = pczt::legacy_test_support::legacy_transparent_sample();
+        let ufvk = derive_ufvk(&MainNetwork, &sample.seed, "m/32'/133'/0'").unwrap();
+
+        check_pczt_cypherpunk(
+            &MainNetwork,
+            &sample.bytes,
+            &ufvk,
+            &sample.seed_fingerprint,
+            0,
+        )
+        .expect("an owned transparent input satisfies singleton ownership");
     }
 
     #[test]

--- a/rust/apps/zcash/src/lib.rs
+++ b/rust/apps/zcash/src/lib.rs
@@ -188,7 +188,7 @@ pub fn check_pczt_multi_coins<P: consensus::Parameters>(
     // FUTURE(omitted-field-recompute): recompute-or-check omitted fields here,
     // mutating `pczt` so the normalized bytes carry the verified values forward.
     // transparent-only build: pczt's orchard feature (and resolve_fields) is not compiled here.
-    reject_legacy_check_unsupported_pczt(&pczt)?;
+    reject_unsupported_pczt(&pczt)?;
     let account_pubkey = transparent_account_pubkey_from_xpub(xpub)?;
     let account_index = zip32::AccountId::try_from(account_index)
         .map_err(|_e| ZcashError::InvalidDataError("invalid account index".to_string()))?;
@@ -230,7 +230,7 @@ fn transparent_account_pubkey_from_xpub(
 }
 
 #[cfg(feature = "multi_coins")]
-fn reject_legacy_check_unsupported_pczt(pczt: &Pczt) -> Result<()> {
+fn reject_unsupported_pczt(pczt: &Pczt) -> Result<()> {
     {
         // The legacy multi-coins check path only verifies transparent data. Reject any
         // shielded (Sapling/Orchard/Ironwood) or V6 PCZT so check, parse, and sign

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -662,3 +662,47 @@ fn check_restricted_zero_value_output(
 
     Ok(())
 }
+
+#[cfg(all(test, feature = "cypherpunk"))]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[derive(Serialize, Deserialize)]
+    struct PcztWirePrefix {
+        global: ::pczt::common::Global,
+        transparent: Option<::pczt::transparent::Bundle>,
+        sapling: Option<::pczt::sapling::Bundle>,
+    }
+
+    #[test]
+    fn check_orchard_accepts_pczt_with_transparent_output() {
+        let orchard_sample = crate::pczt::test_support::sample_orchard_change_pczt();
+        let transparent_sample = crate::pczt::legacy_test_support::legacy_transparent_v6_sample();
+        let (mut prefix, orchard_bundles) =
+            postcard::take_from_bytes::<PcztWirePrefix>(&orchard_sample.bytes[8..]).unwrap();
+        let (transparent_prefix, _) =
+            postcard::take_from_bytes::<PcztWirePrefix>(&transparent_sample.bytes[8..]).unwrap();
+        prefix.transparent = transparent_prefix.transparent;
+
+        let mut bytes = orchard_sample.bytes[..8].to_vec();
+        bytes = postcard::to_extend(&prefix, bytes).unwrap();
+        bytes.extend_from_slice(orchard_bundles);
+        let pczt = Pczt::parse(&bytes).unwrap();
+        let ufvk = UnifiedFullViewingKey::decode(
+            &crate::pczt::test_support::Nu6_3Network,
+            &orchard_sample.ufvk_text,
+        )
+        .unwrap();
+
+        check_pczt_orchard(
+            &crate::pczt::test_support::Nu6_3Network,
+            &orchard_sample.seed_fingerprint,
+            zip32::AccountId::ZERO,
+            &ufvk,
+            &pczt,
+        )
+        .expect("valid Orchard spend with a transparent output should pass checking");
+    }
+}

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -396,7 +396,6 @@ fn check_shielded_bundle<P: consensus::Parameters>(
     bundle: &orchard::pczt::Bundle,
     pool: ShieldedPool,
 ) -> Result<(), ZcashError> {
-    let pool_label = pool;
     let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
         "orchard fvk is not present".to_string(),
     ))?;
@@ -427,7 +426,7 @@ fn check_shielded_bundle<P: consensus::Parameters>(
     match calculated_value_balance {
         Ok(value_balance) if &value_balance == bundle.value_sum() => Ok(()),
         _ => Err(ZcashError::InvalidPczt(format!(
-            "invalid {pool_label} bundle value balance"
+            "invalid {pool} bundle value balance"
         ))),
     }
 }
@@ -446,7 +445,6 @@ fn check_and_parse_shielded_bundle<P: consensus::Parameters>(
     pool: ShieldedPool,
     checked_actions: &mut alloc::vec::Vec<ShieldedAction>,
 ) -> Result<Option<ParsedOrchard>, ZcashError> {
-    let pool_label = pool;
     let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
         "orchard fvk is not present".to_string(),
     ))?;
@@ -520,7 +518,7 @@ fn check_and_parse_shielded_bundle<P: consensus::Parameters>(
             }
         }
         _ => Err(ZcashError::InvalidPczt(format!(
-            "invalid {pool_label} bundle value balance"
+            "invalid {pool} bundle value balance"
         ))),
     }
 }
@@ -537,12 +535,11 @@ fn check_action<P: consensus::Parameters>(
     flags: &orchard::bundle::Flags,
     pool: ShieldedPool,
 ) -> Result<ParsedTo, ZcashError> {
-    let pool_label = pool;
     // Check `cv_net` first so we know that the `value` fields for both the spend and the
     // output are present and correct.
-    action.verify_cv_net().map_err(|e| {
-        ZcashError::InvalidPczt(format!("invalid cv_net in {pool_label} action: {e:?}"))
-    })?;
+    action
+        .verify_cv_net()
+        .map_err(|e| ZcashError::InvalidPczt(format!("invalid cv_net in {pool} action: {e:?}")))?;
 
     check_action_spend(
         params,
@@ -565,7 +562,6 @@ fn check_action_spend<P: consensus::Parameters>(
     spend: &orchard::pczt::Spend,
     pool: ShieldedPool,
 ) -> Result<(), ZcashError> {
-    let pool_label = pool;
     if let (Some(value), Some(zip32_derivation)) = (spend.value(), spend.zip32_derivation()) {
         if value.inner() != 0 && zip32_derivation.seed_fingerprint() == seed_fingerprint {
             let matched_account = super::matching_seed_supported_orchard_account(
@@ -604,11 +600,11 @@ fn check_action_spend<P: consensus::Parameters>(
 
     if let Some(expected_fvk) = can_verify_nf_rk {
         spend.verify_nullifier(expected_fvk).map_err(|e| {
-            ZcashError::InvalidPczt(format!("invalid {pool_label} action nullifier: {e:?}"))
+            ZcashError::InvalidPczt(format!("invalid {pool} action nullifier: {e:?}"))
         })?;
-        spend.verify_rk(expected_fvk).map_err(|e| {
-            ZcashError::InvalidPczt(format!("invalid {pool_label} action rk: {e:?}"))
-        })?;
+        spend
+            .verify_rk(expected_fvk)
+            .map_err(|e| ZcashError::InvalidPczt(format!("invalid {pool} action rk: {e:?}")))?;
     }
 
     Ok(())
@@ -622,11 +618,10 @@ fn check_action_output<P: consensus::Parameters>(
     flags: &orchard::bundle::Flags,
     pool: ShieldedPool,
 ) -> Result<ParsedTo, ZcashError> {
-    let pool_label = pool;
     action
         .output()
         .verify_note_commitment(action.spend())
-        .map_err(|e| ZcashError::InvalidPczt(format!("invalid {pool_label} action cmx: {e:?}")))?;
+        .map_err(|e| ZcashError::InvalidPczt(format!("invalid {pool} action cmx: {e:?}")))?;
 
     // Decode and validate the recipient, rejecting non-zero outputs the device cannot review.
     let parsed_to = super::parse::parse_orchard_output(params, keys, action, pool)?;

--- a/rust/apps/zcash/src/pczt/check.rs
+++ b/rust/apps/zcash/src/pczt/check.rs
@@ -396,7 +396,7 @@ fn check_shielded_bundle<P: consensus::Parameters>(
     bundle: &orchard::pczt::Bundle,
     pool: ShieldedPool,
 ) -> Result<(), ZcashError> {
-    let pool_label = pool.label();
+    let pool_label = pool;
     let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
         "orchard fvk is not present".to_string(),
     ))?;
@@ -446,7 +446,7 @@ fn check_and_parse_shielded_bundle<P: consensus::Parameters>(
     pool: ShieldedPool,
     checked_actions: &mut alloc::vec::Vec<ShieldedAction>,
 ) -> Result<Option<ParsedOrchard>, ZcashError> {
-    let pool_label = pool.label();
+    let pool_label = pool;
     let fvk = ufvk.orchard().ok_or(ZcashError::InvalidDataError(
         "orchard fvk is not present".to_string(),
     ))?;
@@ -537,7 +537,7 @@ fn check_action<P: consensus::Parameters>(
     flags: &orchard::bundle::Flags,
     pool: ShieldedPool,
 ) -> Result<ParsedTo, ZcashError> {
-    let pool_label = pool.label();
+    let pool_label = pool;
     // Check `cv_net` first so we know that the `value` fields for both the spend and the
     // output are present and correct.
     action.verify_cv_net().map_err(|e| {
@@ -565,7 +565,7 @@ fn check_action_spend<P: consensus::Parameters>(
     spend: &orchard::pczt::Spend,
     pool: ShieldedPool,
 ) -> Result<(), ZcashError> {
-    let pool_label = pool.label();
+    let pool_label = pool;
     if let (Some(value), Some(zip32_derivation)) = (spend.value(), spend.zip32_derivation()) {
         if value.inner() != 0 && zip32_derivation.seed_fingerprint() == seed_fingerprint {
             let matched_account = super::matching_seed_supported_orchard_account(
@@ -622,7 +622,7 @@ fn check_action_output<P: consensus::Parameters>(
     flags: &orchard::bundle::Flags,
     pool: ShieldedPool,
 ) -> Result<ParsedTo, ZcashError> {
-    let pool_label = pool.label();
+    let pool_label = pool;
     action
         .output()
         .verify_note_commitment(action.spend())
@@ -651,15 +651,12 @@ fn check_restricted_zero_value_output(
     }
 
     let recipient = action.output().recipient().ok_or_else(|| {
-        ZcashError::InvalidPczt(format!(
-            "missing recipient for funded {} output",
-            pool.label()
-        ))
+        ZcashError::InvalidPczt(format!("missing recipient for funded {} output", pool))
     })?;
     if !super::parse::is_wallet_orchard_address(keys, &recipient)? {
         return Err(ZcashError::InvalidPczt(format!(
             "funded {} output paired with a zero-value spend does not belong to the selected account",
-            pool.label()
+            pool
         )));
     }
 

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -202,7 +202,6 @@ pub(crate) fn matching_seed_supported_orchard_account_parts(
     coin_type: u32,
     pool: ShieldedPool,
 ) -> Result<Option<zcash_vendor::zip32::AccountId>, crate::errors::ZcashError> {
-    let pool_label = pool;
     let Some((derivation_seed_fingerprint, derivation_path)) = derivation else {
         return Ok(None);
     };
@@ -212,7 +211,7 @@ pub(crate) fn matching_seed_supported_orchard_account_parts(
 
     let unsupported_path = || {
         crate::errors::ZcashError::InvalidPczt(alloc::format!(
-            "unsupported {pool_label} spend ZIP 32 derivation path"
+            "unsupported {pool} spend ZIP 32 derivation path"
         ))
     };
 

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -146,11 +146,11 @@ pub(crate) enum ShieldedPool {
 }
 
 #[cfg(feature = "cypherpunk")]
-impl ShieldedPool {
-    pub(crate) fn label(self) -> &'static str {
+impl core::fmt::Display for ShieldedPool {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            ShieldedPool::Orchard => "Orchard",
-            ShieldedPool::Ironwood => "Ironwood",
+            ShieldedPool::Orchard => f.write_str("Orchard"),
+            ShieldedPool::Ironwood => f.write_str("Ironwood"),
         }
     }
 }
@@ -189,7 +189,7 @@ pub(crate) fn matching_seed_supported_orchard_account_parts(
     coin_type: u32,
     pool: ShieldedPool,
 ) -> Result<Option<zcash_vendor::zip32::AccountId>, crate::errors::ZcashError> {
-    let pool_label = pool.label();
+    let pool_label = pool;
     let Some((derivation_seed_fingerprint, derivation_path)) = derivation else {
         return Ok(None);
     };

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -799,22 +799,130 @@ pub(crate) mod test_support {
     }
 
     pub(crate) fn sample_orchard_change_pczt() -> SamplePczt {
-        sample_orchard_change_pczt_for_account(0, TxVersion::V6)
+        sample_orchard_change_pczt_for_account(0)
     }
 
-    pub(crate) fn sample_legacy_orchard_change_pczt() -> SamplePczt {
-        sample_orchard_change_pczt_for_account(0, TxVersion::V5)
+    /// Fixed v1 bytes that remain independent of changes to the current PCZT builders.
+    pub(crate) fn sample_legacy_transparent_orchard_pczt() -> SamplePczt {
+        const PCZT_HEX: &str = concat!(
+            "50435a5401000000058ace9cb502b4a1db960c0100a8897a850100000101010101010101010101010101010101010101",
+            "010101010101010101010101010000000000c0843d1976a914ba4ef3bbc4125b49a6abd7415b967c59e9b667fe88ac00",
+            "000101023069edcd102ea24cb79c64fc6f28b599901bfbc1b4018fda1cb1644263469aff0f213b9facb6c1cf1b1884be",
+            "c4380deffd25fe0a5f8cfac12249474cfaa07a5d05ac80808008858180800880808080080000000000000001b0b63c19",
+            "76a914a4a95f46235f144e92ac1a7e2f601640fd25894388ac00000123743159744669796f35467442707a78327a7241",
+            "586a52597336364556664432447743470000000000000000000000000000000000000000000000000000000000000000",
+            "000000000002d7de77f6ffe88bc38e68fb0a754a8487344a12f5138492f1284b22092000501bca0d93ecc6298e39c882",
+            "41e4788bcff09c8766e5cc643df29dfb4181d060cb2db3b123b6f1b8a19016b8df2daf7b0ba5fbe61055db093d216658",
+            "b8a77126a18d0001f5520a1777474e15757f4a8cbb6b84bf926e24e8c12eda940a9cc69b99fc06cc84e87d0949cb12e2",
+            "22101901c0843d01068957ba39a3428fda2844fc8c8e5cde846908c9291fa36a5a157ef6af45551801cb715a9c98b3f2",
+            "bba68725aebd130616f2055571131313c33a30d4e67430957001fea7e5f33f92dbdaeb60f04893da113cbd058832f724",
+            "b0a521f70c6b32e9e2095587d375f5772a54e29eac5f11352f3ead177237470370b3de8cfc331257681c109f29f7435b",
+            "32df20eff2429ef6f617dcb07705d75701d63d3ea34cdfa9ef3e01000200000000000000000000000000000000000000",
+            "000000000000000000000000d1ab2507c809c2713c000f525e9fbdcb06c958384e51b9cc7f792dde6c97f411c7413f46",
+            "14cd64043abbab7cc1095c9bb104231cea89e2c3e0df83769556d0302111fc397753e5fd50ec74816df27d6ada7ed2a9",
+            "ac3816aab2573c8fac794204806afbfeb45c64d4f2384c51eff30764b84599ae56a7ab3d4a46d9ce3aeab431873e4157",
+            "f2c0f0c645e899360069fcc9d2ed9bc11bf59827af0230ed52edab1827ab1320953ae1ad70c8c15a1253a0a86fbc8a0a",
+            "a36a84207293f8a495ffc4024e14563df191a2a65b4b37113b5230680555051b22d74a8e1f1d706f90f3133bb3bbe4f9",
+            "93d18a0f4eb7f4174b1d8555ce3396855d04676f1ce4f06dda07371f4ef5bde9c6f0d76aeb9e27e93fba28c679dfcb99",
+            "1cbcb8395a2b57924cbd170ea3c02568acebf5ca1ec30d6a7d7cd217a47d6a1b8311bf9462a5f939c6b743073ef9b30b",
+            "ae6122da1605bad6ec5d49b41d4d40caa96c1cf6302b66c5d2d10d3922ae2800cb93abe63b70c172de70362d9830e538",
+            "00398884a7a64ff68ed99e0b187110d92672c24cedb0979cdfc917a6053b310d145c031c7292bb1d65b7661b3f98adbe",
+            "364f148b0cc2042cafc6be1166fae39090ab4b354bfb6217b964453b63f8dbd10df936f1734973e0b3bd25f4ed440566",
+            "c923085903f696bc6347ec0f2182163eac4061885a313568148dfae564e478066dcbe389a0ddb1ecb7f5dc34bd9dc068",
+            "1918a3f3f9cd1f9e06aa1ad68927da63acc13b92a2578b2738a6d331ca2ced953b7fb95e3ba986333da9e69cd355223c",
+            "929731094b6c2174c7638d2e55354b96b56f9e45aae1e0094d71ee248dabf668117778bdc3c19ca5331a4e1a7097b04c",
+            "2aa045a0deffcaca41c5ac92e694466578f5909e72bb78d33310f705e81d6821ff813bd410867a3f22e8e5cb7ac5599a",
+            "610af5c354eb392877362e01157de8567f7c4996b8c4fdc94938fd808c3b2a5ccb79d1a63858adaa9a6dd824fe1fce51",
+            "cd6120c12c124695c4f98b275918fceae6eb209873ed73fe73775d0b1f91982912012669f74d0cfa1030ff37b152324e",
+            "5b8346b3335a0aaeb63a0a2d5dec15f52af17da3931396183cbbbfbea7ed950714540aec06c645c754975522e8ae2ad9",
+            "1d463bab75ee941d33cc5817b613c63cda943a4c07f600591b088a25d53fdee371cef596766823f4a518a583b1158243",
+            "afe89700f0da76da46d0060f15d2444cefe7914c9a61e829c730eceb216288fee825f6b3b6298f6f6b6bd62e4c57a617",
+            "a0aa10ea7a83aa6b6b0ed685b6a3d9e5b8fd14f56cdc18021b12253f3fd4915c19bd831a7920be55d969b2ac23359e25",
+            "59da77de2373f06ca014ba2787d063cd07ee4944222b7762840eb94c688bec743fa8bdf7715c8fe29f104c2a0139c304",
+            "0591d5490335cb982852d9d9db581779db3141cf2198ababa1c15a172c010f213b9facb6c1cf1b1884bec4380deffd25",
+            "fe0a5f8cfac12249474cfaa07a5d03a0808080088581808008808080800800002d97e62e15dd29c7d00a16f9d555e468",
+            "37aaebcdaaefd7d341e142a9e45e2425ce7f12eac4afa1e7f6a807c2a552e88a2459655d57486ec1c6c5e739da72d22f",
+            "c404003f915d95cd8e53c5fa9e4856f0b24bcb639132ddb981241079ed6e9cdfb2197b1bfcb234b23012bb5c7aaf134f",
+            "1ce888360cbb8663acfce17a6c847fc033f630ff9c061bebb9da1732f30e7eb4af50d9f238428896831aa3a323593d34",
+            "863eaf5e2fb1819eedc8ee8a1f280a9672f0a8970eb509ef0df107ce8a621331413ddecb3ac2e54501068e824e423a57",
+            "374e92679e6898db5e76666c87bcae52c8b2b56b62c48b5639f638166426fcc12da61ef0d0be3ee2fca43fe608e30fc3",
+            "121a043cb757cca2c743037800f30560d94395b5f41a7c7c783c3c7255b297ae99fe16c06f0a659da4ec6d67772e87dc",
+            "d4623bbdf40c99d8c526e2605684c64fd30cdbcfa950ad82711011d2a781dd701957d860969093573eea6ca36b698c3e",
+            "ad422c962a5dfb8967b71274fdbf36ab5134bb78df7bf89a72b339a0ef632a4b3361cfec2a8b8af9a8be3b2f8097b3f6",
+            "bf873249cc2aa588b81ec39c733cb7f7e7bf69792781477a7ca429c20401785e6ffc2368c127a183589a3bcab8e58568",
+            "0d9746e43161b83f066eda7e24da96e88f36161ddae9a6eb9a08b272efa14c106d100eaeefbf61671fdca859e91f3b01",
+            "8600deef3469481c0cb4077ddb21dfa54f779d1b39a08d21255c9158be500acf976f0a4beef6ed62dbcf60339eff5d58",
+            "a489a67ab3559dd28d0e92382f7bda1b1c599a3d07e9c4408b2b08734b8635791cb60d0bf16fa5b64a9b03a278a6a613",
+            "17d115be42d48cd37ae395444d6966deec1a47e7728a43dbf296622a2db97dfbcd0fc76ecabd7d831a3b878de5b6dc8c",
+            "5bb3c2f2135a5063bf5055326e1f61e81967fdebc92e26179a5eb596da2948badc09ca94ed0d73bdf9ed250c43d70ca1",
+            "ebae520e069390ae527b3f02be5bb8052c6f4f968bc5aecb23d753b021dd9f7863a60bfa5a134101dae4e5dc1cc3ec8a",
+            "427138f7d59e13b8c21da9b2efd152aaa83ac7dce3b7de048af411a1fff8c8b7fb4f2e01b8dd3c016a45a187bcc465a4",
+            "5a2f8b2b63a5b3296f22b316bd24e7f0fa4eb44bff5e1dfd00000000017fbc144dafdd2423ce223ae359052b61085e8a",
+            "8da4b3e4188c9eaf89e108bb217159134427cdc6afa5d0ed3d9729e7ac122011ce0805d8924974ea5a3381a02da01904",
+            "d5a6b72ae0ee1c2a56c32f3a98ed2b1563bddf70e9d31d0d14c2c1bd0b9d73b752d50c4ccb9013c98fd228098e47640c",
+            "cf96e33ddda1874ff4acac0e890001663a9335eaadf30de4a0c57917476142d8344fd30e78f9ffce3a5256bba83f4d84",
+            "c7589964d089033c8f12010001d7a7f858ffb16f4124a57f5d7d5e3c75919efd26619421cdc116cb77ea36aa3d0176d7",
+            "898d75e50d30ccb98c5616642a2ad7c908e0f43f44519885151afada70f10154c1c128b406f34be416ca8ddc52f0d4a7",
+            "c7318e9eeece33265e30b256cf1a3c93cd916f299b1129571f506df32af6bce7f97690108926c3fcd6a10930733f2c10",
+            "af50998bd7060533695bf10bd470f42333f2ce10648ad8a828281eab4e382401f0b093c30b86420dc27ace6a500c9c35",
+            "859cf9a57403d9b1ddec048652912e6a30aea8583516e059921d3e38a823d7df257152a124743caa09eddab02e1169c9",
+            "f8bd4a45140a7e56356a3b3a228fd9a5a730f871eba0f3983e1dc28a3bf2f88f3bf302760a999cce88e27151507b47dc",
+            "0c79a5e6596c5c14a14461c5d7b9312bc73fb6192c772a9c1305df036f75ffb6f4d497d43e33ae80aab01f8e620e35da",
+            "05dc3fa011e02240f8c6ab0b8cec024b342b6d21a6b35c37dbb396b7becdaf6b90614c233e65bd636063192181d7d9f9",
+            "1843239b9d95ab5859f0abbddd3163bfc53215d10bc15a2c548359e6356e25f1f4f1422f8969a5618447776f56285ecb",
+            "3c43fed11ec73926a555bb7e75e765f73f3820098044c6a084d8d883031e8db9e2fa9a6c0b9c43666027d0cef4765b02",
+            "7c2481a5be19a05ae8d36d4e6cc32fadc995c9d50a0e5ada2cc387903a4e178261bbc168b0f0854194d7e851ba6ce5a9",
+            "efaa6c842323272eaad5245f913d970c69ef20a3a581087b20dc9f16170b175df9e727662b09bb71dda5d918d6754767",
+            "980a9475acebd5c301534c29f9b7d8c9e3c1085d3582e65c64240409161c096874a10381c06fcb14a9f5606734ca7237",
+            "e7faa1f4016b8cc1dd24bb5628587bb328493a52f498a66963f59bffaf8c4ede0f2c0e30113ce58f6d550274e371b945",
+            "c76cee8c06436453aa725ac7d94e2a109bf0fc360f88cf9be0b163fa582e56d6e582ea72acf68c7cdf98b7c099ecd365",
+            "58fccf1a016180d515b4ed742267158a81661211bfcf64dbeca3601107635292e09877bd044e94149d0a9184a5ff060b",
+            "8409a1cb4bdbff30bb5bffb350fa82674255e6a20849d99cf25cf31ccf5abea96de641f7509dc1daebcdd16ad08b96b9",
+            "ed8d47cf1457c1ade6b892f23c3cbe0b924c761f19ec6bc7efa6924c893c3972f84eb0aa3dc7cd7b3d88b3e08be850c4",
+            "9aa33a1e672dc7b204aacf7a81ac461df202b97a3170fdc972c6bb19902051df2db8d635b2c4e6ad62ef1d3dfb5da816",
+            "a1a3b9c00e5c486e2881cce37261f34268277694bad8af2005f3f4e8cb7fd8eacc57cb3923f5538b448a5e8723cdb446",
+            "d976c2451eb8cdeb6d402a341b512db0863ca6df16b501671b46eb4eed88fa0c72dc532d263eaedf4ae89ac334265d84",
+            "8c830e73168813f5d05c16c2c60329bf5f288a20db2716d1017897aee19c23a558c4aeae1991eb4885c2e003ffc2834b",
+            "df4f07e2e6708824f4903ef4d7595672c68b23a830ba20a81eead158627dccf045e10c78cd055e7f15006f029300a08f",
+            "de4824a005066e3567b72245c547d2953121e334f54b9990543ddea0395ee997f26c0b8d30d9ed146b83122323a64cdb",
+            "5bfa95c2b38d01365ad8412fdc67848a0123e6f73e207330ffb52bd38ce531eae1a2d978665fd89fc402e84ab78eb572",
+            "40329de10001688234fd1d9fe781607ae78eedbe68e33ab9233f91e7f2392ed2bad56abb61380001eb7a0da0effe1eb5",
+            "6108c8e542e9eb4ebf05740e3776a6caafe25c88b1245b6f0093128312cee979e30cad333190f0e73616924b250daf78",
+            "8c528a7e954a491108801562a9acd5f569fee3a89c0472d14d705109366e019b786a1078278b429197c404735247d474",
+            "f4fd3ca0c11a5d334d421d3e2b710c725290d5dd005da6eb83daa8c3c8a5cfe9aa2e69eea60170383207a1d1e8fbeb5c",
+            "51e177b0b7849d8e3f73cdb931f37d89350617586ed88f7e993271388c749674a8d57ebdcbd688676cd1ec0f359f6f54",
+            "df92ca61a93d61e1439a640a66e32f1429c3b7492308ba05dc5bf601c154f45389f236fb203b04f977a12695122334f4",
+            "0785cf31464b3c16def65256c06678bb96cd07456577a6fa5f966a8b64d728492b7c3b944c5062f05197274e8065b7ef",
+            "864ff7e0bef15476d3bd855d6cacae99c83a0330f66b42f3f3cce8859c28759aa52bd9456e95cd4a2589c95e8d82bdce",
+            "726b128bc0865ba3913473b9beeacbc478e33aef2f5a529018c0611af2aaf77a6e2beeaad86b067d70d71a45c757b57c",
+            "c82871790c5b70b23f40c6f73499ed3c5d68abe32009d618811b10f7f604df66460a7fe26fb0d4c3b771aa0ba763070c",
+            "78997d6c712f5775e4092844876f5c7849d755e69283ca4788c38427570fbf956f4afbb42c0cc1c2bbc6e49660a1f4eb",
+            "2e5d44183f52abd216d32db5dd5702801065ac6a8edd3f34ea25e16d084b379014946bd809bca84b1861df2d262001dc",
+            "80b132a5a4cee03a5c7c8694cd383c3a89e928af8e70ff66162a43002fcd193c346ff64a4cd72a75478712151b06b78f",
+            "ff0a32f3b4efb6639b68eae3a247defa7c16c55b7a38785544e18a50ad7eb378b29e27d4c447b51f7b2d03693622ed5d",
+            "a3482e18673d22c8e5963491943122eb338538dba12dcf2e8b5bd69043e043beaadd0eb133bdca4454a648dd07235650",
+            "3cc5776971573054c7863a384539afd5e65466cf682378518360e428d669d73a60f168fe1fff33abdb5602c1e088eb28",
+            "d16a79144c089c230b167fcc953678ac3992df58119b0c378c806aa8bc2cd00701a492bd2f05b8c8147f431e5c6fc951",
+            "7393f9f7527dd1a97d0ae104c31143e80940b6ea23a7c5293f109db5010001202811a564c8023a720cfeb8acf07e7a66",
+            "95271230e12055ae9b1bd15ec7a7c10000000001541f53a50812ca83a8b61a9d7cc6e84839dfa1ffcf2d8b3b9266b228",
+            "ad067214038827002078c89963306be0c1793873e73636a0371992af9d75489945d522591dbf98140000",
+        );
+
+        let params = MainNetwork;
+        let seed = [7u8; 32];
+        SamplePczt {
+            bytes: hex::decode(PCZT_HEX).expect("hard-coded v1 PCZT fixture is valid hex"),
+            seed: seed.to_vec(),
+            ufvk_text: derive_ufvk(&params, &seed, "m/32'/133'/0'").unwrap(),
+            seed_fingerprint: calculate_seed_fingerprint(&seed).unwrap(),
+        }
     }
 
     pub(crate) fn sample_orchard_foreign_change_pczt() -> SamplePczt {
-        sample_orchard_change_pczt_for_account(1, TxVersion::V6)
+        sample_orchard_change_pczt_for_account(1)
     }
 
-    fn sample_orchard_change_pczt_for_account(
-        output_account: u32,
-        tx_version: TxVersion,
-    ) -> SamplePczt {
-        let v6 = tx_version == TxVersion::V6;
+    fn sample_orchard_change_pczt_for_account(output_account: u32) -> SamplePczt {
         let params = MainNetwork;
         let seed = [7u8; 32];
         let ufvk_text = derive_ufvk(&params, &seed, "m/32'/133'/0'").unwrap();
@@ -882,16 +990,8 @@ pub(crate) mod test_support {
 
         let mut builder = orchard::builder::Builder::new(
             orchard::builder::BundleType::DEFAULT,
-            if v6 {
-                orchard::bundle::BundleVersion::orchard_v3()
-            } else {
-                orchard::bundle::BundleVersion::orchard_v2()
-            },
-            if v6 {
-                orchard::bundle::BundleVersion::orchard_v3().default_flags()
-            } else {
-                orchard::bundle::BundleVersion::orchard_v2().default_flags()
-            },
+            orchard::bundle::BundleVersion::orchard_v3(),
+            orchard::bundle::BundleVersion::orchard_v3().default_flags(),
             anchor,
         )
         .expect("default flags are representable under the bundle version");
@@ -911,8 +1011,8 @@ pub(crate) mod test_support {
         let seed_fingerprint = calculate_seed_fingerprint(&seed).unwrap();
         let pczt = Creator::build_from_parts(PcztParts {
             params,
-            version: tx_version,
-            consensus_branch_id: if v6 { BranchId::Nu6_3 } else { BranchId::Nu6 },
+            version: TxVersion::V6,
+            consensus_branch_id: BranchId::Nu6_3,
             lock_time: 0,
             expiry_height: BlockHeight::from_u32(10_000_000),
             transparent: None,
@@ -939,7 +1039,7 @@ pub(crate) mod test_support {
                         })
                     })
                     .collect::<Vec<_>>();
-                assert_eq!(signing_action_accounts.len(), if v6 { 2 } else { 1 });
+                assert_eq!(signing_action_accounts.len(), 2);
 
                 for (action_index, account) in signing_action_accounts {
                     let derivation = orchard::pczt::Zip32Derivation::parse(

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -19,6 +19,7 @@ pub(crate) fn parse_pczt(bytes: &[u8]) -> Result<Pczt, ZcashError> {
 
 pub(crate) fn validate_supported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     validate_sapling_bundle_consistency(pczt)?;
+    validate_empty_orchard_protocol_bundle_balances(pczt)?;
 
     {
         if pczt_has_ironwood_actions(pczt) && !pczt_is_v6(pczt) {
@@ -44,6 +45,18 @@ pub(crate) fn validate_supported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
 
     #[cfg(feature = "cypherpunk")]
     validate_distinct_orchard_protocol_rks(pczt)?;
+
+    Ok(())
+}
+
+fn validate_empty_orchard_protocol_bundle_balances(pczt: &Pczt) -> Result<(), ZcashError> {
+    for (pool, bundle) in [("Orchard", pczt.orchard()), ("Ironwood", pczt.ironwood())] {
+        if bundle.actions().is_empty() && bundle.value_sum().0 != 0 {
+            return Err(ZcashError::InvalidPczt(format!(
+                "{pool} value_sum must be zero when {pool} bundle is empty"
+            )));
+        }
+    }
 
     Ok(())
 }
@@ -232,6 +245,92 @@ pub(crate) fn pczt_requires_cypherpunk_support(pczt: &zcash_vendor::pczt::Pczt) 
         || !pczt.sapling().outputs().is_empty()
         || !pczt.orchard().actions().is_empty()
         || !pczt.ironwood().actions().is_empty()
+}
+
+#[cfg(all(test, feature = "cypherpunk"))]
+mod consistency_tests {
+    use alloc::{format, vec::Vec};
+
+    use ::pczt::roles::creator::Creator;
+    use serde::{Deserialize, Serialize};
+    use zcash_vendor::zcash_protocol::consensus::{BranchId, MainNetwork, NetworkConstants};
+
+    use super::*;
+
+    #[derive(Serialize, Deserialize)]
+    struct EmptyPcztWire {
+        global: ::pczt::common::Global,
+        transparent: Option<::pczt::transparent::Bundle>,
+        sapling: Option<::pczt::sapling::Bundle>,
+        orchard: Option<EmptyShieldedBundleWire>,
+        ironwood: Option<EmptyShieldedBundleWire>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct EmptyShieldedBundleWire {
+        actions: Vec<()>,
+        flags: u8,
+        value_sum: (u64, bool),
+        anchor: Option<[u8; 32]>,
+        note_version: NoteVersionWire,
+        zkproof: Option<Vec<u8>>,
+        bsk: Option<[u8; 32]>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    enum NoteVersionWire {
+        V2,
+        V3,
+    }
+
+    fn empty_bundle_with_nonzero_value_sum(pool: ShieldedPool) -> Vec<u8> {
+        let branch_id = match pool {
+            ShieldedPool::Orchard => BranchId::Nu6,
+            ShieldedPool::Ironwood => BranchId::Nu6_3,
+        };
+        let bytes = Creator::new(branch_id.into(), 10, MainNetwork.coin_type(), None, None)
+            .unwrap()
+            .build()
+            .unwrap()
+            .serialize()
+            .unwrap();
+        let mut wire: EmptyPcztWire = postcard::from_bytes(&bytes[8..]).unwrap();
+        let bundle = EmptyShieldedBundleWire {
+            actions: Vec::new(),
+            flags: match pool {
+                ShieldedPool::Orchard => 0b0000_0011,
+                ShieldedPool::Ironwood => 0b0000_0111,
+            },
+            value_sum: (1, false),
+            anchor: None,
+            note_version: match pool {
+                ShieldedPool::Orchard => NoteVersionWire::V2,
+                ShieldedPool::Ironwood => NoteVersionWire::V3,
+            },
+            zkproof: None,
+            bsk: None,
+        };
+        match pool {
+            ShieldedPool::Orchard => wire.orchard = Some(bundle),
+            ShieldedPool::Ironwood => wire.ironwood = Some(bundle),
+        }
+
+        postcard::to_extend(&wire, bytes[..8].to_vec()).unwrap()
+    }
+
+    #[test]
+    fn rejects_nonzero_value_sum_on_empty_orchard_protocol_bundles() {
+        for pool in [ShieldedPool::Orchard, ShieldedPool::Ironwood] {
+            let pczt = parse_pczt(&empty_bundle_with_nonzero_value_sum(pool)).unwrap();
+
+            assert_eq!(
+                validate_supported_pczt(&pczt),
+                Err(ZcashError::InvalidPczt(format!(
+                    "{pool} value_sum must be zero when {pool} bundle is empty"
+                )))
+            );
+        }
+    }
 }
 
 #[cfg(all(test, feature = "cypherpunk"))]

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -240,7 +240,25 @@ pub(crate) fn matching_seed_supported_orchard_account_parts(
 /// v6 is supported by the shared ZIP 244 sighash implementation.
 #[cfg(any(feature = "multi_coins", not(feature = "cypherpunk")))]
 pub(crate) fn pczt_is_unsupported_by_transparent_only(pczt: &zcash_vendor::pczt::Pczt) -> bool {
-    (*pczt.global().tx_version() >= 6 && !pczt_is_v6(pczt))
+    use zcash_vendor::zcash_protocol::{
+        consensus::{BranchId, OrchardProtocolRevision},
+        constants::{V5_TX_VERSION, V5_VERSION_GROUP_ID, V6_TX_VERSION, V6_VERSION_GROUP_ID},
+    };
+
+    let orchard_revision = BranchId::try_from(*pczt.global().consensus_branch_id())
+        .ok()
+        .and_then(|branch_id| branch_id.orchard_protocol_revision());
+    let supported_transaction_format = match (
+        *pczt.global().tx_version(),
+        *pczt.global().version_group_id(),
+        orchard_revision,
+    ) {
+        (V5_TX_VERSION, V5_VERSION_GROUP_ID, Some(_)) => true,
+        (V6_TX_VERSION, V6_VERSION_GROUP_ID, Some(OrchardProtocolRevision::V3)) => true,
+        _ => false,
+    };
+
+    !supported_transaction_format
         || !pczt.sapling().spends().is_empty()
         || !pczt.sapling().outputs().is_empty()
         || !pczt.orchard().actions().is_empty()

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -235,12 +235,12 @@ pub(crate) fn matching_seed_supported_orchard_account_parts(
         .map_err(|_| unsupported_path())
 }
 
-/// Returns whether a PCZT carries anything the transparent-only legacy path
-/// cannot handle: a v6+ transaction, or any shielded (Sapling/Orchard/Ironwood)
-/// content. These must be checked, parsed, and signed by the cypherpunk build.
+/// Returns whether a PCZT carries anything the transparent-only path cannot
+/// handle: shielded content or an unknown transaction format. Transparent-only
+/// v6 is supported by the shared ZIP 244 sighash implementation.
 #[cfg(any(feature = "multi_coins", not(feature = "cypherpunk")))]
-pub(crate) fn pczt_requires_cypherpunk_support(pczt: &zcash_vendor::pczt::Pczt) -> bool {
-    *pczt.global().tx_version() >= 6
+pub(crate) fn pczt_is_unsupported_by_transparent_only(pczt: &zcash_vendor::pczt::Pczt) -> bool {
+    (*pczt.global().tx_version() >= 6 && !pczt_is_v6(pczt))
         || !pczt.sapling().spends().is_empty()
         || !pczt.sapling().outputs().is_empty()
         || !pczt.orchard().actions().is_empty()
@@ -957,7 +957,7 @@ pub(crate) mod legacy_test_support {
             keys::{AccountPrivKey, IncomingViewingKey},
         },
         zcash_protocol::{
-            consensus::{MainNetwork, NetworkUpgrade, Parameters},
+            consensus::{BlockHeight, MainNetwork, NetworkType, NetworkUpgrade, Parameters},
             value::Zatoshis,
         },
         zip32,
@@ -971,6 +971,22 @@ pub(crate) mod legacy_test_support {
         pub(crate) xpub: String,
         #[cfg(feature = "multi_coins")]
         pub(crate) input_pubkey: [u8; 33],
+    }
+
+    #[derive(Clone, Copy)]
+    struct Nu6_3Network;
+
+    impl Parameters for Nu6_3Network {
+        fn network_type(&self) -> NetworkType {
+            NetworkType::Main
+        }
+
+        fn activation_height(&self, nu: NetworkUpgrade) -> Option<BlockHeight> {
+            match nu {
+                NetworkUpgrade::Nu6_3 => Some(BlockHeight::from_u32(10)),
+                _ => MainNetwork.activation_height(nu),
+            }
+        }
     }
 
     pub(crate) fn legacy_transparent_path_for_account(account_index: u32) -> Vec<u32> {
@@ -1008,6 +1024,18 @@ pub(crate) mod legacy_test_support {
 
     pub(crate) fn legacy_transparent_sample() -> LegacyTransparentSample {
         let params = MainNetwork;
+        let target_height = params.activation_height(NetworkUpgrade::Nu5).unwrap();
+        transparent_sample(params, target_height)
+    }
+
+    pub(crate) fn legacy_transparent_v6_sample() -> LegacyTransparentSample {
+        transparent_sample(Nu6_3Network, BlockHeight::from_u32(10))
+    }
+
+    fn transparent_sample<P: Parameters>(
+        params: P,
+        target_height: BlockHeight,
+    ) -> LegacyTransparentSample {
         let seed = [7u8; 32];
         let account = AccountPrivKey::from_seed(&params, &seed, zip32::AccountId::ZERO).unwrap();
         let (input_addr, address_index) = account
@@ -1026,9 +1054,7 @@ pub(crate) mod legacy_test_support {
             .derive_external_ivk()
             .unwrap()
             .default_address();
-        let transparent_recipient = recipient
-            .to_zcash_address(MainNetwork.network_type())
-            .encode();
+        let transparent_recipient = recipient.to_zcash_address(params.network_type()).encode();
 
         let coin = transparent::TxOut::new(
             Zatoshis::const_from_u64(1_000_000),
@@ -1036,7 +1062,7 @@ pub(crate) mod legacy_test_support {
         );
         let mut builder = Builder::new(
             &params,
-            params.activation_height(NetworkUpgrade::Nu5).unwrap(),
+            target_height,
             BuildConfig::Standard {
                 sapling_anchor: None,
                 orchard_anchor: None,

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -782,14 +782,22 @@ pub(crate) mod test_support {
     }
 
     pub(crate) fn sample_orchard_change_pczt() -> SamplePczt {
-        sample_orchard_change_pczt_for_account(0)
+        sample_orchard_change_pczt_for_account(0, TxVersion::V6)
+    }
+
+    pub(crate) fn sample_legacy_orchard_change_pczt() -> SamplePczt {
+        sample_orchard_change_pczt_for_account(0, TxVersion::V5)
     }
 
     pub(crate) fn sample_orchard_foreign_change_pczt() -> SamplePczt {
-        sample_orchard_change_pczt_for_account(1)
+        sample_orchard_change_pczt_for_account(1, TxVersion::V6)
     }
 
-    fn sample_orchard_change_pczt_for_account(output_account: u32) -> SamplePczt {
+    fn sample_orchard_change_pczt_for_account(
+        output_account: u32,
+        tx_version: TxVersion,
+    ) -> SamplePczt {
+        let v6 = tx_version == TxVersion::V6;
         let params = MainNetwork;
         let seed = [7u8; 32];
         let ufvk_text = derive_ufvk(&params, &seed, "m/32'/133'/0'").unwrap();
@@ -857,8 +865,16 @@ pub(crate) mod test_support {
 
         let mut builder = orchard::builder::Builder::new(
             orchard::builder::BundleType::DEFAULT,
-            orchard::bundle::BundleVersion::orchard_v3(),
-            orchard::bundle::BundleVersion::orchard_v3().default_flags(),
+            if v6 {
+                orchard::bundle::BundleVersion::orchard_v3()
+            } else {
+                orchard::bundle::BundleVersion::orchard_v2()
+            },
+            if v6 {
+                orchard::bundle::BundleVersion::orchard_v3().default_flags()
+            } else {
+                orchard::bundle::BundleVersion::orchard_v2().default_flags()
+            },
             anchor,
         )
         .expect("default flags are representable under the bundle version");
@@ -878,8 +894,8 @@ pub(crate) mod test_support {
         let seed_fingerprint = calculate_seed_fingerprint(&seed).unwrap();
         let pczt = Creator::build_from_parts(PcztParts {
             params,
-            version: TxVersion::V6,
-            consensus_branch_id: BranchId::Nu6_3,
+            version: tx_version,
+            consensus_branch_id: if v6 { BranchId::Nu6_3 } else { BranchId::Nu6 },
             lock_time: 0,
             expiry_height: BlockHeight::from_u32(10_000_000),
             transparent: None,
@@ -906,7 +922,7 @@ pub(crate) mod test_support {
                         })
                     })
                     .collect::<Vec<_>>();
-                assert_eq!(signing_action_accounts.len(), 2);
+                assert_eq!(signing_action_accounts.len(), if v6 { 2 } else { 1 });
 
                 for (action_index, account) in signing_action_accounts {
                     let derivation = orchard::pczt::Zip32Derivation::parse(

--- a/rust/apps/zcash/src/pczt/mod.rs
+++ b/rust/apps/zcash/src/pczt/mod.rs
@@ -834,26 +834,25 @@ pub(crate) mod test_support {
     }
 }
 
-#[cfg(all(test, feature = "multi_coins", not(feature = "cypherpunk")))]
+#[cfg(all(test, any(feature = "multi_coins", feature = "cypherpunk")))]
 pub(crate) mod legacy_test_support {
-    use alloc::{
-        string::{String, ToString},
-        vec,
-        vec::Vec,
-    };
+    #[cfg(feature = "multi_coins")]
+    use alloc::string::{String, ToString};
+    use alloc::{vec, vec::Vec};
 
     use ::pczt::roles::{creator::Creator, updater::Updater};
     use bitcoin::secp256k1::Secp256k1;
-    use keystore::algorithms::{
-        secp256k1::get_extended_public_key_by_seed, zcash::calculate_seed_fingerprint,
-    };
+    #[cfg(feature = "multi_coins")]
+    use keystore::algorithms::secp256k1::get_extended_public_key_by_seed;
+    use keystore::algorithms::zcash::calculate_seed_fingerprint;
     use rand_core::OsRng;
     use zcash_primitives::transaction::{
         builder::{BuildConfig, Builder, PcztResult},
         fees::zip317,
     };
+    #[cfg(feature = "multi_coins")]
+    use zcash_vendor::pczt::Pczt;
     use zcash_vendor::{
-        pczt::Pczt,
         transparent::{
             bundle as transparent,
             keys::{AccountPrivKey, IncomingViewingKey},
@@ -869,7 +868,9 @@ pub(crate) mod legacy_test_support {
         pub(crate) bytes: Vec<u8>,
         pub(crate) seed: Vec<u8>,
         pub(crate) seed_fingerprint: [u8; 32],
+        #[cfg(feature = "multi_coins")]
         pub(crate) xpub: String,
+        #[cfg(feature = "multi_coins")]
         pub(crate) input_pubkey: [u8; 33],
     }
 
@@ -883,6 +884,7 @@ pub(crate) mod legacy_test_support {
         ]
     }
 
+    #[cfg(feature = "multi_coins")]
     pub(crate) fn legacy_transparent_pczt_with_input_derivation(
         bytes: &[u8],
         seed_fingerprint: [u8; 32],
@@ -978,6 +980,7 @@ pub(crate) mod legacy_test_support {
             .unwrap()
             .finish();
 
+        #[cfg(feature = "multi_coins")]
         let xpub = get_extended_public_key_by_seed(&seed, &"M/44'/133'/0'".into())
             .unwrap()
             .to_string();
@@ -986,7 +989,9 @@ pub(crate) mod legacy_test_support {
             bytes: pczt.serialize().unwrap(),
             seed: seed.to_vec(),
             seed_fingerprint,
+            #[cfg(feature = "multi_coins")]
             xpub,
+            #[cfg(feature = "multi_coins")]
             input_pubkey,
         }
     }

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -191,7 +191,7 @@ pub(crate) fn decode_output_enc_ciphertext(
         })
     } else {
         // If we reached here, none of our OVKs matched; recover directly as the fallback.
-        let pool_label = pool.label();
+        let pool_label = pool;
 
         let recipient = action.output().recipient().ok_or_else(|| {
             ZcashError::InvalidPczt(format!("Missing recipient field for {pool_label} action"))
@@ -705,7 +705,7 @@ pub(crate) fn parse_orchard_output<P: consensus::Parameters>(
     action: &orchard::pczt::Action,
     pool: ShieldedPool,
 ) -> Result<ParsedTo, ZcashError> {
-    let pool_label = pool.label();
+    let pool_label = pool;
     let output = action.output();
 
     // we should verify the cv_net in checking phrase, the transaction checking should failed if the net value is not correct

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -432,12 +432,12 @@ pub fn parse_pczt_multi_coins<P: consensus::Parameters>(
 #[cfg(feature = "multi_coins")]
 fn reject_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     {
-        // The legacy multi-coins parser only displays transparent data. Reject any
-        // shielded (Sapling/Orchard/Ironwood) or V6 PCZT instead of showing an
-        // incomplete transaction review.
-        if super::pczt_requires_cypherpunk_support(pczt) {
+        // The multi-coins parser only displays transparent data. Reject shielded
+        // content and unknown transaction formats instead of showing an incomplete
+        // transaction review.
+        if super::pczt_is_unsupported_by_transparent_only(pczt) {
             return Err(ZcashError::InvalidPczt(
-                "Shielded or V6 PCZTs require cypherpunk parsing support".to_string(),
+                "PCZT is not supported by transparent-only parsing".to_string(),
             ));
         }
     }
@@ -972,31 +972,23 @@ mod display_accounting_tests {
 #[cfg(all(test, feature = "multi_coins", not(feature = "cypherpunk")))]
 mod legacy_tests {
     use super::*;
-    use zcash_vendor::{
-        pczt::roles::creator::Creator,
-        zcash_protocol::consensus::{BranchId, MainNetwork, NetworkConstants},
-    };
+    use zcash_vendor::zcash_protocol::consensus::MainNetwork;
 
     #[test]
-    fn legacy_parse_rejects_v6_pczt() {
-        let pczt = Creator::new(
-            BranchId::Nu6_3.into(),
-            10,
-            MainNetwork.coin_type(),
-            None,
-            None,
-        )
-        .unwrap()
-        .build()
-        .unwrap();
+    fn legacy_parse_accepts_transparent_only_v6_pczt() {
+        let sample = super::super::legacy_test_support::legacy_transparent_v6_sample();
+        let pczt = Pczt::parse(&sample.bytes).unwrap();
 
-        let result = parse_pczt_multi_coins(&MainNetwork, &[7u8; 32], &pczt);
+        let parsed = parse_pczt_multi_coins(&MainNetwork, &sample.seed_fingerprint, &pczt)
+            .expect("transparent-only v6 PCZT should parse");
 
-        assert!(matches!(
-            result,
-            Err(ZcashError::InvalidPczt(msg))
-                if msg == "Shielded or V6 PCZTs require cypherpunk parsing support"
-        ));
+        assert!(parsed
+            .get_transparent()
+            .unwrap()
+            .get_from()
+            .first()
+            .unwrap()
+            .get_is_mine());
     }
 }
 

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -191,21 +191,19 @@ pub(crate) fn decode_output_enc_ciphertext(
         })
     } else {
         // If we reached here, none of our OVKs matched; recover directly as the fallback.
-        let pool_label = pool;
-
         let recipient = action.output().recipient().ok_or_else(|| {
-            ZcashError::InvalidPczt(format!("Missing recipient field for {pool_label} action"))
+            ZcashError::InvalidPczt(format!("Missing recipient field for {pool} action"))
         })?;
         let value = action.output().value().ok_or_else(|| {
-            ZcashError::InvalidPczt(format!("Missing value field for {pool_label} action"))
+            ZcashError::InvalidPczt(format!("Missing value field for {pool} action"))
         })?;
         let rho = orchard::note::Rho::from_bytes(&action.spend().nullifier().to_bytes())
             .into_option()
             .ok_or_else(|| {
-                ZcashError::InvalidPczt(format!("Missing rho field for {pool_label} action"))
+                ZcashError::InvalidPczt(format!("Missing rho field for {pool} action"))
             })?;
         let rseed = action.output().rseed().ok_or_else(|| {
-            ZcashError::InvalidPczt(format!("Missing rseed field for {pool_label} action"))
+            ZcashError::InvalidPczt(format!("Missing rseed field for {pool} action"))
         })?;
 
         let note = orchard::Note::from_parts(
@@ -216,9 +214,7 @@ pub(crate) fn decode_output_enc_ciphertext(
             (*action.output().note_version()).into(),
         )
         .into_option()
-        .ok_or_else(|| {
-            ZcashError::InvalidPczt(format!("{pool_label} action contains invalid note"))
-        })?;
+        .ok_or_else(|| ZcashError::InvalidPczt(format!("{pool} action contains invalid note")))?;
 
         Ok(match pool {
             ShieldedPool::Orchard => {
@@ -705,7 +701,6 @@ pub(crate) fn parse_orchard_output<P: consensus::Parameters>(
     action: &orchard::pczt::Action,
     pool: ShieldedPool,
 ) -> Result<ParsedTo, ZcashError> {
-    let pool_label = pool;
     let output = action.output();
 
     // we should verify the cv_net in checking phrase, the transaction checking should failed if the net value is not correct
@@ -745,7 +740,7 @@ pub(crate) fn parse_orchard_output<P: consensus::Parameters>(
                 let belongs_to_wallet = is_external || is_internal;
                 if is_internal_ovk && !belongs_to_wallet {
                     return Err(ZcashError::InvalidPczt(alloc::format!(
-                        "{pool_label} output was recoverable with an internal OVK but does not belong to this wallet"
+                        "{pool} output was recoverable with an internal OVK but does not belong to this wallet"
                     )));
                 }
                 let is_dummy = match vk {
@@ -774,7 +769,7 @@ pub(crate) fn parse_orchard_output<P: consensus::Parameters>(
                 // `vk.is_none()` as a fallback. We require that non-trivial outputs are
                 // visible to the Keystone device.
                 (None, Some(value)) if value.inner() != 0 => Err(ZcashError::InvalidPczt(
-                    alloc::format!("enc_ciphertext field for {pool_label} action is undecryptable"),
+                    alloc::format!("enc_ciphertext field for {pool} action is undecryptable"),
                 )),
                 // We couldn't directly decrypt a zero-valued note. This is okay because
                 // it is checked elsewhere that the direct details in the PCZT are valid,
@@ -829,7 +824,7 @@ pub(crate) fn parse_orchard_output<P: consensus::Parameters>(
                 }
                 (None, 0) => Ok(("Dummy output".into(), true)),
                 (None, _) => Err(ZcashError::InvalidPczt(alloc::format!(
-                    "missing user address for {pool_label} output"
+                    "missing user address for {pool} output"
                 ))),
             }?;
             Ok(ParsedTo::new(

--- a/rust/apps/zcash/src/pczt/parse.rs
+++ b/rust/apps/zcash/src/pczt/parse.rs
@@ -395,7 +395,7 @@ pub fn parse_pczt_multi_coins<P: consensus::Parameters>(
     pczt: &Pczt,
 ) -> Result<ParsedPczt, ZcashError> {
     super::validate_supported_pczt(pczt)?;
-    reject_legacy_parse_unsupported_pczt(pczt)?;
+    reject_unsupported_pczt(pczt)?;
 
     let mut parsed_transparent = None;
 
@@ -430,7 +430,7 @@ pub fn parse_pczt_multi_coins<P: consensus::Parameters>(
 }
 
 #[cfg(feature = "multi_coins")]
-fn reject_legacy_parse_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
+fn reject_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     {
         // The legacy multi-coins parser only displays transparent data. Reject any
         // shielded (Sapling/Orchard/Ironwood) or V6 PCZT instead of showing an

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -99,11 +99,11 @@ pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
 #[cfg(not(feature = "cypherpunk"))]
 fn reject_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     {
-        // The legacy helper below carries the pre-NU6.3 transparent sighash implementation.
-        // It must not be used for shielded (Sapling/Orchard/Ironwood) or V6 PCZTs.
-        if super::pczt_requires_cypherpunk_support(pczt) {
+        // This path only signs transparent data. Reject shielded content and unknown
+        // transaction formats; the shared sighash helper handles transparent-only v6.
+        if super::pczt_is_unsupported_by_transparent_only(pczt) {
             return Err(ZcashError::SigningError(
-                "Shielded or V6 PCZTs require cypherpunk signing support".to_string(),
+                "PCZT is not supported by transparent-only signing".to_string(),
             ));
         }
     }
@@ -776,6 +776,48 @@ mod tests {
     // Ironwood spend, so any upstream sighash change turns CI red instead of silently
     // producing wrong signatures on-device.
     #[test]
+    fn test_lean_sighash_transparent_only_v6() {
+        struct SighashCapture(Cell<Option<[u8; 32]>>);
+
+        impl PcztSigner for SighashCapture {
+            type Error = ZcashError;
+
+            fn sign_transparent<F>(
+                &self,
+                index: usize,
+                input: &mut transparent::pczt::Input,
+                hash: F,
+            ) -> Result<(), Self::Error>
+            where
+                F: FnOnce(SignableInput) -> [u8; 32],
+            {
+                self.0.set(Some(input.with_signable_input(index, hash)));
+                Ok(())
+            }
+
+            fn sign_orchard(
+                &self,
+                _action: &mut orchard::pczt::Action,
+                _hash: Hash,
+            ) -> Result<(), Self::Error> {
+                Ok(())
+            }
+        }
+
+        let sample = crate::pczt::legacy_test_support::legacy_transparent_v6_sample();
+        let pczt = Pczt::parse(&sample.bytes).unwrap();
+        let oracle = RoleSigner::new(pczt.clone())
+            .unwrap()
+            .transparent_sighash(0)
+            .unwrap();
+        let capture = SighashCapture(Cell::new(None));
+
+        pczt_ext::sign_transparent(low_level_signer::Signer::new(pczt), &capture).unwrap();
+
+        assert_eq!(capture.0.get(), Some(oracle));
+    }
+
+    #[test]
     fn test_lean_sighash_control_orchard_only() {
         let sample = crate::pczt::test_support::sample_orchard_change_pczt();
         let pczt = Pczt::parse(&sample.bytes).unwrap();
@@ -1116,30 +1158,18 @@ mod tests {
 #[cfg(all(test, feature = "multi_coins", not(feature = "cypherpunk")))]
 mod legacy_tests {
     use super::*;
-    use zcash_vendor::{
-        pczt::roles::creator::Creator,
-        zcash_protocol::consensus::{BranchId, MainNetwork, NetworkConstants},
-    };
 
     #[test]
-    fn legacy_signing_rejects_v6_pczt() {
-        let pczt = Creator::new(
-            BranchId::Nu6_3.into(),
-            10,
-            MainNetwork.coin_type(),
-            None,
-            None,
-        )
-        .unwrap()
-        .build()
-        .unwrap();
+    fn legacy_signing_accepts_transparent_only_v6_pczt() {
+        let sample = super::super::legacy_test_support::legacy_transparent_v6_sample();
+        let signed = sign_pczt(Pczt::parse(&sample.bytes).unwrap(), &sample.seed)
+            .expect("transparent-only v6 PCZT should sign");
+        let signed = Pczt::parse(&signed).unwrap();
 
-        let result = sign_pczt(pczt, &[7u8; 32]);
-
-        assert!(matches!(
-            result,
-            Err(ZcashError::SigningError(msg))
-                if msg == "Shielded or V6 PCZTs require cypherpunk signing support"
-        ));
+        assert!(super::super::pczt_is_v6(&signed));
+        assert_eq!(
+            signed.global().proprietary().get(PROP_KEY_FW_VERSION),
+            Some(&KEYSTONE_FW_VERSION.encode().to_vec())
+        );
     }
 }

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -83,7 +83,7 @@ impl PcztSigner for SeedSigner<'_> {
 #[cfg(not(feature = "cypherpunk"))]
 pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
     super::validate_supported_pczt(&pczt)?;
-    reject_legacy_unsupported_pczt(&pczt)?;
+    reject_unsupported_pczt(&pczt)?;
 
     let signer = low_level_signer::Signer::new(pczt);
 
@@ -97,7 +97,7 @@ pub fn sign_pczt(pczt: Pczt, seed: &[u8]) -> crate::Result<Vec<u8>> {
 }
 
 #[cfg(not(feature = "cypherpunk"))]
-fn reject_legacy_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
+fn reject_unsupported_pczt(pczt: &Pczt) -> Result<(), ZcashError> {
     {
         // The legacy helper below carries the pre-NU6.3 transparent sighash implementation.
         // It must not be used for shielded (Sapling/Orchard/Ironwood) or V6 PCZTs.

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -256,7 +256,7 @@ impl<'a> SeedSigner<'a> {
                 |e| {
                     ZcashError::SigningError(format!(
                         "failed to derive {} spending key: {e:?}",
-                        self.pool.label()
+                        self.pool
                     ))
                 },
             )?,
@@ -324,7 +324,7 @@ impl PcztSigner for SeedSigner<'_> {
         // Strict per-action validation, ported verbatim from the previous
         // collect_orchard_bundle_signing_keys so the lean signer keeps identical
         // skip/reject semantics to the RoleSigner path.
-        let pool_label = self.pool.label();
+        let pool_label = self.pool;
         if action.spend().spend_auth_sig().is_some() {
             return Ok(());
         }

--- a/rust/apps/zcash/src/pczt/sign.rs
+++ b/rust/apps/zcash/src/pczt/sign.rs
@@ -324,7 +324,6 @@ impl PcztSigner for SeedSigner<'_> {
         // Strict per-action validation, ported verbatim from the previous
         // collect_orchard_bundle_signing_keys so the lean signer keeps identical
         // skip/reject semantics to the RoleSigner path.
-        let pool_label = self.pool;
         if action.spend().spend_auth_sig().is_some() {
             return Ok(());
         }
@@ -333,7 +332,8 @@ impl PcztSigner for SeedSigner<'_> {
                 Some(0) | None => return Ok(()),
                 Some(_) => {
                     return Err(ZcashError::InvalidPczt(format!(
-                        "{pool_label} spend dummy_sk is only valid for dummy spends"
+                        "{} spend dummy_sk is only valid for dummy spends",
+                        self.pool
                     )));
                 }
             }
@@ -375,7 +375,7 @@ impl PcztSigner for SeedSigner<'_> {
                     OsRng,
                 )
                 .map_err(|e| {
-                    ZcashError::SigningError(format!("failed to sign {pool_label} action: {e:?}"))
+                    ZcashError::SigningError(format!("failed to sign {} action: {e:?}", self.pool))
                 })
         })?;
         self.signed.set(self.signed.get() + 1);

--- a/rust/zcash_vendor/Cargo.toml
+++ b/rust/zcash_vendor/Cargo.toml
@@ -41,20 +41,20 @@ chacha20poly1305 = { version = "0.10.1", default-features = false, features = [
 ] }
 postcard = { version = "1.0.3", features = ["alloc"] }
 getset = { version = "0.1.3" }
-orchard = { version = "0.15.0", default-features = false, optional = true }
-pczt = { version = "0.7", default-features = false }
+orchard = { version = "0.15.1", default-features = false, optional = true }
+pczt = { version = "0.8.0-rc.1", default-features = false }
 serde = { workspace = true }
 serde_with = { version = "3.11.0", features = [
     "alloc",
     "macros",
 ], default-features = false }
-transparent = { package = "zcash_transparent", version = "0.9.0-pre.0", default-features = false, features = [
+transparent = { package = "zcash_transparent", version = "0.9.0", default-features = false, features = [
     "transparent-inputs",
 ] }
-zcash_address = { version = "0.13.0-pre.0", default-features = false }
+zcash_address = { version = "0.13.0", default-features = false }
 zcash_encoding = { version = "0.4", default-features = false }
-zcash_keys = { version = "0.15.0-pre.0", default-features = false }
-zcash_protocol = { version = "0.10.0-pre.0", default-features = false }
+zcash_keys = { version = "0.15.0", default-features = false }
+zcash_protocol = { version = "0.10.0", default-features = false }
 zip32 = { version = "0.2", default-features = false }
 rust_tools = { workspace = true }
 #zcash end
@@ -65,7 +65,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [dev-dependencies]
-transparent = { package = "zcash_transparent", version = "0.9.0-pre.0", default-features = false, features = [
+transparent = { package = "zcash_transparent", version = "0.9.0", default-features = false, features = [
     "transparent-inputs",
     "test-dependencies",
 ] }


### PR DESCRIPTION
This follows up on agreed upstream review feedback in isolated commits. It uses `ShieldedPool` display values directly, simplifies unsupported PCZT paths, strengthens singleton ownership plus shielded bundle balance and transparent format validation, supports transparent-only V6 PCZTs, and restores transparent-output and v1 end-to-end coverage.

PCZT, Orchard, and the librustzcash crate family now use their released crates.io versions. `ur-registry` remains patched to Keystone SDK revision `4131bae5407e31633c01edf9c324094aca69341a` because the published release does not yet include the PCZT-owned batch messages or the firmware version in batch results.