### PR TITLE
Hygiene fixup : cyberpunk -> cypherpunk

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,7 @@ execute_build() {
         cmake_parm="${cmake_parm} -DBTC_ONLY=true"
     fi
     if [[ "${build_options[cypherpunk]}" == true ]]; then
-        cmake_parm="${cmake_parm} -DCYBERPUNK=true"
+        cmake_parm="${cmake_parm} -DCYPHERPUNK=true"
     fi
     if [[ "${build_options[screen]}" == true ]]; then
         cmake_parm="${cmake_parm} -DENABLE_SCREEN_SHOT=true"

--- a/rust/rust_c/build.rs
+++ b/rust/rust_c/build.rs
@@ -27,7 +27,7 @@ fn main() {
     //feature toggle
     config.after_includes = config.after_includes.map(|mut v| {
         #[cfg(feature = "cypherpunk")]
-        v.push_str("#define BUILD_CYBERPUNK\n");
+        v.push_str("#define BUILD_CYPHERPUNK\n");
         #[cfg(feature = "multi-coins")]
         v.push_str("#define BUILD_MULTI_COINS\n");
 

--- a/rust/rust_c/cbindgen.toml
+++ b/rust/rust_c/cbindgen.toml
@@ -6,7 +6,7 @@ language = "C"
 
 [defines]
 "feature = multi-coins" = "BUILD_MULTI_COINS"
-"feature = cypherpunk" = "BUILD_CYBERPUNK"
+"feature = cypherpunk" = "BUILD_CYPHERPUNK"
 
 "feature = aptos" = "FEATURE_APTOS"
 "feature = arweave" = "FEATURE_ARWEAVE"


### PR DESCRIPTION
Forgotten in the renaming 2 years ago. Simply hygiene. Not sure the script is still useful.