### PR TITLE
fix: don't truncate 64-bit EVM chain IDs in the ETH signing UI

### DIFF
--- a/src/ui/gui_chain/multi/web3/gui_eth.c
+++ b/src/ui/gui_chain/multi/web3/gui_eth.c
@@ -7,9 +7,11 @@
 #include "gui_qr_hintbox.h"
 #include "screen_manager.h"
 #include "user_sqlite3.h"
+#include "user_utils.h"
 #include "account_manager.h"
 #include "math.h"
 #include "stdio.h"
+#include "stdlib.h"
 #include "string.h"
 #include "drv_mpu.h"
 #include "device_setting.h"
@@ -1005,7 +1007,7 @@ void GetEthTypedDataDomianChainId(void *indata, void *param, uint32_t maxLen)
 {
     DisplayETHTypedData *message = (DisplayETHTypedData *)param;
     if (message->chain_id != NULL) {
-        snprintf_s((char *)indata, maxLen, "%s (%s)", message->chain_id, FindEvmNetwork(atoi(message->chain_id)).name);
+        snprintf_s((char *)indata, maxLen, "%s (%s)", message->chain_id, FindEvmNetwork(strtoull(message->chain_id, NULL, 10)).name);
     } else {
         strcpy_s((char *)indata, maxLen, "");
     }
@@ -1766,7 +1768,11 @@ static void GetEthNetWork(void *indata, void *param, uint32_t maxLen)
     DisplayETH *eth = (DisplayETH *)param;
     EvmNetwork_t network = FindEvmNetwork(eth->chain_id);
     if (network.chainId == 0) {
-        snprintf_s((char *)indata,  maxLen, "ID: %lu", eth->chain_id);
+        // chain_id is a uint64_t; "%lu" is only 32 bits on the device (and
+        // newlib-nano has no "%llu"), so format it manually.
+        char chainIdStr[21] = {0};
+        Uint64ToDecStr(eth->chain_id, chainIdStr, sizeof(chainIdStr));
+        snprintf_s((char *)indata,  maxLen, "ID: %s", chainIdStr);
         return;
     }
     strcpy_s((char *)indata, maxLen, network.name);

--- a/src/user_sqlite3.c
+++ b/src/user_sqlite3.c
@@ -630,14 +630,16 @@ bool GetEnsName(const char *addr, char *name)
     return strnlen_s(name, SQL_ENS_NAME_MAX_LEN) ? true : false;
 }
 
-bool GetDBContract(const char* address, const char *selector, const uint32_t chainId, char *functionABIJson, char *contractName)
+bool GetDBContract(const char* address, const char *selector, const uint64_t chainId, char *functionABIJson, char *contractName)
 {
     assert(strnlen_s(address, SQL_ADDR_MAX_LEN) == SQL_ADDR_MAX_LEN - 1);
     sqlite3 *db;
     char index = address[2]; // [0,f]
 
+    char chainIdStr[21] = {0};
+    Uint64ToDecStr(chainId, chainIdStr, sizeof(chainIdStr));
     char contractDBPath[BUFFER_SIZE_128] = {0};
-    snprintf_s(contractDBPath, BUFFER_SIZE_128, "0:contracts/%u_%c_contracts.db", chainId, index);
+    snprintf_s(contractDBPath, BUFFER_SIZE_128, "0:contracts/%s_%c_contracts.db", chainIdStr, index);
     if (OpenDb(contractDBPath, &db)) {
         return NULL;
     }

--- a/src/user_sqlite3.h
+++ b/src/user_sqlite3.h
@@ -15,6 +15,6 @@
 void Sqlite3Test(int argc, char *argv[]);
 void UserSqlite3Init(void);
 bool GetEnsName(const char *addr, char *name);
-bool GetDBContract(const char* address, const char *selector, const uint32_t chainId, char *functionABIJson, char *contractName);
+bool GetDBContract(const char* address, const char *selector, const uint64_t chainId, char *functionABIJson, char *contractName);
 
 #endif

--- a/src/utils/user_utils.c
+++ b/src/utils/user_utils.c
@@ -324,3 +324,28 @@ void insert_16bit_value(uint8_t *frame, int offset, uint16_t value)
     frame[offset] = (uint8_t)(value >> 8);
     frame[offset + 1] = (uint8_t)(value & 0xFF);
 }
+
+// Format a uint64_t as a decimal string without going through printf.
+// newlib-nano's formatted IO (used on the device) has no long long support,
+// so "%llu"/PRIu64 would silently truncate to 32 bits.
+void Uint64ToDecStr(uint64_t value, char *out, uint32_t maxLen)
+{
+    char tmp[21] = {0}; // max uint64_t is 20 digits + NUL
+    uint32_t len = 0;
+    if (out == NULL || maxLen == 0) {
+        return;
+    }
+    do {
+        tmp[len++] = (char)('0' + (value % 10));
+        value /= 10;
+    } while (value > 0 && len < sizeof(tmp) - 1);
+    if (len >= maxLen) {
+        // Never emit a silently truncated number; an empty string is safer.
+        out[0] = '\0';
+        return;
+    }
+    for (uint32_t i = 0; i < len; i++) {
+        out[i] = tmp[len - 1 - i];
+    }
+    out[len] = '\0';
+}

--- a/src/utils/user_utils.h
+++ b/src/utils/user_utils.h
@@ -37,5 +37,6 @@ void CutAndFormatFileName(char *out, uint32_t maxLen, const char *fileName, cons
 uint16_t extract_16bit_value(const uint8_t *frame, int offset);
 void insert_16bit_value(uint8_t *frame, int offset, uint16_t value);
 void ReplaceStringInBuffer(char *str, const char *old_str, const char *new_str);
+void Uint64ToDecStr(uint64_t value, char *out, uint32_t maxLen);
 
 #endif /* _USER_UTILS_H */

--- a/ui_simulator/simulator_model.c
+++ b/ui_simulator/simulator_model.c
@@ -416,7 +416,7 @@ uint8_t GetFingerUnlockFlag(void)
     return 1;
 }
 
-bool GetDBContract(const char *address, const char *selector, const uint32_t chainId, char *functionABIJson, char *contractName)
+bool GetDBContract(const char *address, const char *selector, const uint64_t chainId, char *functionABIJson, char *contractName)
 {
     return false;
 }


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->
When signing an ETH transaction for a chain that is **not** in the built-in network table and whose chain ID is **≥ 2³²**, the device displays a wrong chain ID.

The Rust parser reads the chain ID correctly as `u64`, but `GetEthNetWork()` in `src/ui/gui_chain/multi/web3/gui_eth.c` renders it with `"ID: %lu"`. On the device target (`thumbv7em-none-eabihf`) `unsigned long` is 32 bits, so `snprintf` only consumes the low half of the `uint64_t`. The `ui_simulator` runs on a 64-bit host where `%lu` happens to be 64 bits, which is why this is not visible there.

Real-world trigger: the Ethereum `glamsterdam-devnet-8` testnet has chain ID **7091047534** (`0x1A6A8CC6E`, 33 bits). The Keystone showed **2796080238** (= low 32 bits) on the signing screen, which looks like a plausible-but-different chain. A user signing with a hardware wallet cannot tell whether the host is lying to them or the device is — that's exactly the check a hardware wallet exists to provide, so this should be treated as a display-integrity bug.

`%llu` / `PRIu64` is **not** a fix: the firmware links newlib-nano (`--specs=nano.specs` in `firmware.cmake`), and the Arm GNU toolchain builds nano's formatted IO without `long long` support, so `%llu` would still print 32 bits. This PR adds a tiny `Uint64ToDecStr()` helper in `user_utils` and uses it instead.

Two related 32-bit narrowings on the same code path are fixed as well:
- `GetEthTypedDataDomianChainId()` (EIP-712 domain) used `atoi()` (returns `int`) for the network lookup → `strtoull()`.
- `GetDBContract()` took the chain ID as `uint32_t` (called with a `uint64_t`) → `uint64_t` (firmware + simulator stub); the contract DB path is byte-for-byte identical for all IDs < 2³², so existing DB files are unaffected.

Changes are confined to the C UI/util layer; no Rust or UR changes.
<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine. *(host-compiled and unit-tested the new helper against `PRIu64` output for 0, 1, 2³²−1, 2³², 7091047534 and `UINT64_MAX`; I don't have the device toolchain set up, so a device build/QA pass by the maintainers is needed)*
- [ ] All unit tests passed locally.

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->
1. Build a legacy or EIP-1559 transaction with `chainId = 7091047534` (or any value ≥ 4294967296 not in `FindEvmNetwork`'s table) and send it to the device as an `eth-sign-request` UR (e.g. via the Keystone SDK / a throwaway MetaMask on a custom network).
2. Before this PR the Network field on the signing screen reads `ID: 2796080238`; after this PR it reads `ID: 7091047534`.
3. Regression: sign a mainnet (1) / Polygon (137) tx — network name display is unchanged; sign a tx on an unknown chain with a small ID (e.g. 31337) — `ID: 31337` unchanged.
4. Sign an EIP-712 typed message with `domain.chainId = 7091047534` — the domain chain ID line still shows the raw value, and the network lookup no longer overflows.
<!-- END -->

https://claude.ai/code/session_01W6farDG9cUMLe193U9rtA7
