### PR TITLE
Support newer GCCs

### DIFF
--- a/firmware.cmake
+++ b/firmware.cmake
@@ -9,7 +9,7 @@ set(MCU cortex-m4)
 set(LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/mh1903b.ld)
 set(ARCH_FLAGS "-mcpu=${MCU} -mthumb -mlittle-endian")
 set(MCU_FLAGS "${ARCH_FLAGS} -Os -mfloat-abi=hard -mfpu=fpv4-sp-d16")
-set(CMAKE_C_FLAGS "${MCU_FLAGS} -Wall -Wno-unknown-pragmas -Wno-format -g")
+set(CMAKE_C_FLAGS "${MCU_FLAGS} -std=gnu17 -Wall -Wno-unknown-pragmas -Wno-format -g")
 set(CMAKE_CXX_FLAGS "${MCU_FLAGS} -Wall -Wno-unknown-pragmas -Wno-format -g")
 
 if(NOT BUILD_PRODUCTION)

--- a/src/crypto/checksum/crc.h
+++ b/src/crypto/checksum/crc.h
@@ -8,5 +8,8 @@
 
 uint16_t crc16_ccitt(const uint8_t *puchMsg, uint32_t usDataLen);
 uint32_t crc32_ieee(uint32_t crc, const uint8_t *buffer, uint32_t size);
+#if FINGER_PRINT_STANDARD_CRC == 1
+uint32_t crc32_update_fast(const uint8_t *buffer, uint16_t size);
+#endif
 
 #endif

--- a/src/device_settings.c
+++ b/src/device_settings.c
@@ -177,7 +177,7 @@ void InitBootParam(void)
     if (needSave) {
         SaveBootParam();
     } else {
-        AesDecryptBuffer(&g_bootParam, sizeof(g_bootParam), &bootParam);
+        AesDecryptBuffer((uint8_t *)&g_bootParam, sizeof(g_bootParam), (uint8_t *)&bootParam);
         PrintArray("bootParam.bootCheckFlag", g_bootParam.bootCheckFlag, sizeof(g_bootParam.bootCheckFlag));
         PrintArray("bootParam.recoveryModeSwitch", g_bootParam.recoveryModeSwitch, sizeof(g_bootParam.recoveryModeSwitch));
         if (memcmp(g_bootParam.recoveryModeSwitch, g_recoveryModeFlag, sizeof(g_bootParam.recoveryModeSwitch)) == 0) {

--- a/src/managers/fingerprint_process.c
+++ b/src/managers/fingerprint_process.c
@@ -27,6 +27,7 @@
 #include "screen_manager.h"
 #include "low_power.h"
 #include "se_manager.h"
+#include "crc.h"
 
 /* DEFINES */
 #define FINGERPRINT_REG_MAX_TIMES               (18)

--- a/src/ui/gui_chain/multi/web3/gui_eth.c
+++ b/src/ui/gui_chain/multi/web3/gui_eth.c
@@ -15,6 +15,7 @@
 #include "device_setting.h"
 #include "cjson/cJSON.h"
 #include "gui_hintbox.h"
+#include "gui_pending_hintbox.h"
 #include "gui_views.h"
 #include "gui_chain_components.h"
 


### PR DESCRIPTION
## Explanation
<!-- Why this PR is required and what changed -->
<!-- START -->

Depending on the version of GCC used, you could end up with different results or errors. This now specifies `--std=gnu17` (the default of GCC 9, which is pinned in the Dockerfile) and makes a couple changes to avoid things that that GCC 14+ treats as errors.

<!-- END -->

## Pre-merge check list
- [x] PR run build successfully on local machine.
- [x] All unit tests passed locally.

## How to test
<!-- Explain how the reviewer and QA can test this PR -->
<!-- START -->

Build with GCC 14 or 15. It’ll fail before this PR, but succeed after.

<!-- END -->

