### PR TITLE
Fix simulator build exit code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ RUN apt-get install -y \
     cmake \
     make \
     build-essential --fix-missing \
-    && cd /usr/local/bin \
-    && ln -s /usr/bin/python3 python \
     && rm -rf /var/lib/apt/lists/*
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
 ENV PATH=/root/.cargo/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ python3 build.py
 
 ```bash
 # Run the build script at the root of the project.
-python build.py -t btc_only
+python3 build.py -t btc_only
 ```
 
 #### Building img to C file
@@ -75,7 +75,7 @@ The first way is to execute the command below.
 
 ```bash
 # Run the build script at the root of the project.
-python img_converter.py
+python3 img_converter.py
 ```
 
 The second way is already integrated in the "build.py" file, so you can simply use it.
@@ -84,7 +84,7 @@ The second way is already integrated in the "build.py" file, so you can simply u
 python3 build.py
 
 # or
-python build.py -t btc_only
+python3 build.py -t btc_only
 ```
 
 ## Code Structure

--- a/build.bat
+++ b/build.bat
@@ -72,7 +72,7 @@ IF "%build_simulator%"=="true" (
     ) ELSE (
         make -j16
     )
-    python padding_bin_file.py mh1903.bin
+    python3 padding_bin_file.py mh1903.bin
     popd
 )
 

--- a/build.py
+++ b/build.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# !/usr/bin/python
+# !/usr/bin/python3
 
 import shutil
 import platform
@@ -64,7 +64,7 @@ def build_firmware(environment, options, bin_type):
     make_result = os.system('make -j')
     if make_result != 0:
         return make_result
-    return os.system('python padding_bin_file.py mh1903.bin')
+    return os.system('python3 padding_bin_file.py mh1903.bin')
 
 
 def ota_maker():

--- a/build.py
+++ b/build.py
@@ -22,6 +22,7 @@ def build_firmware(environment, options, bin_type):
     is_release = environment == "production"
     is_btc_only = bin_type == "btc_only"
     is_cypherpunk = bin_type == "cypherpunk"
+    is_simulator = "simulator" in options
     if not os.path.exists(build_dir):
         os.makedirs(build_dir)
 
@@ -62,7 +63,7 @@ def build_firmware(environment, options, bin_type):
     if cmd_result != 0:
         return cmd_result
     make_result = os.system('make -j')
-    if make_result != 0:
+    if is_simulator or make_result != 0:
         return make_result
     return os.system('python3 padding_bin_file.py mh1903.bin')
 
@@ -143,9 +144,10 @@ if __name__ == '__main__':
     build_result = build_firmware(env, options, bin_type)
     if build_result != 0:
         exit(1)
-    if platform.system() == 'Darwin':
-        ota_maker()
-    purpose = args.purpose
-    if purpose and purpose == "debug":
-        ota_maker()
+    if "simulator" not in options:
+        if platform.system() == 'Darwin':
+            ota_maker()
+        purpose = args.purpose
+        if purpose and purpose == "debug":
+            ota_maker()
 

--- a/src/ui/lv_i18n/check_un_translate.py
+++ b/src/ui/lv_i18n/check_un_translate.py
@@ -1,6 +1,5 @@
-
 # -*- coding: utf-8 -*-
-# !/usr/bin/python
+# !/usr/bin/python3
 
 import pandas as pd
 

--- a/tools/padding_bin_file/padding_bin_file.py
+++ b/tools/padding_bin_file/padding_bin_file.py
@@ -86,7 +86,7 @@ def padding_bin_file(file_name):
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:
-        print("Usage: python padding_bin_file.py [file_name]")
+        print("Usage: python3 padding_bin_file.py [file_name]")
         sys.exit()
     file_name = sys.argv[1]
     padding_bin_file(file_name)


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->

`build.py -o simulator` would sometimes exit with a failure, despite correctly producing the simulator.

This was caused by a missing `python` symlink, which caused an irrelevant failure when trying to produce firmware. In cases where there was such a symlink, it would produce invalid firmware alongside the simulator.

This switches all uses of `python` to `python3` (including removing the creation of a `python` symlink from the Dockerfile). It also conditionalizes the firmware creation so that it doesn’t happen on a simulator build.

<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->

Run `build.py -o simulator` on a system without `python`.

1. Without this PR, it’ll exit with an error, despite producing a valid simulator;
2. with the first commit, it’ll succeed, but produce an invalid keystone.bin; and
3. with both commits, it’ll succeed without producing invalid firmware.

<!-- END -->

